### PR TITLE
Add FAQ entry: we don't disclose infrastructure/deliverability details

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -10,6 +10,7 @@ Answers to the questions we get asked most often about using ZeroSMTP.
 - [Can ZeroSMTP receive email too?](#can-zerosmtp-receive-email-too)
 - [My printer/device shows a certificate error — do I need to disable certificate verification?](#my-printerdevice-shows-a-certificate-error--do-i-need-to-disable-certificate-verification)
 - [Why is ZeroSMTP free? What's the catch?](#why-is-zerosmtp-free-whats-the-catch)
+- [Can you share details about your infrastructure or how deliverability is maintained?](#can-you-share-details-about-your-infrastructure-or-how-deliverability-is-maintained)
 - [Still have questions?](#still-have-questions)
 
 ## Can I use ZeroSMTP with my own hosting and my own domain?
@@ -124,6 +125,20 @@ marketing or resold, and abuse accounts are actively removed to protect
 deliverability for everyone else. If your use case needs more than what's
 documented here, ask at abuse@msgwing.com rather than assuming it isn't
 supported.
+
+## Can you share details about your infrastructure or how deliverability is maintained?
+
+No. We don't publish operational specifics — server setup, IP reputation
+management, abuse monitoring, or anything else about how the relay is kept
+off blacklists — beyond what's already documented on this page (rate
+limits, SPF/DKIM/DMARC alignment, and the abuse policy above). Sharing
+that level of detail would make it easier to abuse the shared domain's
+reputation, which is exactly what those trade-offs exist to protect
+against for everyone using the service.
+
+If you're evaluating ZeroSMTP for a legitimate use case and have specific
+questions about *your own* integration rather than our internals, reach
+out at abuse@msgwing.com.
 
 ## Still have questions?
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -94,6 +94,14 @@
             "@type": "Answer",
             "text": "There isn't a hidden one. The trade-offs are the ones already documented: mail always goes out from a shared @msgwing.com address, not your own domain, and sending is rate-limited per account to keep the shared domain's reputation good for everyone. Beyond that, your data isn't processed for marketing or resold, and abuse accounts are actively removed to protect deliverability for everyone else."
           }
+        },
+        {
+          "@type": "Question",
+          "name": "Can you share details about your infrastructure or how deliverability is maintained?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "No. We don't publish operational specifics - server setup, IP reputation management, abuse monitoring, or anything else about how the relay is kept off blacklists - beyond what's already documented (rate limits, SPF/DKIM/DMARC alignment, and the abuse policy). Sharing that level of detail would make it easier to abuse the shared domain's reputation, which is exactly what those trade-offs exist to protect against for everyone using the service."
+          }
         }
       ]
     }


### PR DESCRIPTION
## Summary
Adds a new FAQ entry declining to share operational/infrastructure specifics (server setup, IP reputation management, abuse monitoring), prompted by an external email asking exactly that. Added to both the page content and the FAQPage JSON-LD.

## Test plan
- [x] Local build confirms the FAQPage JSON-LD parses with all 9 questions (8 existing + 1 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)