### PR TITLE
Add FAQ entry: no third-party plugins/widgets/scripts on the docs site

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -11,6 +11,7 @@ Answers to the questions we get asked most often about using ZeroSMTP.
 - [My printer/device shows a certificate error — do I need to disable certificate verification?](#my-printerdevice-shows-a-certificate-error--do-i-need-to-disable-certificate-verification)
 - [Why is ZeroSMTP free? What's the catch?](#why-is-zerosmtp-free-whats-the-catch)
 - [Can you share details about your infrastructure or how deliverability is maintained?](#can-you-share-details-about-your-infrastructure-or-how-deliverability-is-maintained)
+- [Do you accept third-party plugins, widgets, or scripts on the docs site?](#do-you-accept-third-party-plugins-widgets-or-scripts-on-the-docs-site)
 - [Still have questions?](#still-have-questions)
 
 ## Can I use ZeroSMTP with my own hosting and my own domain?
@@ -139,6 +140,20 @@ against for everyone using the service.
 If you're evaluating ZeroSMTP for a legitimate use case and have specific
 questions about *your own* integration rather than our internals, reach
 out at abuse@msgwing.com.
+
+## Do you accept third-party plugins, widgets, or scripts on the docs site?
+
+No. This documentation site intentionally ships with zero third-party
+JavaScript — no analytics, no trackers, no chat widgets, no translation
+or accessibility overlays, nothing that executes in a visitor's browser
+beyond what's in [the repository](https://github.com/msgwing/ZeroSMTP).
+A remote script is something that has to be trusted indefinitely rather
+than reviewed once, which doesn't fit the same handling of visitor data
+described elsewhere on this page. That holds regardless of price or how
+simple the integration is — the concern is ongoing trust, not setup cost.
+
+If multilingual support is ever added, it will be static, self-hosted
+pages generated from this repository, not a live third-party widget.
 
 ## Still have questions?
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -102,6 +102,14 @@
             "@type": "Answer",
             "text": "No. We don't publish operational specifics - server setup, IP reputation management, abuse monitoring, or anything else about how the relay is kept off blacklists - beyond what's already documented (rate limits, SPF/DKIM/DMARC alignment, and the abuse policy). Sharing that level of detail would make it easier to abuse the shared domain's reputation, which is exactly what those trade-offs exist to protect against for everyone using the service."
           }
+        },
+        {
+          "@type": "Question",
+          "name": "Do you accept third-party plugins, widgets, or scripts on the docs site?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "No. This documentation site intentionally ships with zero third-party JavaScript - no analytics, no trackers, no chat widgets, no translation or accessibility overlays, nothing that executes in a visitor's browser beyond what's in the repository. A remote script has to be trusted indefinitely rather than reviewed once, which doesn't fit the same handling of visitor data described elsewhere on this page. That holds regardless of price or how simple the integration is. If multilingual support is ever added, it will be static, self-hosted pages generated from this repository, not a live third-party widget."
+          }
         }
       ]
     }


### PR DESCRIPTION
## Summary
Adds a general FAQ entry declining third-party plugin/widget/script integration on the docs site, prompted by an unsolicited translation-widget pitch. Written as neutral policy documentation (not phrased as a reply to that specific sender) so it covers any future similar pitch. Added to both page content and the FAQPage JSON-LD.

## Test plan
- [x] Local build confirms the FAQPage JSON-LD parses with all 10 questions (9 existing + 1 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)