### PR TITLE
Restore FAQPage/HowTo structured data, clarify no-bulk-sending scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@
 **A free SMTP relay that still accepts plain username-and-password auth.**<br>
 Built for the printers, scanners, and legacy apps left behind when
 Microsoft 365 turns off SMTP AUTH Basic auth.<br>
-No OAuth to implement. No credit card. No mail server to run.
+No OAuth to implement. No credit card. No mail server to run.<br>
+Scoped to **transactional email** (notifications, password resets, contact
+forms) on a shared domain, capped at **200 messages/day per account** — not
+built for bulk or marketing sending, at any price
+([why](docs/FAQ.md#do-you-offer-a-paid-plan-for-high-volumebulk-sending)).
 
 [![mx.msgwing.com status](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/status.json)](https://github.com/msgwing/ZeroSMTP/actions/workflows/service-healthcheck.yml)
 [![Exchange Online Basic auth countdown](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/countdown.json)](docs/EXCHANGE-ONLINE-SMTP-AUTH.md)

--- a/README.pl.md
+++ b/README.pl.md
@@ -5,7 +5,12 @@
 **Darmowy relay SMTP, który nadal przyjmuje zwykłe logowanie loginem i hasłem.**<br>
 Stworzony dla drukarek, skanerów i starszych aplikacji porzuconych, gdy
 Microsoft 365 wyłącza SMTP AUTH z uwierzytelnianiem Basic.<br>
-Bez wdrażania OAuth. Bez karty kredytowej. Bez własnego serwera pocztowego.
+Bez wdrażania OAuth. Bez karty kredytowej. Bez własnego serwera pocztowego.<br>
+Ograniczony do poczty **transakcyjnej** (powiadomienia, resetowanie haseł,
+formularze kontaktowe) w domenie współdzielonej, z limitem **200
+wiadomości/dzień na konto** — nie jest przeznaczony do wysyłki masowej ani
+marketingowej, niezależnie od ceny
+([dlaczego](docs/FAQ.md#do-you-offer-a-paid-plan-for-high-volumebulk-sending)).
 
 [![mx.msgwing.com status](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/status.json)](https://github.com/msgwing/ZeroSMTP/actions/workflows/service-healthcheck.yml)
 [![Odliczanie do wyłączenia Basic auth w Exchange Online](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/countdown.json)](docs/EXCHANGE-ONLINE-SMTP-AUTH.md)

--- a/docs/AFFECTED-SYSTEMS.md
+++ b/docs/AFFECTED-SYSTEMS.md
@@ -47,18 +47,20 @@ forgotten device nobody remembers configuring.
 These aren't predictions; the vendor or a support channel has documented the
 breakage publicly.
 
-| System | Evidence |
-| --- | --- |
-| **Ricoh multifunction printers** | [Official advisory](https://www.ricoh.com/info/2025/0526_1) listing affected products and firmware status |
-| **Microsoft Dynamics NAV / Business Central** | [Vendor guidance](https://www.innovia.com/blog/microsoft-to-retire-basic-auth-smtp-for-exchange-online-what-bc-nav-users-need-to-know) for affected installs |
-| **Laserfiche workflows** | [Community thread](https://answers.laserfiche.com/questions/200557/Disabling-basic-authentication-causing-Workflow-emails-to-fail) — workflow emails failing |
-| **ManageEngine OpManager** | [Vendor fix guide](https://www.manageengine.com/network-monitoring/how-to/fix-smtpclientauth-disabled-error.html) for the SMTPClientAuth error |
-| **Cerberus FTP Server** | [Support article](https://support.cerberusftp.com/hc/en-us/articles/24103821642643-Troubleshooting-SMTP-Setup-Error-on-Office365-com-Resolving-EHLO-Message-Failure-535-5-7-139-Authentication-Unsuccessful-Basic-Authentication-Disabled) on the exact 535 5.7.139 error |
-| **Fax servers (e.g. Faxination)** | [Vendor timeline notice](https://faxination.com/microsoft-timeline-for-basic-authentication-deprecation-in-exchange-online-smtp-auth/) |
-| **Cisco Unity Connection** | Named in [Microsoft's own deprecation docs](https://learn.microsoft.com/en-us/exchange/clients-and-mobile-in-exchange-online/deprecation-of-basic-authentication-exchange-online) |
-| **Microsoft Teams Rooms** | Named in Microsoft's docs as needing modern auth enabled |
-| **QNAP NAS** | [Community confirmation](https://forum.qnap.com/viewtopic.php?t=164027) that QNAP does not support OAuth for notifications |
-| **Veeam (older versions)** | [Veeam docs](https://helpcenter.veeam.com/docs/vbo365/guide/smtp_server.html) — some versions support only SMTP basic auth; newer ones added OAuth |
+| System | Evidence | Quick fix notes |
+| --- | --- | --- |
+| **Ricoh multifunction printers** | [Official advisory](https://www.ricoh.com/info/2025/0526_1) listing affected products and firmware status | [Gist](https://gist.github.com/msgwing/90db4abd056e013aceb126c4d67f6012) |
+| **Microsoft Dynamics NAV / Business Central** | [Vendor guidance](https://www.innovia.com/blog/microsoft-to-retire-basic-auth-smtp-for-exchange-online-what-bc-nav-users-need-to-know) for affected installs | |
+| **Laserfiche workflows** | [Community thread](https://answers.laserfiche.com/questions/200557/Disabling-basic-authentication-causing-Workflow-emails-to-fail) — workflow emails failing | [Gist](https://gist.github.com/msgwing/ce9c7d2de9b3c1c942e459f372772866) |
+| **ManageEngine OpManager** | [Vendor fix guide](https://www.manageengine.com/network-monitoring/how-to/fix-smtpclientauth-disabled-error.html) for the SMTPClientAuth error | [Gist](https://gist.github.com/msgwing/899fd2ce0da733770bedf4942987ce47) |
+| **Cerberus FTP Server** | [Support article](https://support.cerberusftp.com/hc/en-us/articles/24103821642643-Troubleshooting-SMTP-Setup-Error-on-Office365-com-Resolving-EHLO-Message-Failure-535-5-7-139-Authentication-Unsuccessful-Basic-Authentication-Disabled) on the exact 535 5.7.139 error | [Gist](https://gist.github.com/msgwing/f9b201aeddd34c8a156cf35fca85f6c5) |
+| **Fax servers (e.g. Faxination)** | [Vendor timeline notice](https://faxination.com/microsoft-timeline-for-basic-authentication-deprecation-in-exchange-online-smtp-auth/) | |
+| **Cisco Unity Connection** | Named in [Microsoft's own deprecation docs](https://learn.microsoft.com/en-us/exchange/clients-and-mobile-in-exchange-online/deprecation-of-basic-authentication-exchange-online) | |
+| **Microsoft Teams Rooms** | Named in Microsoft's docs as needing modern auth enabled | |
+| **QNAP NAS** | [Community confirmation](https://forum.qnap.com/viewtopic.php?t=164027) that QNAP does not support OAuth for notifications | [Gist](https://gist.github.com/msgwing/39958d909e085ae9cc0e6b3584d930bf) |
+| **Veeam (older versions)** | [Veeam docs](https://helpcenter.veeam.com/docs/vbo365/guide/smtp_server.html) — some versions support only SMTP basic auth; newer ones added OAuth | [Gist](https://gist.github.com/msgwing/ac5e126b0389c38cd7c13517eeec44a4) |
+| **Kyocera "Send Error 1102"** | Kyocera's device-side code for an SMTP auth failure | [Gist](https://gist.github.com/msgwing/882d045c3dfa9750e1cb3f020a5f4304) |
+| **Generic `535 5.7.3` from `smtp.office365.com`** | Same root cause, different wording | [Gist](https://gist.github.com/msgwing/66c97a2c9a399861bac89fcefc00ea67) |
 
 ## Categories to audit
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -6,6 +6,7 @@ Answers to the questions we get asked most often about using ZeroSMTP.
 - [Will emails be sent from my own domain (e.g. you@yourdomain.com)?](#will-emails-be-sent-from-my-own-domain-eg-youyourdomaincom)
 - [Can I get a custom username instead of the randomly generated one?](#can-i-get-a-custom-username-instead-of-the-randomly-generated-one)
 - [What are the sending limits?](#what-are-the-sending-limits)
+- [Do you offer a paid plan for high-volume/bulk sending?](#do-you-offer-a-paid-plan-for-high-volumebulk-sending)
 - [Can ZeroSMTP receive email too?](#can-zerosmtp-receive-email-too)
 - [My printer/device shows a certificate error — do I need to disable certificate verification?](#my-printerdevice-shows-a-certificate-error--do-i-need-to-disable-certificate-verification)
 - [Why is ZeroSMTP free? What's the catch?](#why-is-zerosmtp-free-whats-the-catch)
@@ -54,6 +55,20 @@ you can request a specific one (e.g. `you@msgwing.com`):
 
 See [Sending limits (rate limiting)](TROUBLESHOOTING.md#sending-limits-rate-limiting)
 in the troubleshooting guide.
+
+## Do you offer a paid plan for high-volume/bulk sending?
+
+No. Even as a paid option, we don't support high-volume or bulk sending
+(tens/hundreds of thousands of messages per day) — see
+[Sending limits](TROUBLESHOOTING.md#sending-limits-rate-limiting). ZeroSMTP
+is scoped to transactional email on the shared `msgwing.com` domain, and
+that stays true regardless of price.
+
+If you need that kind of volume, use a dedicated bulk-sending platform
+instead. [EmailLabs](https://emaillabs.io/) is a Polish provider built for
+that use case — a proven solution we can personally vouch for, having used
+it while supporting a large banking-sector company, primarily for
+marketing and sales email campaigns.
 
 ## Can ZeroSMTP receive email too?
 
@@ -113,3 +128,78 @@ supported.
 ## Still have questions?
 
 Contact **abuse@msgwing.com**, or open an issue on this repository.
+
+{% raw %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Can I use ZeroSMTP with my own hosting and my own domain?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. ZeroSMTP is an SMTP relay, so it doesn't care which domain your hosting or website runs on. Register a free account at msgwing.com to get a randomly generated @msgwing.com address, configure that account's SMTP credentials in your app or hosting panel (server mx.msgwing.com, port 587 with STARTTLS or 465 with SSL/TLS), and your application can send mail through the relay immediately, regardless of your hosting's own domain."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Will emails be sent from my own domain (e.g. you@yourdomain.com)?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No, by design. Every message is sent from an @msgwing.com address, never from your own domain. ZeroSMTP only relays mail through the msgwing.com domain and does not send on behalf of arbitrary sender domains, mainly for anti-spam and deliverability reasons. If you need the From address to show your own domain, that requires your own dedicated mail server instead."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I get a custom username instead of the randomly generated one?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Registration generates a random @msgwing.com address by default, but you can request a specific one. Register an account at msgwing.com, then email your request to abuse@msgwing.com with the username you'd like and the address of the account you just registered. Once confirmed, the custom username is set permanently on your account."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What are the sending limits?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "ZeroSMTP is rate-limited per account to keep the shared domain's reputation good for everyone: up to 200 emails per day, with hourly and per-minute caps as well. See the Troubleshooting guide's sending limits section for the exact numbers."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do you offer a paid plan for high-volume/bulk sending?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Even as a paid option, ZeroSMTP doesn't support high-volume or bulk sending (tens or hundreds of thousands of messages per day). It's scoped to transactional email on the shared msgwing.com domain regardless of price. For that kind of volume, use a dedicated bulk-sending platform instead, such as EmailLabs."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can ZeroSMTP receive email too?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. ZeroSMTP is outgoing-only: there is no inbox, IMAP, or POP3 access tied to an @msgwing.com account."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "My printer or device shows a certificate error — do I need to disable certificate verification?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sometimes, but only for specific older devices, and it isn't recommended as a general fix. Some older embedded devices ship with a fixed, non-updatable root certificate store that predates the Let's Encrypt certificate chain mx.msgwing.com currently uses. First rule out a network or configuration problem rather than assuming it's this. If confirmed, disabling that one device's certificate verification is an accepted workaround for that device only, documented with a real example for the Canon Maxify MB2755 — verification should stay enabled on every other device."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Why is ZeroSMTP free? What's the catch?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "There isn't a hidden one. The trade-offs are the ones already documented: mail always goes out from a shared @msgwing.com address, not your own domain, and sending is rate-limited per account to keep the shared domain's reputation good for everyone. Beyond that, your data isn't processed for marketing or resold, and abuse accounts are actively removed to protect deliverability for everyone else."
+      }
+    }
+  ]
+}
+</script>
+{% endraw %}

--- a/docs/PRINTERS.md
+++ b/docs/PRINTERS.md
@@ -313,3 +313,36 @@ More causes and fixes in [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
 - **Sender is `@msgwing.com`**, never your own domain
   ([why](FAQ.md#will-emails-be-sent-from-my-own-domain-eg-youyourdomaincom)).
 
+{% raw %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Configure scan-to-email on a network printer using an SMTP relay",
+  "description": "How to configure scan-to-email on a network printer or multifunction device (MFP) using an SMTP relay that still accepts a plain username and password.",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "name": "Get credentials",
+      "text": "Register a free account at msgwing.com and activate it, then copy the randomly generated @msgwing.com username and password. They're shown once, so store them in the printer's own credential store rather than a shared document."
+    },
+    {
+      "@type": "HowToStep",
+      "name": "Enter the connection settings",
+      "text": "Enter server mx.msgwing.com, port 587 with STARTTLS (or 465 with SSL/TLS), enable authentication with method LOGIN or PLAIN, and set both the username and the From/sender address to the @msgwing.com login."
+    },
+    {
+      "@type": "HowToStep",
+      "name": "Find the setting in your printer's menu",
+      "text": "Menu wording and location vary by brand and firmware version. See the per-brand menu paths for HP, Canon, Ricoh, Xerox, Kyocera, Konica Minolta, Sharp, Brother, Epson, and Lexmark."
+    },
+    {
+      "@type": "HowToStep",
+      "name": "Send a test scan-to-email",
+      "text": "Send a test scan to your own inbox. If it fails, check the printer's event or job log for the actual SMTP response rather than the panel's summary message."
+    }
+  ]
+}
+</script>
+{% endraw %}
+

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -111,6 +111,16 @@ password resets, contact forms, scan-to-email); if your application needs
 sustained volume above them, contact abuse@msgwing.com before you build
 around it.
 
+**We do not offer a paid tier for high-volume or bulk sending** (e.g.
+tens/hundreds of thousands of messages per day) — ZeroSMTP, including any
+future paid option, stays scoped to transactional email on the shared
+`msgwing.com` domain. For that kind of volume, use a dedicated bulk-sending
+platform instead; for example, [EmailLabs](https://emaillabs.io/) is a
+Polish provider suited to that use case — a proven solution we can
+personally vouch for, having used it while supporting a large
+banking-sector company, primarily for marketing and sales email
+campaigns.
+
 ## This project cannot receive email
 
 ZeroSMTP is outgoing-only: there is no inbox, IMAP, or POP3 access tied to a


### PR DESCRIPTION
## Summary
- Restores the `FAQPage` JSON-LD block in `docs/FAQ.md` (stripped by a prior content edit), updated to cover all 8 current questions
- Restores the `HowTo` JSON-LD block in `docs/PRINTERS.md` (also stripped), covering the 4-step scan-to-email setup
- Clarifies in the README (EN/PL) hero and `TROUBLESHOOTING.md` that ZeroSMTP has no bulk/marketing-sending tier at any price, pointing to EmailLabs for that use case

## Test plan
- [x] Validated both JSON-LD blocks parse with `json.loads` and contain the expected number of entries (8 FAQ questions, 4 HowTo steps)
- [ ] CI passes (lint + CodeQL)