### PR TITLE
docs: keep the code-examples link on-site instead of jumping to GitHub

### DIFF
--- a/docs/CODE-EXAMPLES.md
+++ b/docs/CODE-EXAMPLES.md
@@ -1,0 +1,31 @@
+# Code Examples
+
+Ready-to-run, production-ready examples for `mx.msgwing.com:465` (SSL/TLS) or
+`:587` (STARTTLS), one file per language — all in the
+[GitHub repository](https://github.com/msgwing/ZeroSMTP):
+
+| Language | File |
+| --- | --- |
+| Python | [python-zerosmtp.py](https://github.com/msgwing/ZeroSMTP/blob/main/python-zerosmtp.py) |
+| PHP (PHPMailer) | [php-zerosmtp.php](https://github.com/msgwing/ZeroSMTP/blob/main/php-zerosmtp.php) |
+| PHP (Symfony Mailer) | [php-symfony-mailer-zerosmtp.php](https://github.com/msgwing/ZeroSMTP/blob/main/php-symfony-mailer-zerosmtp.php) |
+| Node.js | [node-zerosmtp.mjs](https://github.com/msgwing/ZeroSMTP/blob/main/node-zerosmtp.mjs) |
+| TypeScript | [ts-zerosmtp.ts](https://github.com/msgwing/ZeroSMTP/blob/main/ts-zerosmtp.ts) |
+| Bash (curl) | [bash-curl-zerosmtp.sh](https://github.com/msgwing/ZeroSMTP/blob/main/bash-curl-zerosmtp.sh) |
+| Bash (swaks) | [bash-swaks-zerosmtp.sh](https://github.com/msgwing/ZeroSMTP/blob/main/bash-swaks-zerosmtp.sh) |
+| Java | [java-zerosmtp.java](https://github.com/msgwing/ZeroSMTP/blob/main/java-zerosmtp.java) |
+| C# (.NET / MailKit) | [cs-zerosmtp.cs](https://github.com/msgwing/ZeroSMTP/blob/main/cs-zerosmtp.cs) |
+| Go | [go-zerosmtp.go](https://github.com/msgwing/ZeroSMTP/blob/main/go-zerosmtp.go) |
+| Ruby | [ruby-zerosmtp.rb](https://github.com/msgwing/ZeroSMTP/blob/main/ruby-zerosmtp.rb) |
+| Rust | [rust-zerosmtp.rs](https://github.com/msgwing/ZeroSMTP/blob/main/rust-zerosmtp.rs) |
+| Kotlin | [kotlin-zerosmtp.kt](https://github.com/msgwing/ZeroSMTP/blob/main/kotlin-zerosmtp.kt) |
+| Swift | [swift-zerosmtp.swift](https://github.com/msgwing/ZeroSMTP/blob/main/swift-zerosmtp.swift) |
+| PowerShell | [pwsh-zerosmtp.ps1](https://github.com/msgwing/ZeroSMTP/blob/main/pwsh-zerosmtp.ps1) |
+
+Each example reads credentials from `ZEROSMTP_*` environment variables
+(`ZEROSMTP_USERNAME`, `ZEROSMTP_PASSWORD`, `ZEROSMTP_FROM`, `ZEROSMTP_TO`,
+`ZEROSMTP_SUBJECT`) — never hardcode real credentials into a script.
+
+See the [Quickstart](index.md#get-started) for how to get `@msgwing.com`
+credentials, and [Troubleshooting](TROUBLESHOOTING.md) if a send hangs or
+fails.

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ If that's the error you're seeing, start with
 | Have a printer or MFP to reconfigure | [Printer scan-to-email setup by brand](PRINTERS.md) |
 | Manage Windows Server / IIS / Exchange | [Windows Server guide](WINDOWS-SERVER.md) |
 | Manage Linux servers | [Linux](LINUX.md) · [system-wide relay](SYSTEM-MTA.md) |
-| Are sending from an app or script | [Code examples in 15 languages](https://github.com/msgwing/ZeroSMTP#code-examples) |
+| Are sending from an app or script | [Code examples in 15 languages](CODE-EXAMPLES.md) |
 | Have it failing or timing out | [Troubleshooting](TROUBLESHOOTING.md) |
 | Just want the short answers | [FAQ](FAQ.md) |
 


### PR DESCRIPTION
## Summary
- Adds `docs/CODE-EXAMPLES.md`, mirroring the README's code-examples table so the docs site has its own page for it.
- Changes the "Code examples in 15 languages" row in `docs/index.md`'s Start-here table to link there instead of to a GitHub README anchor.

Every other row in that table already links to a `docs.msgwing.com` page — this was the one exception.