### PR TITLE
Add a config override for the Actions build test workflow

### DIFF
--- a/.github/workflows/pages-build-test.yml
+++ b/.github/workflows/pages-build-test.yml
@@ -24,12 +24,15 @@ jobs:
           ruby-version: '3.3'
           bundler-cache: true
           working-directory: docs
+        env:
+          BUNDLE_GEMFILE: ${{ github.workspace }}/docs/Gemfile.pages-actions-migration
 
       - name: Build with Jekyll
         working-directory: docs
-        run: bundle exec jekyll build --destination _site --trace
+        run: bundle exec jekyll build --destination _site --config _config.yml,_config_actions.yml --trace
         env:
           JEKYLL_ENV: production
+          BUNDLE_GEMFILE: ${{ github.workspace }}/docs/Gemfile.pages-actions-migration
 
       - name: Show output and confirm lastmod is present
         working-directory: docs

--- a/docs/_config_actions.yml
+++ b/docs/_config_actions.yml
@@ -1,0 +1,15 @@
+# Config override, merged on top of _config.yml ONLY by the Actions-based
+# build (jekyll build --config _config.yml,_config_actions.yml). The
+# classic "deploy from a branch" build never reads this file, so it can't
+# break that build the way listing this plugin directly in _config.yml did
+# - jekyll-last-modified-at isn't on the classic build's allowed-plugin list.
+#
+# Delete this file and fold `plugins:` back into _config.yml once the
+# repo's Pages source is switched to "GitHub Actions" and the classic
+# build is no longer in play at all.
+plugins:
+  - jekyll-seo-tag
+  - jekyll-sitemap
+  - jekyll-relative-links
+  - jekyll-optional-front-matter
+  - jekyll-last-modified-at


### PR DESCRIPTION
Keeps jekyll-last-modified-at out of _config.yml (shared with the still-active classic Pages build) by putting it in a new docs/_config_actions.yml, merged in only by pages-build-test.yml via --config. This is what pages-build-test.yml was always supposed to test - it just wasn't wired up correctly yet.