### PR TITLE
Add a live countdown badge to both READMEs

### DIFF
--- a/.github/workflows/countdown-badge.yml
+++ b/.github/workflows/countdown-badge.yml
@@ -1,0 +1,78 @@
+name: Dec 2026 countdown badge
+
+# Publishes a shields.io endpoint badge showing days remaining until
+# Microsoft disables Basic authentication for SMTP AUTH by default on
+# existing tenants (end of December 2026). Same publishing pattern as
+# service-healthcheck.yml: writes a small JSON file to the orphan
+# "status" branch (not main), which the README badge reads via
+# img.shields.io/endpoint. Runs once a day - a days-remaining counter
+# doesn't need the 6-hour cadence the connectivity check uses.
+
+on:
+  schedule:
+    - cron: '5 0 * * *' # once a day, just after midnight UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  countdown:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compute days remaining and publish badge data
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          DEADLINE="2026-12-31T23:59:59Z"
+          NOW_EPOCH=$(date -u +%s)
+          DEADLINE_EPOCH=$(date -u -d "$DEADLINE" +%s)
+          DIFF=$(( (DEADLINE_EPOCH - NOW_EPOCH) / 86400 ))
+
+          if [ "$DIFF" -lt 0 ]; then
+            MESSAGE="default has flipped"
+            COLOR="red"
+          elif [ "$DIFF" -eq 0 ]; then
+            MESSAGE="today"
+            COLOR="red"
+          elif [ "$DIFF" -eq 1 ]; then
+            MESSAGE="1 day left"
+            COLOR="red"
+          elif [ "$DIFF" -le 30 ]; then
+            MESSAGE="${DIFF} days left"
+            COLOR="red"
+          elif [ "$DIFF" -le 90 ]; then
+            MESSAGE="${DIFF} days left"
+            COLOR="orange"
+          else
+            MESSAGE="${DIFF} days left"
+            COLOR="blue"
+          fi
+
+          WORKDIR=$(mktemp -d)
+          cd "$WORKDIR"
+          git init -q
+          git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          if git fetch -q origin status 2>/dev/null; then
+            git checkout -q -B status origin/status
+          else
+            git checkout -q --orphan status
+            git rm -rf . -q 2>/dev/null || true
+          fi
+
+          cat > countdown.json <<JSON
+          {"schemaVersion":1,"label":"Basic auth (SMTP AUTH) shutdown","message":"${MESSAGE}","color":"${COLOR}"}
+          JSON
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add countdown.json
+          if ! git diff --cached --quiet; then
+            git commit -q -m "Update countdown: ${MESSAGE}"
+            git push -q origin status
+          else
+            echo "Countdown unchanged (${MESSAGE}), nothing to push"
+          fi

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Microsoft 365 turns off SMTP AUTH Basic auth.<br>
 No OAuth to implement. No credit card. No mail server to run.
 
 [![mx.msgwing.com status](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/status.json)](https://github.com/msgwing/ZeroSMTP/actions/workflows/service-healthcheck.yml)
+[![Basic auth countdown](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/countdown.json)](docs/EXCHANGE-ONLINE-SMTP-AUTH.md)
 [![Lint examples](https://github.com/msgwing/ZeroSMTP/actions/workflows/lint.yml/badge.svg)](https://github.com/msgwing/ZeroSMTP/actions/workflows/lint.yml)
 [![15 languages](https://img.shields.io/badge/examples-15%20languages-blue)](#code-examples)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)

--- a/README.pl.md
+++ b/README.pl.md
@@ -8,6 +8,7 @@ Microsoft 365 wyłącza SMTP AUTH z uwierzytelnianiem Basic.<br>
 Bez wdrażania OAuth. Bez karty kredytowej. Bez własnego serwera pocztowego.
 
 [![mx.msgwing.com status](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/status.json)](https://github.com/msgwing/ZeroSMTP/actions/workflows/service-healthcheck.yml)
+[![Odliczanie do wyłączenia Basic auth](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/countdown.json)](docs/EXCHANGE-ONLINE-SMTP-AUTH.md)
 [![Lint examples](https://github.com/msgwing/ZeroSMTP/actions/workflows/lint.yml/badge.svg)](https://github.com/msgwing/ZeroSMTP/actions/workflows/lint.yml)
 [![15 języków](https://img.shields.io/badge/przyk%C5%82ady-15%20j%C4%99zyk%C3%B3w-blue)](#przykłady-kodu)
 [![Licencja: MIT](https://img.shields.io/badge/licencja-MIT-green.svg)](LICENSE)


### PR DESCRIPTION
Reuses the exact publishing pattern already proven in `service-healthcheck.yml`: a daily workflow writes a small shields.io endpoint JSON (`countdown.json`) to the orphan `status` branch, and a new README badge reads it. Shows days remaining until Microsoft disables Basic auth for SMTP AUTH by default (end of Dec 2026), color escalating blue -> orange (<=90 days) -> red (<=30 days). Date-diff bash logic tested locally before use.