### PR TITLE
Skip creating an issue when the outreach digest finds nothing

### DIFF
--- a/.github/workflows/outreach-digest.yml
+++ b/.github/workflows/outreach-digest.yml
@@ -71,17 +71,23 @@ jobs:
               }
             }
 
-            const body = results.length
-              ? [
-                  `Found ${results.length} recent public issue(s) (last 7 days) that may be`,
-                  `genuinely asking about free SMTP/email-sending options:`,
-                  '',
-                  ...results,
-                  '',
-                  '_Discovery digest only — nothing was posted anywhere automatically._',
-                  '_Read each one yourself and decide if/how a genuine, on-topic reply makes sense._',
-                ].join('\n')
-              : 'No matching public issues found this week.';
+            if (!results.length) {
+              core.summary
+                .addHeading('Weekly outreach digest')
+                .addRaw('No matching public issues found this week.')
+                .write();
+              return;
+            }
+
+            const body = [
+              `Found ${results.length} recent public issue(s) (last 7 days) that may be`,
+              `genuinely asking about free SMTP/email-sending options:`,
+              '',
+              ...results,
+              '',
+              '_Discovery digest only — nothing was posted anywhere automatically._',
+              '_Read each one yourself and decide if/how a genuine, on-topic reply makes sense._',
+            ].join('\n');
 
             const title = `Outreach digest — week of ${sinceDate}`;
 


### PR DESCRIPTION
## Summary
- The weekly outreach-digest workflow opened an issue even on a zero-result week ("No matching public issues found this week"), which clutters the issue tracker with noise.
- Now writes a job summary instead and skips issue creation entirely when there are no matches.

## Test plan
- [x] Reviewed logic: unchanged behavior when results are found; early return with job summary when empty.