### PR TITLE
Composite-friendly countdown animation + skip lint.yml on docs-only PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,13 @@ name: Lint examples
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
 
 # None of these jobs need to write anything — they only check out the repo
 # and run a build/syntax-check. Explicit minimal permissions (flagged by

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -232,7 +232,10 @@
         text-align:center;
         box-shadow:0 0 30px rgba(255,46,196,.25), inset 0 0 60px rgba(60,20,120,.4);
       }
-      @keyframes zc-fc-pulse { 0%,100%{ text-shadow:0 0 12px currentColor,0 0 24px currentColor; } 50%{ text-shadow:0 0 20px currentColor,0 0 40px currentColor; } }
+      /* filter, not text-shadow: Lighthouse flags animated text-shadow as a
+         non-composited (main-thread) animation. filter: drop-shadow gives
+         the same glow but runs on the compositor. */
+      @keyframes zc-fc-pulse { 0%,100%{ filter:drop-shadow(0 0 6px currentColor) drop-shadow(0 0 12px currentColor); } 50%{ filter:drop-shadow(0 0 10px currentColor) drop-shadow(0 0 20px currentColor); } }
       @keyframes zc-fc-twinkle { 0%,100%{ opacity:.15; } 50%{ opacity:.9; } }
       .zc-fc-unit { min-width:64px; }
       .zc-fc-num {


### PR DESCRIPTION
## Summary
- Countdown widget's glow pulse animated `text-shadow`, which Lighthouse's "Avoid non-composited animations" diagnostic flags (forces a main-thread repaint every frame, x4 for the four digit units). Switched to `filter: drop-shadow(...)`, visually equivalent, runs on the compositor instead.
- `lint.yml` ran its full 12-language build matrix (Go, Rust, Kotlin/Gradle, Swift, .NET, etc.) on every PR regardless of what changed, so a one-line docs/ CSS tweak still waited ~3-4 minutes on unrelated language builds. Added `paths-ignore: [docs/**, **.md]` to both `push` and `pull_request` triggers - any PR touching real example code still runs the full matrix; docs-only PRs skip it.

## Test plan
- [x] This PR itself touches a non-docs file (`lint.yml`), so the full matrix still runs here as a sanity check that the new trigger config is valid YAML and doesn't break anything.
- [ ] Confirm a future docs-only PR skips `lint.yml` entirely.
- [ ] Confirm the countdown widget's glow still renders as expected on docs.msgwing.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)