### PR TITLE
Add Lua example

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,5 +14,5 @@
     "ghcr.io/devcontainers/features/dotnet:2": {},
     "ghcr.io/devcontainers/features/rust:1": {}
   },
-  "postCreateCommand": "cp -n .env.example .env || true"
+  "postCreateCommand": "sudo apt-get update && sudo apt-get install -y lua5.4 lua-socket lua-sec && cp -n .env.example .env || true"
 }

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -42,6 +42,9 @@ go:
 ruby:
   - changed-files:
       - any-glob-to-any-file: 'ruby-zerosmtp.rb'
+lua:
+  - changed-files:
+      - any-glob-to-any-file: 'lua-zerosmtp.lua'
 rust:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -108,6 +108,16 @@ jobs:
       - name: Syntax-check Ruby script
         run: ruby -c ruby-zerosmtp.rb
 
+  lua:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: leafo/gh-actions-lua@v11
+      - name: Syntax-check Lua script
+        run: luac -p lua-zerosmtp.lua
+
   php:
     needs: changes
     if: needs.changes.outputs.code == 'true'

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ built for bulk or marketing sending, at any price
 [![mx.msgwing.com status](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/status.json)](https://github.com/msgwing/ZeroSMTP/actions/workflows/service-healthcheck.yml)
 [![Exchange Online Basic auth countdown](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/countdown.json)](docs/EXCHANGE-ONLINE-SMTP-AUTH.md)
 [![Lint examples](https://github.com/msgwing/ZeroSMTP/actions/workflows/lint.yml/badge.svg)](https://github.com/msgwing/ZeroSMTP/actions/workflows/lint.yml)
-[![15 languages](https://img.shields.io/badge/examples-15%20languages-blue)](#code-examples)
+[![16 languages](https://img.shields.io/badge/examples-16%20languages-blue)](#code-examples)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 [![Exchange Online Basic auth (SMTP AUTH) countdown](https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/countdown-card.svg)](docs/EXCHANGE-ONLINE-SMTP-AUTH.md)
@@ -157,6 +157,7 @@ Ready-to-run, production-ready examples for `mx.msgwing.com:465` (SSL/TLS) or
 | Ruby | [ruby-zerosmtp.rb](ruby-zerosmtp.rb) |
 | Rust | [rust-zerosmtp.rs](rust-zerosmtp.rs) |
 | Kotlin | [kotlin-zerosmtp.kt](kotlin-zerosmtp.kt) |
+| Lua | [lua-zerosmtp.lua](lua-zerosmtp.lua) |
 | Swift | [swift-zerosmtp.swift](swift-zerosmtp.swift) |
 | PowerShell | [pwsh-zerosmtp.ps1](pwsh-zerosmtp.ps1) |
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -161,6 +161,7 @@ Gotowe do użycia przykłady dla `mx.msgwing.com:465` (SSL/TLS) lub `:587`
 | Ruby | [ruby-zerosmtp.rb](ruby-zerosmtp.rb) |
 | Rust | [rust-zerosmtp.rs](rust-zerosmtp.rs) |
 | Kotlin | [kotlin-zerosmtp.kt](kotlin-zerosmtp.kt) |
+| Lua | [lua-zerosmtp.lua](lua-zerosmtp.lua) |
 | Swift | [swift-zerosmtp.swift](swift-zerosmtp.swift) |
 | PowerShell | [pwsh-zerosmtp.ps1](pwsh-zerosmtp.ps1) |
 

--- a/docs/LINUX.md
+++ b/docs/LINUX.md
@@ -47,6 +47,7 @@ Only install what you need for the example(s) you're using — see the
 | PHP + Composer | `php-cli composer` | `php-cli composer` | `php composer` |
 | Node.js / TypeScript | `nodejs npm` | `nodejs npm` | `nodejs npm` |
 | Ruby | `ruby` | `ruby` | `ruby` |
+| Lua | `lua5.4 lua-socket lua-sec` | `lua lua-socket lua-sec` | `lua54 lua-socket lua-sec` |
 | Go | `golang-go` | `golang` | `go` |
 | Java | `default-jdk` | `java-21-openjdk-devel` | `java-21-openjdk-devel` |
 | Kotlin | install [Gradle](https://gradle.org/install/) manually (no build needed — `gradle build` fetches Kotlin itself) | same | same |

--- a/lua-zerosmtp.lua
+++ b/lua-zerosmtp.lua
@@ -1,0 +1,107 @@
+#!/usr/bin/env lua
+-- lua-zerosmtp.lua
+-- Lua 5.1+ with LuaSocket and LuaSec - ZeroSMTP mx.msgwing.com:465 SSL/TLS
+-- Production-ready | Let's Encrypt | SMTP over TLS
+
+local socket = require("socket")
+local ssl = require("ssl")
+local mime = require("mime")
+
+-- NOTE: variable names are prefixed with ZEROSMTP_ to avoid colliding with
+-- reserved/OS-level variables (e.g. USERNAME is auto-set on Windows).
+local config = {
+  username = os.getenv("ZEROSMTP_USERNAME") or "your-username",
+  password = os.getenv("ZEROSMTP_PASSWORD") or "your-password",
+  from = os.getenv("ZEROSMTP_FROM") or "sender@example.com",
+  to = os.getenv("ZEROSMTP_TO") or "recipient@example.com",
+  subject = os.getenv("ZEROSMTP_SUBJECT") or "Test Email from ZeroSMTP"
+}
+
+local function read_reply(sock)
+  local status, line = sock:receive("*l")
+  if not status then
+    return nil, line
+  end
+  return tonumber(line:sub(1, 3)), line
+end
+
+local function expect(sock, expected, label)
+  local code, line = read_reply(sock)
+  if not code or code ~= expected then
+    error(string.format("%s failed: %s", label, line or "connection closed"))
+  end
+end
+
+local function send_command(sock, command)
+  local ok, err = sock:send(command .. "\r\n")
+  if not ok then
+    error("send failed: " .. tostring(err))
+  end
+end
+
+local function build_message()
+  local boundary = string.format("boundary_zerosmtp_%d", socket.gettime())
+  return table.concat({
+    "From: " .. config.from,
+    "To: " .. config.to,
+    "Subject: " .. config.subject,
+    "MIME-Version: 1.0",
+    'Content-Type: multipart/alternative; boundary="' .. boundary .. '"',
+    "",
+    "--" .. boundary,
+    'Content-Type: text/plain; charset="UTF-8"',
+    "",
+    "Hello from ZeroSMTP! This is plain text.",
+    "",
+    "--" .. boundary,
+    'Content-Type: text/html; charset="UTF-8"',
+    "",
+    "<html><body><h1>Hello from ZeroSMTP!</h1><p>This is an HTML email sent via mx.msgwing.com:465</p></body></html>",
+    "",
+    "--" .. boundary .. "--",
+    ""
+  }, "\r\n")
+end
+
+local function send_email()
+  local client = assert(socket.tcp())
+  client:settimeout(10)
+  assert(client:connect("mx.msgwing.com", 465))
+
+  local tls = assert(ssl.wrap(client, {
+    mode = "client",
+    protocol = "tlsv1_2",
+    verify = "peer"
+  }))
+  assert(tls:dohandshake())
+
+  expect(tls, 220, "Server greeting")
+  send_command(tls, "EHLO zerosmtp-lua")
+  expect(tls, 250, "EHLO")
+  send_command(tls, "AUTH LOGIN")
+  expect(tls, 334, "AUTH LOGIN")
+  send_command(tls, mime.b64(config.username))
+  expect(tls, 334, "Username")
+  send_command(tls, mime.b64(config.password))
+  expect(tls, 235, "Authentication")
+  send_command(tls, "MAIL FROM:<" .. config.from .. ">")
+  expect(tls, 250, "MAIL FROM")
+  send_command(tls, "RCPT TO:<" .. config.to .. ">")
+  expect(tls, 250, "RCPT TO")
+  send_command(tls, "DATA")
+  expect(tls, 354, "DATA")
+  tls:send(build_message() .. ".\r\n")
+  expect(tls, 250, "Message accepted")
+  send_command(tls, "QUIT")
+  tls:close()
+  return true
+end
+
+local ok, err = pcall(send_email)
+if ok then
+  print("Email sent")
+  os.exit(0)
+else
+  print("Email sending failed: " .. tostring(err))
+  os.exit(1)
+end


### PR DESCRIPTION
Adds `lua-zerosmtp.lua` using LuaSocket and LuaSec, reads the standard `ZEROSMTP_*` environment variables, and wires the example into READMEs, docs, lint, labeler, and the Dev Container.

Closes #28