### PR TITLE
Fix accessibility gaps flagged by PageSpeed Insights

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -150,7 +150,7 @@
         color: #24292f;
         text-decoration: none;
       }
-      .site-header nav a { font-size: .95rem; margin-right: 1rem; }
+      .site-header nav a { font-size: .95rem; margin-right: 1rem; text-decoration: underline; }
       .site-footer {
         margin-top: 3rem;
         padding-top: 1rem;
@@ -158,6 +158,7 @@
         font-size: .9rem;
         color: #57606a;
       }
+      .site-footer a { text-decoration: underline; }
       @media (prefers-color-scheme: dark) {
         .site-header, .site-footer { border-color: #30363d; }
         .site-header .wordmark { color: #e6edf3; }
@@ -179,7 +180,9 @@
         </nav>
       </header>
 
-      {{ content }}
+      <main id="content">
+        {{ content }}
+      </main>
 
       <footer class="site-footer">
         <p>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-![ZeroSMTP — free SMTP relay for developers and sysadmins, mx.msgwing.com, port 587/465, TLS](assets/banner.png)
+<img src="assets/banner.png" width="1280" height="340" alt="ZeroSMTP — free SMTP relay for developers and sysadmins, mx.msgwing.com, port 587/465, TLS">
 
 # ZeroSMTP — a free SMTP relay that still accepts basic auth
 


### PR DESCRIPTION
## Summary
- Add a `<main>` landmark around page content (Lighthouse: "Document doesn't have a main landmark")
- Underline header/footer nav links so they aren't distinguishable by color alone (Lighthouse: "Links rely on color alone")
- Add explicit width/height to the homepage banner image to remove a CLS risk noted in performance diagnostics

## Test plan
- [x] Verified PageSpeed Insights (mobile) baseline: Performance 100, Best Practices 100, SEO 100, Accessibility 91
- [ ] Re-run PageSpeed Insights after deploy to confirm Accessibility reaches 100 on mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)