### PR TITLE
Move infra/third-party-integration policy to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,6 +25,30 @@ ZeroSMTP relay (`mx.msgwing.com`). Vulnerabilities in scope include:
 Vulnerabilities in the ZeroSMTP *service* itself (mx.msgwing.com,
 msgwing.com) should also be reported to abuse@msgwing.com.
 
+## Infrastructure and third-party integration inquiries
+
+We don't publish operational specifics about the relay — server setup, IP
+reputation management, abuse monitoring, or anything else about how
+`mx.msgwing.com` stays off blacklists — beyond what's already documented
+in the [FAQ](https://docs.msgwing.com/FAQ.html) (rate limits,
+SPF/DKIM/DMARC alignment, and the abuse policy). Sharing that level of
+detail would make it easier to abuse the shared domain's reputation,
+which those trade-offs exist to protect against for everyone using the
+service. If you're evaluating ZeroSMTP for a legitimate use case and have
+questions about *your own* integration rather than our internals, reach
+out at abuse@msgwing.com.
+
+We also don't accept third-party plugins, widgets, or scripts on the
+docs site (docs.msgwing.com). It intentionally ships with zero
+third-party JavaScript — no analytics, no trackers, no chat widgets, no
+translation or accessibility overlays, nothing that executes in a
+visitor's browser beyond what's in this repository. A remote script has
+to be trusted indefinitely rather than reviewed once, which doesn't fit
+the handling of visitor data described in the FAQ. That holds regardless
+of price or how simple the integration is. If multilingual support is
+ever added, it will be static, self-hosted pages generated from this
+repository, not a live third-party widget.
+
 ## Supported Versions
 
 This is an examples repository rather than a versioned library — only the

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -129,31 +129,13 @@ supported.
 
 ## Can you share details about your infrastructure or how deliverability is maintained?
 
-No. We don't publish operational specifics — server setup, IP reputation
-management, abuse monitoring, or anything else about how the relay is kept
-off blacklists — beyond what's already documented on this page (rate
-limits, SPF/DKIM/DMARC alignment, and the abuse policy above). Sharing
-that level of detail would make it easier to abuse the shared domain's
-reputation, which is exactly what those trade-offs exist to protect
-against for everyone using the service.
-
-If you're evaluating ZeroSMTP for a legitimate use case and have specific
-questions about *your own* integration rather than our internals, reach
-out at abuse@msgwing.com.
+No — see the [Security Policy](https://github.com/msgwing/ZeroSMTP/blob/main/SECURITY.md#infrastructure-and-third-party-integration-inquiries)
+for what we do and don't disclose, and why.
 
 ## Do you accept third-party plugins, widgets, or scripts on the docs site?
 
-No. This documentation site intentionally ships with zero third-party
-JavaScript — no analytics, no trackers, no chat widgets, no translation
-or accessibility overlays, nothing that executes in a visitor's browser
-beyond what's in [the repository](https://github.com/msgwing/ZeroSMTP).
-A remote script is something that has to be trusted indefinitely rather
-than reviewed once, which doesn't fit the same handling of visitor data
-described elsewhere on this page. That holds regardless of price or how
-simple the integration is — the concern is ongoing trust, not setup cost.
-
-If multilingual support is ever added, it will be static, self-hosted
-pages generated from this repository, not a live third-party widget.
+No — see the [Security Policy](https://github.com/msgwing/ZeroSMTP/blob/main/SECURITY.md#infrastructure-and-third-party-integration-inquiries)
+for the reasoning.
 
 ## Still have questions?
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -100,7 +100,7 @@
           "name": "Can you share details about your infrastructure or how deliverability is maintained?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "No. We don't publish operational specifics - server setup, IP reputation management, abuse monitoring, or anything else about how the relay is kept off blacklists - beyond what's already documented (rate limits, SPF/DKIM/DMARC alignment, and the abuse policy). Sharing that level of detail would make it easier to abuse the shared domain's reputation, which is exactly what those trade-offs exist to protect against for everyone using the service."
+            "text": "No - see the Security Policy (SECURITY.md in the GitHub repository) for what we do and don't disclose, and why."
           }
         },
         {
@@ -108,7 +108,7 @@
           "name": "Do you accept third-party plugins, widgets, or scripts on the docs site?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "No. This documentation site intentionally ships with zero third-party JavaScript - no analytics, no trackers, no chat widgets, no translation or accessibility overlays, nothing that executes in a visitor's browser beyond what's in the repository. A remote script has to be trusted indefinitely rather than reviewed once, which doesn't fit the same handling of visitor data described elsewhere on this page. That holds regardless of price or how simple the integration is. If multilingual support is ever added, it will be static, self-hosted pages generated from this repository, not a live third-party widget."
+            "text": "No - see the Security Policy (SECURITY.md in the GitHub repository) for the reasoning."
           }
         }
       ]


### PR DESCRIPTION
## Summary
Relocates the detailed policy text (added in #73/#75) to SECURITY.md, keeping short pointer answers + the same anchors on FAQ.html so nothing already surfaced to search engines breaks.

- FAQ.html keeps both question headings/anchors (`#can-you-share-details...`, `#do-you-accept-third-party-plugins...`) and both FAQPage JSON-LD entries, just shortened to point at SECURITY.md.
- SECURITY.md gains a new "Infrastructure and third-party integration inquiries" section with the full detail - the more fitting home since both topics are security-posture statements, not customer FAQ.

## Test plan
- [x] Local build confirms FAQPage JSON-LD still has 10 questions.
- [x] Both FAQ anchors still present (no dead fragments for anything already indexed/inspected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)