### PR TITLE
Add Dec 2026 readiness tools: countdown, decision quiz, brand picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ scan-to-email · IoT and device notifications · homelabs.
 > this one. **[What breaks →](docs/AFFECTED-SYSTEMS.md)** is the audit list,
 > with PowerShell to find your exposure.
 
-Setup guides: [Network printers](docs/PRINTERS.md) · [Popular applications](docs/APPS.md) · [Linux (Debian/Ubuntu/Rocky/Fedora/openSUSE)](docs/LINUX.md) · [System-wide mail relay (Postfix/msmtp/Exim4)](docs/SYSTEM-MTA.md) · [Windows Server](docs/WINDOWS-SERVER.md) · [Exchange Online SMTP AUTH migration](docs/EXCHANGE-ONLINE-SMTP-AUTH.md) · [Troubleshooting](docs/TROUBLESHOOTING.md) · [Reliability (retries)](docs/RELIABILITY.md) · [FAQ](docs/FAQ.md)
+Setup guides: [Network printers](docs/PRINTERS.md) · [Popular applications](docs/APPS.md) · [Linux (Debian/Ubuntu/Rocky/Fedora/openSUSE)](docs/LINUX.md) · [System-wide mail relay (Postfix/msmtp/Exim4)](docs/SYSTEM-MTA.md) · [Windows Server](docs/WINDOWS-SERVER.md) · [Exchange Online SMTP AUTH migration](docs/EXCHANGE-ONLINE-SMTP-AUTH.md) · [Monitoring alerts](docs/MONITORING.md) · [Device case studies](docs/DEVICE-CASE-STUDIES.md) · [Troubleshooting](docs/TROUBLESHOOTING.md) · [Reliability (retries)](docs/RELIABILITY.md) · [FAQ](docs/FAQ.md)
 
 ## How does this compare to other options?
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -87,7 +87,7 @@ monitoringu · skan-do-mail · powiadomień IoT · homelabów.
 > — omawia wszystkie opcje (Graph API, Direct Send, własny relay, usługi
 > płatne), nie tylko tę jedną.
 
-Przewodniki konfiguracji: [Drukarki sieciowe](docs/PRINTERS.md) · [Popularne aplikacje](docs/APPS.md) · [Linux (Debian/Ubuntu/Rocky/Fedora/openSUSE)](docs/LINUX.md) · [Systemowy relay pocztowy (Postfix/msmtp/Exim4)](docs/SYSTEM-MTA.md) · [Windows Server](docs/WINDOWS-SERVER.md) · [Migracja z Exchange Online SMTP AUTH](docs/EXCHANGE-ONLINE-SMTP-AUTH.md) · [Rozwiązywanie problemów](docs/TROUBLESHOOTING.md) · [Niezawodność (ponawianie prób)](docs/RELIABILITY.md) · [FAQ](docs/FAQ.md)
+Przewodniki konfiguracji: [Drukarki sieciowe](docs/PRINTERS.md) · [Popularne aplikacje](docs/APPS.md) · [Linux (Debian/Ubuntu/Rocky/Fedora/openSUSE)](docs/LINUX.md) · [Systemowy relay pocztowy (Postfix/msmtp/Exim4)](docs/SYSTEM-MTA.md) · [Windows Server](docs/WINDOWS-SERVER.md) · [Migracja z Exchange Online SMTP AUTH](docs/EXCHANGE-ONLINE-SMTP-AUTH.md) · [Alerty monitoringu](docs/MONITORING.md) · [Przypadki konkretnych urządzeń](docs/DEVICE-CASE-STUDIES.md) · [Rozwiązywanie problemów](docs/TROUBLESHOOTING.md) · [Niezawodność (ponawianie prób)](docs/RELIABILITY.md) · [FAQ](docs/FAQ.md)
 
 ## Jak to wypada na tle innych opcji?
 

--- a/docs/DEVICE-CASE-STUDIES.md
+++ b/docs/DEVICE-CASE-STUDIES.md
@@ -1,0 +1,41 @@
+# Device case studies
+
+Manuals tell you where a setting *should* be. They don't tell you that a
+specific 2016 printer needs its certificate check turned off because its
+firmware never got a root certificate update — that only comes from someone
+who actually hit the problem on real hardware.
+
+This page collects those reports: one device, one confirmed fix, credited to
+whoever found it.
+
+## Case studies
+
+### Canon Maxify MB2755 — certificate verification must stay off on port 465
+
+**Reported by:** [`@kevinbytnar`](https://github.com/msgwing/ZeroSMTP/discussions/6)
+
+This 2016-era SOHO inkjet MFP fails certificate validation against
+`mx.msgwing.com`'s Let's Encrypt certificate on port 465, because its
+firmware's root CA store was never updated to trust `ISRG Root X1`. On port
+587 it connects successfully with certificate verification left **on** — no
+workaround needed there.
+
+Full writeup, screenshots and the technical explanation:
+[PRINTERS.md → Known exception: Canon Maxify MB2755](PRINTERS.md#known-exception-canon-maxify-mb2755).
+
+---
+
+## Have a device with a similar quirk?
+
+If you hit something on real hardware that isn't in [PRINTERS.md](PRINTERS.md)
+— a certificate issue, a firmware bug, a menu that's in a different place
+than the manual says — report it:
+
+- [Open an issue](https://github.com/msgwing/ZeroSMTP/issues/new/choose) or
+  a pull request with what you found (a screenshot helps, with any account
+  details redacted).
+- Hardware-confirmed reports are worth more here than anything written from
+  a manual, and get credited by GitHub username when added.
+
+This list only grows if people who hit the edge cases report them —
+consider this an open invitation.

--- a/docs/EXCHANGE-ONLINE-SMTP-AUTH.md
+++ b/docs/EXCHANGE-ONLINE-SMTP-AUTH.md
@@ -119,6 +119,105 @@ outbound 587/465 to a new host is often firewalled.
 
 ## Quick decision guide
 
+Answer two or three questions for a straight recommendation, or read the
+same logic as a flowchart below.
+
+<div id="zc-quiz" style="background:#f6f8fa;border:1px solid #d0d7de;border-radius:6px;padding:20px;margin:20px 0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;max-width:520px;">
+  <noscript>JavaScript is off — use the flowchart below instead.</noscript>
+</div>
+<script>
+(function(){
+  var el = document.getElementById('zc-quiz');
+  if (!el) return;
+
+  var steps = {
+    start: {
+      q: "Does the mail have to come FROM your own domain?",
+      options: [
+        { label: "Yes", next: "codeControl" },
+        { label: "No", next: "volume" }
+      ]
+    },
+    codeControl: {
+      q: "Can you change the app's code?",
+      options: [
+        { label: "Yes", next: "result_oauth" },
+        { label: "No", next: "staticIp" }
+      ]
+    },
+    staticIp: {
+      q: "Do your devices sit behind a static public IP?",
+      options: [
+        { label: "Yes", next: "result_directsend" },
+        { label: "No", next: "result_relay_or_paid" }
+      ]
+    },
+    volume: {
+      q: "Is this low volume and non-critical (scans, device alerts, notifications)?",
+      options: [
+        { label: "Yes", next: "result_zerosmtp" },
+        { label: "No", next: "result_paid" }
+      ]
+    }
+  };
+
+  var results = {
+    result_oauth: {
+      title: "Option 1 — OAuth 2.0 / Microsoft Graph API",
+      body: "Microsoft's own recommended path, and since you control the code, it's the right one: full auditing, keeps your domain, no third party involved."
+    },
+    result_directsend: {
+      title: "Option 2 — Direct Send / SMTP relay connector",
+      body: "With a static public IP, Direct Send often solves this without touching the devices at all &mdash; but it only delivers to your own tenant's domains."
+    },
+    result_relay_or_paid: {
+      title: "Options 3 or 4 — on-prem relay or a paid SMTP service",
+      body: "Without a static IP, you need either your own relay (Postfix/IIS &mdash; see SYSTEM-MTA.md) or a paid provider (SendGrid, Mailgun, SES...) that supports your own domain."
+    },
+    result_zerosmtp: {
+      title: "Option 5 — ZeroSMTP fits this case",
+      body: "Free, three settings changed, done &mdash; as long as sending from <code>@msgwing.com</code> instead of your own domain is acceptable here. See the Quickstart."
+    },
+    result_paid: {
+      title: "Option 4 — a paid SMTP service",
+      body: "Higher volume or anything customer-facing needs a provider built for that (SendGrid, Mailgun, Brevo, SES...)."
+    }
+  };
+
+  function renderQuestion(key){
+    var step = steps[key];
+    var html = '<div style="font-weight:600;margin-bottom:10px;">' + step.q + '</div>';
+    step.options.forEach(function(opt){
+      html += '<button data-next="' + opt.next + '" style="display:block;width:100%;text-align:left;background:#fff;border:1px solid #d0d7de;border-radius:6px;padding:8px 12px;margin:6px 0;cursor:pointer;font-size:14px;">' + opt.label + '</button>';
+    });
+    el.innerHTML = html;
+    Array.prototype.forEach.call(el.querySelectorAll('button'), function(btn){
+      btn.addEventListener('click', function(){
+        var next = btn.getAttribute('data-next');
+        if (results[next]) { renderResult(next); } else { renderQuestion(next); }
+      });
+    });
+  }
+
+  function renderResult(key){
+    var r = results[key];
+    el.innerHTML =
+      '<div style="font-weight:600;margin-bottom:8px;">Recommendation</div>' +
+      '<div style="background:#dafbe1;border:1px solid #2ea043;border-radius:6px;padding:12px 14px;"><strong>' + r.title + '</strong><p style="margin:8px 0 0;">' + r.body + '</p></div>' +
+      '<a href="#" id="zc-restart" style="display:inline-block;margin-top:10px;font-size:13px;">&larr; start over</a>';
+    document.getElementById('zc-restart').addEventListener('click', function(e){
+      e.preventDefault();
+      renderQuestion("start");
+    });
+  }
+
+  renderQuestion("start");
+})();
+</script>
+
+<details>
+<summary>Same logic as a flowchart (for reference, or if JavaScript is off)</summary>
+
 ```
 Does the mail have to come FROM your own domain?
 ├── Yes ──► Can you change the app's code?
@@ -130,6 +229,8 @@ Does the mail have to come FROM your own domain?
             ├── Yes ──► ZeroSMTP                          (option 5)
             └── No  ──► Paid SMTP service                 (option 4)
 ```
+
+</details>
 
 ## "Can I just turn it back on?"
 

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -1,0 +1,109 @@
+# Monitoring alerts via SMTP relay
+
+Monitoring tools use two different patterns for sending alert email, and it
+changes what you actually need to configure:
+
+- **Tools with their own built-in SMTP settings** (Zabbix, Uptime Kuma, PRTG)
+  — you enter `mx.msgwing.com` and your `@msgwing.com` credentials directly
+  in that tool's UI. There's no config file to edit.
+- **Tools that shell out to the system's mail command** (classic Nagios,
+  Icinga2) — they don't have their own SMTP settings at all. They call
+  `mail`/`sendmail` and rely on **the system's own MTA** to deliver it. Point
+  that at `mx.msgwing.com` once — see [SYSTEM-MTA.md](SYSTEM-MTA.md) — and
+  every tool on that host that already calls `mail`/`sendmail` starts
+  working through the relay with no per-tool change at all.
+
+The connection values are the same everywhere:
+
+| Setting | Value |
+| --- | --- |
+| Server | `mx.msgwing.com` |
+| Port | `587` (STARTTLS) or `465` (SSL/TLS) |
+| Encryption | STARTTLS on 587, or SSL/TLS on 465 — required |
+| Authentication | Username + password (`LOGIN` or `PLAIN`) |
+| Username / From | your `@msgwing.com` login |
+| Password | your `@msgwing.com` password |
+
+## Zabbix
+
+Zabbix's email alerting is a **Media type**, configured in the frontend or
+via API — not a config file. Under **Administration → Media types → Email**
+(exact menu path varies slightly by Zabbix version):
+
+| Field | Value |
+| --- | --- |
+| SMTP server | `mx.msgwing.com` |
+| SMTP server port | `587` or `465` |
+| SMTP helo | your domain or hostname (anything valid) |
+| SMTP email | your `@msgwing.com` login |
+| Connection security | `STARTTLS` (port 587) or `SSL/TLS` (port 465) |
+| Authentication | `Username and password` |
+| Username | your `@msgwing.com` login |
+| Password | your `@msgwing.com` password |
+
+Then assign that media type to a user under **Users → Media**, and use it in
+an alert action. See
+[Zabbix: configure email media type](https://www.zabbix.com/documentation/current/en/manual/config/notifications/media/email)
+for the current field layout on your version.
+
+## Uptime Kuma
+
+Under **Settings → Notifications → Setup Notification**, choose
+**Email (SMTP)** as the notification type:
+
+| Field | Value |
+| --- | --- |
+| Hostname | `mx.msgwing.com` |
+| Port | `587` or `465` |
+| Security | `STARTTLS` (port 587) or `TLS` (port 465) |
+| Username | your `@msgwing.com` login |
+| Password | your `@msgwing.com` password |
+| From Email | your `@msgwing.com` login |
+| To Email | wherever you want the alert |
+
+Save, then use **Test** to confirm before attaching it to a monitor.
+
+## Nagios / Icinga2
+
+These don't have their own SMTP settings — the default notification
+commands (`notify-host-by-email`, `notify-service-by-email`, or Icinga2's
+`mail-host-notification`/`mail-service-notification`) pipe the message to
+the system's `mail` or `sendmail` command, which hands off to whatever MTA
+is installed (usually Postfix, msmtp or Exim on the monitoring server).
+
+That means the fix isn't a Nagios/Icinga setting at all — it's making the
+**host's own outgoing mail** work, which [SYSTEM-MTA.md](SYSTEM-MTA.md)
+already covers (Postfix satellite mode, msmtp, or Exim4). Do that once, then
+verify with the same command Nagios/Icinga already uses:
+
+```bash
+echo "Test from Nagios/Icinga host" | mail -s "ZeroSMTP test" you@example.com
+```
+
+If that delivers, existing notification commands work unchanged.
+
+## PRTG
+
+Under **Setup → Account Settings → Notification Delivery → Add New Mail
+Server** (menu wording varies by PRTG version):
+
+| Field | Value |
+| --- | --- |
+| Server | `mx.msgwing.com` |
+| Port | `587` or `465` |
+| Connection security | `STARTTLS` (port 587) or `Implicit SSL` (port 465) |
+| Authentication | enabled, username + password |
+| Username | your `@msgwing.com` login |
+| Password | your `@msgwing.com` password |
+| Sender address | your `@msgwing.com` login |
+
+Send a test notification from the same screen before relying on it.
+
+## Rate limits apply here too
+
+Monitoring alerts can burst during an outage — a flapping check can queue up
+dozens of notifications in minutes. The same
+[sending limits](TROUBLESHOOTING.md#sending-limits-rate-limiting) apply
+(5/minute, 50/hour, 200/day): configure alert flapping/throttling in your
+monitoring tool so a single incident doesn't burn through the daily limit
+before a human sees it.

--- a/docs/PRINTERS.md
+++ b/docs/PRINTERS.md
@@ -153,6 +153,51 @@ Menu wording shifts between firmware versions, but locations are stable
 enough to be a reliable starting point. Each entry links to the vendor's own
 current documentation — check there if the wording has moved on your model.
 
+**Pick your brand for just that menu path**, or scroll down for all ten at once.
+
+<div style="background:#f6f8fa;border:1px solid #d0d7de;border-radius:6px;padding:16px 20px;margin:16px 0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;max-width:640px;">
+  <label for="zc-brand-picker" style="font-weight:600;display:block;margin-bottom:8px;">Printer brand</label>
+  <select id="zc-brand-picker" style="width:100%;padding:8px;border:1px solid #d0d7de;border-radius:6px;font-size:14px;margin-bottom:12px;">
+    <option value="">Select a brand…</option>
+  </select>
+  <div id="zc-brand-output" style="font-size:14px;"></div>
+</div>
+<script>
+(function(){
+  var select = document.getElementById('zc-brand-picker');
+  var output = document.getElementById('zc-brand-output');
+  if (!select || !output) return;
+
+  var brands = [
+    { name: "HP", path: "Embedded Web Server (browser → printer's IP) → <code>Networking</code> or <code>Scan</code> tab → <code>TCP/IP Settings</code> → <code>Outgoing Email</code> / <code>Scan to Email</code> → <code>Outgoing Email Profiles</code> → add a profile using the values above." },
+    { name: "Canon", path: "Remote UI (browser → printer's IP) → <code>Settings/Registration</code> → <code>TX Settings</code> → <code>E-Mail/I-Fax Settings</code> → <code>SMTP Server Settings</code>. Covers imageRUNNER, imageCLASS, Maxify and PIXMA business models. On the Maxify MB2755 this menu also holds a certificate-verification toggle — see the known exception further down this page." },
+    { name: "Ricoh", path: "Web Image Monitor (browser → printer's IP, log in as administrator) → <code>Device Management</code> → <code>Configuration</code> → <code>Email</code> (under Device Settings) → set <code>SMTP Server Name</code>, <code>SMTP Port No.</code>, and enable <code>SMTP Authentication</code>." },
+    { name: "Xerox", path: "Embedded Web Server → <code>Properties</code> → <code>Connectivity</code> → <code>Protocols</code> → <code>SMTP Server</code> → <code>General</code>. Newer app-based models use <code>Properties → Apps → Email → Setup</code> instead." },
+    { name: "Kyocera", path: "Command Center RX (browser → printer's IP, admin login) → <code>Advanced</code> → <code>E-mail</code> → <code>SMTP</code> → <code>General</code>. Set <code>SMTP Security</code> to match your chosen port, and confirm <code>SMTP (E-mail TX)</code> is <code>On</code> under <code>Network Settings → Protocol</code>." },
+    { name: "Konica Minolta", path: "Touch panel: <code>Utility</code> → <code>Administrator Settings</code> → <code>Network Settings</code> → <code>E-Mail Settings</code> → <code>E-Mail TX (SMTP)</code>. Web Connection: <code>Network</code> → <code>E-mail Setting</code> → <code>E-mail TX (SMTP)</code>." },
+    { name: "Sharp", path: "<code>Settings (Administrator)</code> → <code>System Settings</code> → <code>Network Settings</code> → <code>Service Settings</code> → <code>SMTP</code> tab. Some models expose this on the web page as <code>Settings → E-mail</code>. Set <code>Primary Server</code>, <code>Port Number</code>, <code>Sender Address</code>, and enable SMTP authentication and <code>SSL/TLS</code>." },
+    { name: "Brother", path: "Web Based Management (browser → printer's IP) → <code>Network</code> → <code>Protocol</code> → <code>SMTP Client</code>. Set <code>SSL/TLS</code> to <code>STARTTLS</code> for port 587, or <code>SSL</code> for 465." },
+    { name: "Epson", path: "Printer's web configuration page → <code>Network Scan</code> or <code>Basic</code> → <code>Email Server</code> → enter server, port and authentication values. Applies to WorkForce and EcoTank Pro models with Scan-to-Email." },
+    { name: "Lexmark", path: "Embedded Web Server → <code>Settings</code> → <code>E-mail/FTP Settings</code> → <code>SMTP Setup</code>. Server goes in <code>Primary SMTP Gateway</code>, port in <code>Primary SMTP Gateway Port</code>, and set <code>Use SSL/TLS</code> to <code>Required</code>." }
+  ];
+
+  brands.forEach(function(b, i){
+    var opt = document.createElement('option');
+    opt.value = i;
+    opt.textContent = b.name;
+    select.appendChild(opt);
+  });
+
+  select.addEventListener('change', function(){
+    if (select.value === '') { output.innerHTML = ''; return; }
+    var b = brands[parseInt(select.value, 10)];
+    output.innerHTML =
+      '<p>' + b.path + '</p>' +
+      '<p style="color:#57606a;">Server: <code>mx.msgwing.com</code> &middot; Port: <code>587</code> (STARTTLS) or <code>465</code> (SSL/TLS) &middot; full settings table above.</p>';
+  });
+})();
+</script>
+
 ### HP
 Embedded Web Server (browser → printer's IP) → `Networking` or `Scan` tab →
 `TCP/IP Settings` → `Outgoing Email` / `Scan to Email` →
@@ -229,6 +274,10 @@ and set `Use SSL/TLS` to `Required`.
 ---
 
 ## Known exception: Canon Maxify MB2755
+
+*One entry in the growing [device case studies](DEVICE-CASE-STUDIES.md) list
+— hit something similar on your own hardware? See that page for how to
+report it.*
 
 Most printers validate `mx.msgwing.com`'s certificate correctly and should
 keep certificate verification **enabled** — the safe default recommended in

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -123,6 +123,21 @@ defaults:
       description: >-
         How to handle temporary SMTP failures correctly with backoff and
         retries instead of tight retry loops.
+  - scope:
+      path: "DEVICE-CASE-STUDIES.md"
+    values:
+      title: "Device case studies: real printer fixes"
+      description: >-
+        Confirmed, hardware-tested fixes for specific printer and MFP models
+        — certificate quirks and firmware issues manuals don't mention,
+        credited to whoever found them.
+  - scope:
+      path: "MONITORING.md"
+    values:
+      title: "Monitoring alerts via SMTP relay"
+      description: >-
+        Drop-in email alert configuration for Zabbix, Nagios/Icinga, Uptime
+        Kuma and PRTG using a free SMTP relay.
 
 exclude:
   - assets/*.py

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,31 @@ option among them.
 If that's the error you're seeing, start with
 [Exchange Online SMTP AUTH migration](EXCHANGE-ONLINE-SMTP-AUTH.md).
 
+<div id="zc-countdown" style="background:#f6f8fa;border:1px solid #d0d7de;border-radius:6px;padding:16px 20px;margin:20px 0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;">
+  <noscript>Basic authentication for SMTP AUTH is disabled by default on existing Microsoft 365 tenants at the end of December 2026.</noscript>
+</div>
+<script>
+(function(){
+  var el = document.getElementById('zc-countdown');
+  if (!el) return;
+  var deadline = new Date('2026-12-31T23:59:59Z');
+  function render(){
+    var diff = deadline - new Date();
+    if (diff <= 0) {
+      el.innerHTML = '<strong>The default has flipped.</strong> Basic authentication for SMTP AUTH is now disabled by default on existing Microsoft 365 tenants.';
+      return;
+    }
+    var d = Math.floor(diff / 86400000);
+    var h = Math.floor((diff % 86400000) / 3600000);
+    el.innerHTML =
+      '<div style="font-size:12px;text-transform:uppercase;letter-spacing:.04em;color:#57606a;margin-bottom:4px;">Until Microsoft 365 disables Basic auth for SMTP AUTH by default</div>' +
+      '<div style="font-size:22px;font-weight:600;color:#0969da;">' + d + ' day' + (d === 1 ? '' : 's') + ', ' + h + ' hour' + (h === 1 ? '' : 's') + '</div>';
+  }
+  render();
+  setInterval(render, 3600000);
+})();
+</script>
+
 ---
 
 ## Start here
@@ -27,6 +52,8 @@ If that's the error you're seeing, start with
 | Manage Linux servers | [Linux](LINUX.md) · [system-wide relay](SYSTEM-MTA.md) |
 | Are sending from an app or script | [Code examples in 15 languages](CODE-EXAMPLES.md) |
 | Have it failing or timing out | [Troubleshooting](TROUBLESHOOTING.md) |
+| Have monitoring/alerting tools that need to send mail | [Monitoring alerts](MONITORING.md) |
+| Want to see confirmed fixes for specific hardware | [Device case studies](DEVICE-CASE-STUDIES.md) |
 | Just want the short answers | [FAQ](FAQ.md) |
 
 ## What is happening


### PR DESCRIPTION
## Summary
- Live countdown to the end-of-December-2026 Basic auth default flip on the docs homepage.
- The existing ASCII decision tree in EXCHANGE-ONLINE-SMTP-AUTH.md is now also an interactive click-through quiz (same logic; ASCII version kept for no-JS/accessibility/search parsing).
- Brand picker on PRINTERS.md surfaces just the one menu path for a selected printer brand, sourced from the existing per-brand sections.
- New docs/DEVICE-CASE-STUDIES.md indexing hardware-confirmed fixes (Canon MB2755 to start), open for more reports.
- New docs/MONITORING.md: SMTP connection values for Zabbix/Uptime Kuma/PRTG (UI-configured, not a config file), plus the Nagios/Icinga case which has no SMTP settings of its own and is fixed via the host's MTA per SYSTEM-MTA.md.
- Both READMEs and _config.yml updated to link/index the two new pages.

## Test plan
- [x] Countdown math verified against current date locally
- [x] Decision quiz clicked through multiple branches (ZeroSMTP path, OAuth path) locally before committing
- [x] Brand picker dropdown selection verified locally