### PR TITLE
Minify built HTML/CSS/JS output (jekyll-minifier)

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -13,6 +13,7 @@ gem "jekyll-sitemap"
 gem "jekyll-relative-links"
 gem "jekyll-optional-front-matter"
 gem "jekyll-last-modified-at"
+gem "jekyll-minifier"
 
 # Ruby 3.4+ dropped these from the default gems; Jekyll still needs them.
 gem "webrick"

--- a/docs/_config_actions.yml
+++ b/docs/_config_actions.yml
@@ -13,3 +13,15 @@ plugins:
   - jekyll-relative-links
   - jekyll-optional-front-matter
   - jekyll-last-modified-at
+  - jekyll-minifier
+
+# jekyll-minifier: strips whitespace/comments from the built HTML, inline
+# <style>/<script>, and the linked style.css - pure syntactic minification,
+# doesn't touch selectors or behavior, so it can't break rendering the way
+# a CSS purge tool could. Addresses PageSpeed's "Minify CSS" opportunity.
+# Preserve the countdown/quiz widgets' template literals and comments they
+# rely on for readability isn't a concern here since minifier only strips
+# CSS/JS comments and whitespace, not logic.
+jekyll-minifier:
+  uglifier_args:
+    harmony: true


### PR DESCRIPTION
## Summary
- Add `jekyll-minifier` to the Actions-only build config (same pattern as `jekyll-last-modified-at`: listed in `_config_actions.yml`, not `_config.yml`, so it can't affect the classic Pages build).
- Strips whitespace/comments from built HTML and the linked/inline CSS+JS. Pure syntactic minification - doesn't touch selectors or behavior, so it can't break rendering.
- Targets PageSpeed's "Minify CSS" opportunity (~8 KiB) flagged in every recent report.

## Not included
Intentionally *not* attempting a CSS purge (removing unused selectors, ~15 KiB) in this PR - that needs a build-time content scan against the rendered HTML and no local Ruby/Node toolchain is available in this environment to verify it visually before shipping to the production docs site. Flagging as a possible follow-up rather than shipping it unverified.

## Test plan
- [ ] Confirm `Deploy docs to GitHub Pages` succeeds after merge (Gemfile resolves, jekyll-minifier installs cleanly on the Actions runner)
- [ ] Spot-check docs.msgwing.com renders identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)