### PR TITLE
Clarify the countdown badge is about Exchange Online, not ZeroSMTP

### DIFF
--- a/.github/workflows/countdown-badge.yml
+++ b/.github/workflows/countdown-badge.yml
@@ -64,7 +64,7 @@ jobs:
           fi
 
           cat > countdown.json <<JSON
-          {"schemaVersion":1,"label":"Basic auth (SMTP AUTH) shutdown","message":"${MESSAGE}","color":"${COLOR}"}
+          {"schemaVersion":1,"label":"Exchange Online Basic auth (SMTP AUTH)","message":"${MESSAGE}","color":"${COLOR}"}
           JSON
 
           git config user.name "github-actions[bot]"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Microsoft 365 turns off SMTP AUTH Basic auth.<br>
 No OAuth to implement. No credit card. No mail server to run.
 
 [![mx.msgwing.com status](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/status.json)](https://github.com/msgwing/ZeroSMTP/actions/workflows/service-healthcheck.yml)
-[![Basic auth countdown](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/countdown.json)](docs/EXCHANGE-ONLINE-SMTP-AUTH.md)
+[![Exchange Online Basic auth countdown](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/countdown.json)](docs/EXCHANGE-ONLINE-SMTP-AUTH.md)
 [![Lint examples](https://github.com/msgwing/ZeroSMTP/actions/workflows/lint.yml/badge.svg)](https://github.com/msgwing/ZeroSMTP/actions/workflows/lint.yml)
 [![15 languages](https://img.shields.io/badge/examples-15%20languages-blue)](#code-examples)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)

--- a/README.pl.md
+++ b/README.pl.md
@@ -8,7 +8,7 @@ Microsoft 365 wyłącza SMTP AUTH z uwierzytelnianiem Basic.<br>
 Bez wdrażania OAuth. Bez karty kredytowej. Bez własnego serwera pocztowego.
 
 [![mx.msgwing.com status](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/status.json)](https://github.com/msgwing/ZeroSMTP/actions/workflows/service-healthcheck.yml)
-[![Odliczanie do wyłączenia Basic auth](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/countdown.json)](docs/EXCHANGE-ONLINE-SMTP-AUTH.md)
+[![Odliczanie do wyłączenia Basic auth w Exchange Online](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/countdown.json)](docs/EXCHANGE-ONLINE-SMTP-AUTH.md)
 [![Lint examples](https://github.com/msgwing/ZeroSMTP/actions/workflows/lint.yml/badge.svg)](https://github.com/msgwing/ZeroSMTP/actions/workflows/lint.yml)
 [![15 języków](https://img.shields.io/badge/przyk%C5%82ady-15%20j%C4%99zyk%C3%B3w-blue)](#przykłady-kodu)
 [![Licencja: MIT](https://img.shields.io/badge/licencja-MIT-green.svg)](LICENSE)


### PR DESCRIPTION
The label "Basic auth (SMTP AUTH) shutdown" alone could read as ZeroSMTP itself shutting something down. Made it explicit this is Microsoft's Exchange Online deprecation - both in the published badge JSON and the README alt text.