### PR TITLE
Add a build-only test workflow for the Actions-based Pages migration

### DIFF
--- a/.github/workflows/pages-build-test.yml
+++ b/.github/workflows/pages-build-test.yml
@@ -1,0 +1,43 @@
+name: Docs Pages build test
+
+# Sanity-check the docs/ Jekyll build under the Gemfile in
+# pages-deploy.yml, without touching the live GitHub Pages deployment.
+# Delete this workflow once pages-deploy.yml is confirmed working and
+# the repo's Pages source has been switched to "GitHub Actions".
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+          working-directory: docs
+
+      - name: Build with Jekyll
+        working-directory: docs
+        run: bundle exec jekyll build --destination _site --trace
+        env:
+          JEKYLL_ENV: production
+
+      - name: Show output and confirm lastmod is present
+        working-directory: docs
+        run: |
+          set -euo pipefail
+          echo "--- _site size ---"
+          du -sh _site
+          echo "--- sitemap.xml ---"
+          cat _site/sitemap.xml
+          echo "--- lastmod count ---"
+          grep -c "<lastmod>" _site/sitemap.xml

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,13 @@
 # Local Claude Code tool config — machine-specific, not project source
 .claude/
 
+# Jekyll build output and Bundler cache for docs/
+docs/_site/
+docs/.jekyll-cache/
+docs/.jekyll-metadata
+docs/Gemfile.lock
+docs/vendor/
+
 # Per-language build artifacts / dependency caches, in case a
 # contributor sets up a local project around one of the examples
 vendor/

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,21 @@
+source "https://rubygems.org"
+
+# Custom GitHub Actions build (not the classic "Deploy from a branch" build),
+# needed for jekyll-last-modified-at: that plugin isn't on GitHub Pages'
+# allowed-plugins list for the classic build, so it can't run there at all.
+# It powers <lastmod> in sitemap.xml from real git history per file - a
+# freshness signal worth having on a page whose whole premise is a hard
+# December 2026 deadline.
+gem "jekyll", "~> 4.3"
+gem "jekyll-theme-primer"
+gem "jekyll-seo-tag"
+gem "jekyll-sitemap"
+gem "jekyll-relative-links"
+gem "jekyll-optional-front-matter"
+gem "jekyll-last-modified-at"
+
+# Ruby 3.4+ dropped these from the default gems; Jekyll still needs them.
+gem "webrick"
+gem "csv"
+gem "base64"
+gem "logger"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -9,8 +9,10 @@
 # " | ZeroSMTP" to every one (~11 chars), and anything past ~60 total gets
 # truncated or flagged by Bing/Google as "title too long".
 #
-# Only plugins on GitHub Pages' supported list are used, so the site builds
-# natively without a custom Actions workflow.
+# Built by .github/workflows/pages-deploy.yml (a custom Actions workflow,
+# not GitHub Pages' classic "Deploy from a branch" build) so that
+# jekyll-last-modified-at - not on the classic build's allowed-plugin list -
+# can run and populate sitemap.xml's <lastmod> from real git history.
 
 title: ZeroSMTP
 tagline: Free SMTP relay that still accepts basic username/password auth
@@ -32,6 +34,7 @@ plugins:
   - jekyll-sitemap           # sitemap.xml for crawlers
   - jekyll-relative-links    # rewrites [x](FAQ.md) to working site URLs
   - jekyll-optional-front-matter  # render .md files that have no front matter
+  - jekyll-last-modified-at  # <lastmod> in sitemap.xml, from real git history
 
 relative_links:
   enabled: true


### PR DESCRIPTION
Staging step: this workflow only builds the docs/ Jekyll site (workflow_dispatch, no deploy) to validate the new Gemfile/plugin set — including jekyll-last-modified-at, which the classic Pages build can't run — before switching the repo's Pages source setting and adding a real deploy workflow.