### PR TITLE
Hotfix: restore missing default layout site-wide

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -59,6 +59,7 @@ defaults:
   - scope:
       path: ""
     values:
+      layout: default
       image: /assets/banner.png
   - scope:
       path: "index.md"


### PR DESCRIPTION
The classic build's jekyll-default-layout (bundled in the github-pages gem) auto-applied layout: default; our own Gemfile for the Actions build doesn't pull that plugin in, so since the cutover every page has rendered with no layout at all (no head, no meta, no nav, no CSS). Sets layout: default explicitly instead.