### PR TITLE
Ignore setup-swift v3 in Dependabot until upstream GPG bug is fixed

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,3 +39,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # v3's Swiftly-based install fails GPG verification on GitHub-hosted
+      # runners ("gpg: Can't check signature: No public key") — a confirmed,
+      # still-open upstream bug: github.com/swift-actions/setup-swift/issues/798.
+      # Remove this once that's fixed upstream.
+      - dependency-name: "swift-actions/setup-swift"
+        versions: ["3.x"]


### PR DESCRIPTION
## Summary
- PR #16 (bump `swift-actions/setup-swift` 2→3) fails the `swift` CI job with `gpg: Can't check signature: No public key` — a confirmed, still-open upstream bug ([swift-actions/setup-swift#798](https://github.com/swift-actions/setup-swift/issues/798)), not something fixable from our workflow.
- Adds a Dependabot ignore rule for `3.x` of this action so it stops re-proposing the same broken bump every week.
- Closing PR #16 separately with a comment pointing here.

## Test plan
- [ ] CI passes (this only touches `dependabot.yml`, no workflow behavior change)