### PR TITLE
Fix remaining PageSpeed gaps: color-only links, banner aspect ratio

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -159,6 +159,22 @@
         color: #57606a;
       }
       .site-footer a { text-decoration: underline; }
+
+      /* Body-content links: the theme underlines these on hover only,
+         which Lighthouse flags as distinguishable by color alone. */
+      .markdown-body a[href]:not(.anchor) {
+        text-decoration: underline;
+      }
+
+      /* The theme sets max-width: 100% on content images but no height
+         rule, so a fixed height="" attribute (kept for CLS) stretches the
+         image once its width is scaled down. height: auto lets the browser
+         derive the box from the width/height attributes' aspect ratio
+         instead, so it stays proportional at any container width. */
+      .markdown-body img {
+        height: auto;
+      }
+
       @media (prefers-color-scheme: dark) {
         .site-header, .site-footer { border-color: #30363d; }
         .site-header .wordmark { color: #e6edf3; }


### PR DESCRIPTION
## Summary
- Underline in-content markdown links (tables, prose) - `.markdown-body a` was only underlined on hover, which Lighthouse's contrast audit flags as "links distinguishable mainly by color" (Accessibility 93/100 on both mobile and desktop after PR #62).
- Add `height: auto` for `.markdown-body img` - the theme sets `max-width: 100%` but no height rule, so the banner's fixed `height="340"` attribute squashed it once its display width shrank below 1280px, tripping the "incorrect aspect ratio" / "low resolution" Best Practices audits (92/100).

## Test plan
- [x] Re-ran PageSpeed Insights (fresh, not cached) for both mobile and desktop against production before this change: Accessibility 93, Best Practices 92 on both, with exactly these two audits failing.
- [ ] Re-run PageSpeed Insights after deploy to confirm Accessibility and Best Practices reach 100 on both mobile and desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)