### PR TITLE
Add an Atom feed of documentation updates

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -154,6 +154,7 @@
     <link rel="icon" type="image/x-icon" href="{{ '/assets/favicon.ico' | relative_url }}">
     <link rel="icon" type="image/png" sizes="32x32" href="{{ '/assets/favicon-32.png' | relative_url }}">
     <link rel="apple-touch-icon" sizes="180x180" href="{{ '/assets/apple-touch-icon.png' | relative_url }}">
+    <link rel="alternate" type="application/atom+xml" title="{{ site.title }}" href="{{ '/feed.xml' | relative_url }}">
 
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
 
@@ -272,7 +273,8 @@
         <p>
           <a href="https://msgwing.com">Get a free account</a> ·
           <a href="https://github.com/msgwing/ZeroSMTP">Source on GitHub</a> ·
-          <a href="https://github.com/msgwing/ZeroSMTP/issues/new/choose">Report an issue</a>
+          <a href="https://github.com/msgwing/ZeroSMTP/issues/new/choose">Report an issue</a> ·
+          <a href="{{ '/feed.xml' | relative_url }}">RSS feed of doc updates</a>
         </p>
       </footer>
 

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -1,0 +1,28 @@
+---
+layout: null
+permalink: /feed.xml
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>{{ site.title }}</title>
+  <subtitle>{{ site.description | strip_newlines }}</subtitle>
+  <link href="{{ site.url }}/feed.xml" rel="self" type="application/atom+xml" />
+  <link href="{{ site.url }}/" rel="alternate" type="text/html" />
+  <updated>{{ site.time | date_to_xmlschema }}</updated>
+  <id>{{ site.url }}/</id>
+  <author>
+    <name>ZeroSMTP</name>
+  </author>
+  {% assign feed_pages = site.pages | where_exp: "p", "p.title" | where_exp: "p", "p.last_modified_at" | where_exp: "p", "p.url != '/404.html'" | sort: "last_modified_at" | reverse %}
+  {% for p in feed_pages %}
+  <entry>
+    <title>{{ p.title | xml_escape }}</title>
+    <link href="{{ site.url }}{{ p.url }}" rel="alternate" type="text/html" />
+    <id>{{ site.url }}{{ p.url }}</id>
+    <updated>{{ p.last_modified_at | date_to_xmlschema }}</updated>
+    {% if p.description %}
+    <summary>{{ p.description | strip_newlines | xml_escape }}</summary>
+    {% endif %}
+  </entry>
+  {% endfor %}
+</feed>


### PR DESCRIPTION
## Summary
Hand-rolled \`docs/feed.xml\` (Atom, not \`jekyll-feed\`, which only feeds Jekyll "posts" - this site has none). Zero new dependencies, only core Jekyll Liquid filters. Pulls every real content page (has \`title\` + \`last_modified_at\`), sorted newest-first, 404.html excluded. Autodiscovery link added to \`<head>\`, plus a footer link for humans.

Supports the growth strategy's planned monthly \`AFFECTED-SYSTEMS.md\` updates - a no-account way for sysadmins/MSPs to track doc changes.

## Test plan
- [x] Local build: 15 entries (matches sitemap.xml's page count exactly), 404.html excluded, XML tags balanced.
- [ ] Confirm live after deploy: \`/feed.xml\` returns valid XML, autodiscovery link present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)