### PR TITLE
Add the docs.msgwing.com countdown card to both READMEs

### DIFF
--- a/.github/workflows/countdown-badge.yml
+++ b/.github/workflows/countdown-badge.yml
@@ -1,12 +1,13 @@
 name: Dec 2026 countdown badge
 
-# Publishes a shields.io endpoint badge showing days remaining until
-# Microsoft disables Basic authentication for SMTP AUTH by default on
-# existing tenants (end of December 2026). Same publishing pattern as
-# service-healthcheck.yml: writes a small JSON file to the orphan
-# "status" branch (not main), which the README badge reads via
-# img.shields.io/endpoint. Runs once a day - a days-remaining counter
-# doesn't need the 6-hour cadence the connectivity check uses.
+# Publishes a shields.io endpoint badge, and a synthwave "Final Countdown"
+# SVG card matching the one on docs.msgwing.com, showing days remaining
+# until Microsoft disables Basic authentication for SMTP AUTH by default
+# on existing tenants (end of December 2026). Same publishing pattern as
+# service-healthcheck.yml: writes small files to the orphan "status"
+# branch (not main), read via img.shields.io/endpoint (badge) and a raw
+# githubusercontent.com image (card) in both READMEs. Runs once a day - a
+# days-remaining counter doesn't need the 6-hour connectivity-check cadence.
 
 on:
   schedule:
@@ -34,21 +35,36 @@ jobs:
           if [ "$DIFF" -lt 0 ]; then
             MESSAGE="default has flipped"
             COLOR="red"
+            ACCENT="#ff5555"
           elif [ "$DIFF" -eq 0 ]; then
             MESSAGE="today"
             COLOR="red"
+            ACCENT="#ff5555"
           elif [ "$DIFF" -eq 1 ]; then
             MESSAGE="1 day left"
             COLOR="red"
+            ACCENT="#ff5555"
           elif [ "$DIFF" -le 30 ]; then
             MESSAGE="${DIFF} days left"
             COLOR="red"
+            ACCENT="#ff5555"
           elif [ "$DIFF" -le 90 ]; then
             MESSAGE="${DIFF} days left"
             COLOR="orange"
+            ACCENT="#ffb86c"
           else
             MESSAGE="${DIFF} days left"
             COLOR="blue"
+            ACCENT="#8be9fd"
+          fi
+
+          LEN=${#MESSAGE}
+          if [ "$LEN" -le 14 ]; then
+            BIGSIZE=40
+          elif [ "$LEN" -le 20 ]; then
+            BIGSIZE=28
+          else
+            BIGSIZE=22
           fi
 
           WORKDIR=$(mktemp -d)
@@ -67,9 +83,48 @@ jobs:
           {"schemaVersion":1,"label":"Exchange Online Basic auth (SMTP AUTH)","message":"${MESSAGE}","color":"${COLOR}"}
           JSON
 
+          cat > countdown-card.svg <<SVG
+          <svg xmlns="http://www.w3.org/2000/svg" width="480" height="120" viewBox="0 0 480 120" role="img" aria-label="Exchange Online Basic auth (SMTP AUTH) countdown: ${MESSAGE}">
+            <title>Exchange Online Basic auth (SMTP AUTH) countdown: ${MESSAGE}</title>
+            <defs>
+              <radialGradient id="bg" cx="50%" cy="130%" r="90%">
+                <stop offset="0%" stop-color="#2d1b4e"/>
+                <stop offset="55%" stop-color="#0d0620"/>
+                <stop offset="100%" stop-color="#050310"/>
+              </radialGradient>
+              <filter id="glowPink" x="-50%" y="-50%" width="200%" height="200%">
+                <feGaussianBlur stdDeviation="3" result="blur"/>
+                <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+              </filter>
+              <filter id="glowAccent" x="-50%" y="-50%" width="200%" height="200%">
+                <feGaussianBlur stdDeviation="4" result="blur"/>
+                <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+              </filter>
+              <style>
+                .pulse { animation: zc-pulse 2.2s ease-in-out infinite; }
+                @keyframes zc-pulse { 0%, 100% { opacity: 0.85; } 50% { opacity: 1; } }
+                .twinkle { animation: zc-twinkle 3s ease-in-out infinite; }
+                @keyframes zc-twinkle { 0%, 100% { opacity: 0.15; } 50% { opacity: 0.9; } }
+              </style>
+            </defs>
+            <rect x="1" y="1" width="478" height="118" rx="12" fill="url(#bg)" stroke="${ACCENT}" stroke-width="1.5"/>
+            <circle class="twinkle" cx="40" cy="20" r="1" fill="#fff" style="animation-delay:0s"/>
+            <circle class="twinkle" cx="90" cy="95" r="1" fill="#fff" style="animation-delay:.6s"/>
+            <circle class="twinkle" cx="150" cy="15" r="1.5" fill="#fff" style="animation-delay:1.1s"/>
+            <circle class="twinkle" cx="320" cy="100" r="1" fill="#fff" style="animation-delay:.3s"/>
+            <circle class="twinkle" cx="410" cy="18" r="1" fill="#fff" style="animation-delay:1.6s"/>
+            <circle class="twinkle" cx="440" cy="70" r="1.5" fill="#fff" style="animation-delay:.9s"/>
+            <circle class="twinkle" cx="250" cy="12" r="1" fill="#fff" style="animation-delay:2s"/>
+            <circle class="twinkle" cx="60" cy="60" r="1" fill="#fff" style="animation-delay:1.3s"/>
+            <text x="240" y="30" text-anchor="middle" font-family="-apple-system,Segoe UI,Helvetica,Arial,sans-serif" font-size="11" letter-spacing="2" fill="#ff2ec4" filter="url(#glowPink)" class="pulse" style="text-transform:uppercase;font-weight:700;">IT'S THE FINAL COUNTDOWN</text>
+            <text x="240" y="78" text-anchor="middle" font-family="Courier New,monospace" font-weight="700" font-size="${BIGSIZE}" fill="${ACCENT}" filter="url(#glowAccent)" class="pulse">${MESSAGE}</text>
+            <text x="240" y="104" text-anchor="middle" font-family="-apple-system,Segoe UI,Helvetica,Arial,sans-serif" font-size="11" fill="${ACCENT}" opacity="0.85">Exchange Online Basic auth (SMTP AUTH) &#8212; disabled by default end of Dec 2026</text>
+          </svg>
+          SVG
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add countdown.json
+          git add countdown.json countdown-card.svg
           if ! git diff --cached --quiet; then
             git commit -q -m "Update countdown: ${MESSAGE}"
             git push -q origin status

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ No OAuth to implement. No credit card. No mail server to run.
 [![15 languages](https://img.shields.io/badge/examples-15%20languages-blue)](#code-examples)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
+[![Exchange Online Basic auth (SMTP AUTH) countdown](https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/countdown-card.svg)](docs/EXCHANGE-ONLINE-SMTP-AUTH.md)
+
 [**Get a free account →**](https://msgwing.com) · [**Exchange Online migration →**](docs/EXCHANGE-ONLINE-SMTP-AUTH.md) · [Documentation site](https://docs.msgwing.com/) · [Quickstart](#quickstart) · [Code examples](#code-examples) · [FAQ](docs/FAQ.md) · [Polski](README.pl.md)
 
 </div>

--- a/README.pl.md
+++ b/README.pl.md
@@ -13,6 +13,8 @@ Bez wdrażania OAuth. Bez karty kredytowej. Bez własnego serwera pocztowego.
 [![15 języków](https://img.shields.io/badge/przyk%C5%82ady-15%20j%C4%99zyk%C3%B3w-blue)](#przykłady-kodu)
 [![Licencja: MIT](https://img.shields.io/badge/licencja-MIT-green.svg)](LICENSE)
 
+[![Odliczanie do wyłączenia Basic auth w Exchange Online (SMTP AUTH)](https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/countdown-card.svg)](docs/EXCHANGE-ONLINE-SMTP-AUTH.md)
+
 [**Załóż darmowe konto →**](https://msgwing.com) · [**Migracja z Exchange Online →**](docs/EXCHANGE-ONLINE-SMTP-AUTH.md) · [Strona dokumentacji](https://docs.msgwing.com/) · [Szybki start](#szybki-start) · [Przykłady kodu](#przykłady-kodu) · [FAQ](docs/FAQ.md) · [English](README.md)
 
 </div>


### PR DESCRIPTION
## Summary
- GitHub strips `<script>` tags from rendered READMEs, so the live JS countdown widget on the docs homepage can't be embedded directly there.
- Extended `.github/workflows/countdown-badge.yml` to also generate a static SVG "Final Countdown" card — same synthwave look as the docs site, with CSS `@keyframes` glow/twinkle animations that still render for a static `<img>`/`![]()` reference — alongside the existing `countdown.json`, published daily to the orphan `status` branch.
- Referenced the card as an image in both `README.md` and `README.pl.md`, linking to the Exchange Online migration doc.
- Card color/urgency tier matches the existing badge (blue >90 days, orange ≤90, red ≤30).

## Test plan
- [x] Verified the heredoc-based SVG/JSON generation logic locally (isolated from git) — valid JSON, well-formed SVG, correct placeholder substitution.
- [x] Verified the generated SVG parses with no errors in a browser (correct width/height, text elements, title).
- [ ] Trigger the workflow manually and confirm `countdown-card.svg` publishes to the `status` branch and renders in both READMEs on GitHub.