### PR TITLE
Add ZeroSMTP vs. other free SMTP relays comparison page

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ scan-to-email · IoT and device notifications · homelabs.
 > this one. **[What breaks →](docs/AFFECTED-SYSTEMS.md)** is the audit list,
 > with PowerShell to find your exposure.
 
-Setup guides: [Network printers](docs/PRINTERS.md) · [Popular applications](docs/APPS.md) · [Linux (Debian/Ubuntu/Rocky/Fedora/openSUSE)](docs/LINUX.md) · [System-wide mail relay (Postfix/msmtp/Exim4)](docs/SYSTEM-MTA.md) · [Windows Server](docs/WINDOWS-SERVER.md) · [Exchange Online SMTP AUTH migration](docs/EXCHANGE-ONLINE-SMTP-AUTH.md) · [Monitoring alerts](docs/MONITORING.md) · [Device case studies](docs/DEVICE-CASE-STUDIES.md) · [Troubleshooting](docs/TROUBLESHOOTING.md) · [Reliability (retries)](docs/RELIABILITY.md) · [FAQ](docs/FAQ.md)
+Setup guides: [Network printers](docs/PRINTERS.md) · [Popular applications](docs/APPS.md) · [Linux (Debian/Ubuntu/Rocky/Fedora/openSUSE)](docs/LINUX.md) · [System-wide mail relay (Postfix/msmtp/Exim4)](docs/SYSTEM-MTA.md) · [Windows Server](docs/WINDOWS-SERVER.md) · [Exchange Online SMTP AUTH migration](docs/EXCHANGE-ONLINE-SMTP-AUTH.md) · [Monitoring alerts](docs/MONITORING.md) · [Device case studies](docs/DEVICE-CASE-STUDIES.md) · [Troubleshooting](docs/TROUBLESHOOTING.md) · [Reliability (retries)](docs/RELIABILITY.md) · [vs. other free relays](docs/ALTERNATIVES.md) · [FAQ](docs/FAQ.md)
 
 ## How does this compare to other options?
 

--- a/docs/ALTERNATIVES.md
+++ b/docs/ALTERNATIVES.md
@@ -1,0 +1,47 @@
+# ZeroSMTP vs. other free SMTP relays
+
+Free transactional SMTP relays fall into two groups: services built for
+sending from **your own domain** (SMTP2GO, Brevo, MailerSend, and similar),
+and ZeroSMTP, built for sending when you **don't want to touch DNS at all**.
+Neither is "better" in the abstract — they solve different problems.
+
+![Setup path: a typical free relay takes five steps including DNS configuration; ZeroSMTP takes three steps with no DNS work](assets/setup-comparison.svg)
+
+## The one difference that matters
+
+Every relay below gives you SMTP credentials (username + password) — that
+part is standard. What differs is what happens *before* you can use them.
+
+| | ZeroSMTP | SMTP2GO / Brevo / MailerSend (typical) |
+| --- | --- | --- |
+| **Time to first email** | ~2 minutes | Minutes to 48 hours (DNS propagation) |
+| **DNS records to configure** | None | SPF + DKIM (and DMARC, recommended) |
+| **Sends from your own domain** | ❌ shared `@msgwing.com` address | ✅ once verified |
+| **Sender reputation** | Managed for you — shared domain, actively monitored for abuse | Yours to build and protect — a fresh domain/IP has no reputation yet, and one bad list wrecks it |
+| **Free tier** | 200/day, permanent | Roughly 300/day–3,000/month, mostly permanent |
+| **Credit card required** | No | Usually no |
+| **Best fit** | Printers, NAS units, scripts, legacy devices — anything that just needs mail to leave, from anyone | Apps and products sending under your own brand |
+
+Sources: [SMTP2GO — verified senders](https://support.smtp2go.com/hc/en-gb/articles/115004408567-Verified-Senders)
+(verification required for normal sending), [Brevo domain authentication](https://community.brevo.com/t/smtp-domain-authentication-sender-domain-verification/760)
+(not required to start, recommended for deliverability).
+
+## Which one fits you
+
+- ✅ **Pick ZeroSMTP if:** you don't have a domain to spare for this, don't
+  want to learn what an SPF record is, or the device sending the mail
+  (a printer, a NAS, a cron job) doesn't care whose address it comes from —
+  see [Printers](PRINTERS.md) and [Device case studies](DEVICE-CASE-STUDIES.md).
+- ✅ **Pick a domain-based relay if:** the mail needs to visibly come from
+  *your* company, you're past a couple hundred messages a day, or the
+  sending identity is part of your product (receipts, customer
+  notifications, marketing).
+
+This is the same honest split covered in
+[option 4 of the Exchange Online migration guide](EXCHANGE-ONLINE-SMTP-AUTH.md#4-a-third-party-smtp-service-that-still-accepts-usernamepassword) —
+this page just puts the comparison front and center instead of as one
+paragraph among several options.
+
+[**Get a free account →**](https://msgwing.com) if ZeroSMTP is the fit. If
+it isn't, no hard feelings — [FAQ](FAQ.md) covers the trade-offs in more
+detail, and the guides above name providers built for the other case.

--- a/docs/EXCHANGE-ONLINE-SMTP-AUTH.md
+++ b/docs/EXCHANGE-ONLINE-SMTP-AUTH.md
@@ -82,7 +82,9 @@ changes, but it's another server to run, patch, and monitor. Our
 Commercial relays (SendGrid, Mailgun, Brevo, SMTP2GO, Amazon SES…) accept
 plain SMTP AUTH and let you verify your own domain, so devices keep working
 with just a credential change. This is the usual paid answer, and for a
-business sending on its own domain it's typically the right one.
+business sending on its own domain it's typically the right one — see
+[ZeroSMTP vs. other free relays](ALTERNATIVES.md) for exactly what that
+verification step involves.
 
 ### 5. ZeroSMTP — where it actually fits
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -171,6 +171,13 @@ defaults:
       description: >-
         Drop-in email alert configuration for Zabbix, Nagios/Icinga, Uptime
         Kuma and PRTG using a free SMTP relay.
+  - scope:
+      path: "ALTERNATIVES.md"
+    values:
+      title: "ZeroSMTP vs. other free SMTP relays"
+      description: >-
+        How ZeroSMTP compares to SMTP2GO, Brevo and MailerSend: no DNS
+        setup vs. sending from your own verified domain.
 
 exclude:
   - assets/*.py

--- a/docs/assets/setup-comparison.svg
+++ b/docs/assets/setup-comparison.svg
@@ -1,0 +1,99 @@
+<svg viewBox="0 0 760 580" xmlns="http://www.w3.org/2000/svg" role="img">
+<title>Setup path comparison: typical free SMTP relay vs ZeroSMTP</title>
+<desc>A typical free relay takes five steps, including DNS configuration for SPF, DKIM and DMARC, verification, and waiting for propagation. ZeroSMTP takes three steps with no DNS configuration - SPF, DKIM, DMARC and TLS are already configured on the service side.</desc>
+<style>
+  text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; }
+  .col-title { font-size: 14px; font-weight: 600; letter-spacing: .02em; text-transform: uppercase; }
+  .col-sub { font-size: 12px; }
+  .step-title { font-size: 14.5px; font-weight: 600; }
+  .step-sub { font-size: 12.5px; }
+  .num { font-size: 11px; font-weight: 700; }
+  .foot { font-size: 11.5px; }
+  :root {
+    --text: #1c1f26; --text-dim: #6b7280; --rail: #d7dbe0;
+    --node: #b9bfc7; --node-ring: #ffffff;
+    --accent: #1a8f5f; --accent-soft: #e7f5ee;
+    --bg: #ffffff; --hair: #ececef;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --text: #e9eaee; --text-dim: #9398a3; --rail: #3a3f47;
+      --node: #565c66; --node-ring: #14161a;
+      --accent: #3ecf8e; --accent-soft: #14261e;
+      --bg: #14161a; --hair: #24272e;
+    }
+  }
+  svg { background: var(--bg); }
+</style>
+<rect x="0" y="0" width="760" height="580" fill="var(--bg)"/>
+
+<text x="40" y="38" class="col-title" fill="var(--text-dim)">Typical free SMTP relay</text>
+<text x="40" y="58" class="col-sub" fill="var(--text-dim)">sending from your own domain</text>
+
+<text x="420" y="38" class="col-title" fill="var(--accent)">ZeroSMTP</text>
+<text x="420" y="58" class="col-sub" fill="var(--text-dim)">sending from a ready-made address</text>
+
+<line x1="380" y1="20" x2="380" y2="540" stroke="var(--hair)" stroke-width="1"/>
+
+<line x1="52" y1="92" x2="52" y2="452" stroke="var(--rail)" stroke-width="2"/>
+<g>
+  <circle cx="52" cy="92" r="7" fill="var(--node)" stroke="var(--node-ring)" stroke-width="2"/>
+  <text x="49" y="96" class="num" fill="var(--bg)" text-anchor="middle">1</text>
+  <text x="76" y="88" class="step-title" fill="var(--text)">Create an account</text>
+  <text x="76" y="106" class="step-sub" fill="var(--text-dim)">email + password</text>
+</g>
+<g>
+  <circle cx="52" cy="182" r="7" fill="var(--node)" stroke="var(--node-ring)" stroke-width="2"/>
+  <text x="49" y="186" class="num" fill="var(--bg)" text-anchor="middle">2</text>
+  <text x="76" y="172" class="step-title" fill="var(--text)">Add DNS records</text>
+  <text x="76" y="190" class="step-sub" fill="var(--text-dim)">SPF, DKIM, DMARC - by hand</text>
+</g>
+<g>
+  <circle cx="52" cy="272" r="7" fill="var(--node)" stroke="var(--node-ring)" stroke-width="2"/>
+  <text x="49" y="276" class="num" fill="var(--bg)" text-anchor="middle">3</text>
+  <text x="76" y="262" class="step-title" fill="var(--text)">Wait for propagation</text>
+  <text x="76" y="280" class="step-sub" fill="var(--text-dim)">minutes to 48 hours</text>
+</g>
+<g>
+  <circle cx="52" cy="362" r="7" fill="var(--node)" stroke="var(--node-ring)" stroke-width="2"/>
+  <text x="49" y="366" class="num" fill="var(--bg)" text-anchor="middle">4</text>
+  <text x="76" y="352" class="step-title" fill="var(--text)">Verify the domain</text>
+  <text x="76" y="370" class="step-sub" fill="var(--text-dim)">a wrong record means mail lands in spam</text>
+</g>
+<g>
+  <circle cx="52" cy="452" r="7" fill="var(--node)" stroke="var(--node-ring)" stroke-width="2"/>
+  <text x="49" y="456" class="num" fill="var(--bg)" text-anchor="middle">5</text>
+  <text x="76" y="442" class="step-title" fill="var(--text)">Configure your app and send</text>
+  <text x="76" y="460" class="step-sub" fill="var(--text-dim)">only now, the first email</text>
+</g>
+
+<line x1="432" y1="92" x2="432" y2="272" stroke="var(--accent)" stroke-width="2"/>
+<g>
+  <circle cx="432" cy="92" r="7" fill="var(--accent)" stroke="var(--node-ring)" stroke-width="2"/>
+  <text x="429" y="96" class="num" fill="var(--bg)" text-anchor="middle">1</text>
+  <text x="456" y="88" class="step-title" fill="var(--text)">Create an account</text>
+  <text x="456" y="106" class="step-sub" fill="var(--text-dim)">at msgwing.com</text>
+</g>
+<g>
+  <circle cx="432" cy="182" r="7" fill="var(--accent)" stroke="var(--node-ring)" stroke-width="2"/>
+  <text x="429" y="186" class="num" fill="var(--bg)" text-anchor="middle">2</text>
+  <text x="456" y="172" class="step-title" fill="var(--text)">Copy your credentials</text>
+  <text x="456" y="190" class="step-sub" fill="var(--text-dim)">a ready @msgwing.com address</text>
+</g>
+<g>
+  <circle cx="432" cy="272" r="7" fill="var(--accent)" stroke="var(--node-ring)" stroke-width="2"/>
+  <text x="429" y="276" class="num" fill="var(--bg)" text-anchor="middle">3</text>
+  <text x="456" y="262" class="step-title" fill="var(--text)">Send your first email</text>
+  <text x="456" y="280" class="step-sub" fill="var(--text-dim)">port 587 STARTTLS / 465 SSL, right away</text>
+</g>
+
+<rect x="420" y="322" width="300" height="112" rx="12" fill="var(--accent-soft)"/>
+<text x="440" y="350" class="step-title" fill="var(--accent)">Already configured for you</text>
+<text x="440" y="374" class="step-sub" fill="var(--text)">SPF &#183; DKIM &#183; DMARC &#183; TLS</text>
+<text x="440" y="394" class="step-sub" fill="var(--text-dim)">authentication and transport encryption</text>
+<text x="440" y="410" class="step-sub" fill="var(--text-dim)">on msgwing.com, from day one.</text>
+
+<line x1="0" y1="458" x2="760" y2="458" stroke="var(--hair)" stroke-width="1"/>
+<text x="40" y="482" class="foot" fill="var(--text-dim)">Cost: mail goes out from @msgwing.com, not your own domain.</text>
+<text x="40" y="502" class="foot" fill="var(--text-dim)">Source: SMTP2GO docs (verification required for normal sending) and Brevo (recommended).</text>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,7 @@ Microsoft 365 tenants at the end of December 2026.
 | Have it failing or timing out | [Troubleshooting](TROUBLESHOOTING.md) |
 | Have monitoring/alerting tools that need to send mail | [Monitoring alerts](MONITORING.md) |
 | Want to see confirmed fixes for specific hardware | [Device case studies](DEVICE-CASE-STUDIES.md) |
+| Are comparing free SMTP relays | [ZeroSMTP vs. other free relays](ALTERNATIVES.md) |
 | Just want the short answers | [FAQ](FAQ.md) |
 
 ## What is happening


### PR DESCRIPTION
## Summary
- New `docs/ALTERNATIVES.md`: a fact-checked comparison against SMTP2GO/Brevo/MailerSend, centered on the one difference that holds up (DNS/domain verification + reputation management vs. none), not padded with claims that don't actually differentiate (all of them support plain SMTP AUTH too).
- New `docs/assets/setup-comparison.svg`: 5-step vs 3-step setup path diagram, matching the existing hand-drawn SVG style already used elsewhere in `docs/assets/`.
- Cross-linked from `index.md`, `README.md`, and `EXCHANGE-ONLINE-SMTP-AUTH.md`'s option 4.
- Fills content gap #4 from the growth-strategy review (standalone comparison article for "smtp relay alternative" queries).

## Test plan
- [x] Local build confirms `ALTERNATIVES.html` renders, image tag resolves, table renders, internal links convert to `.html` correctly.
- [ ] Confirm live after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)