### PR TITLE
docs: add Elixir ZeroSMTP example

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -108,6 +108,19 @@ jobs:
       - name: Syntax-check Ruby script
         run: ruby -c ruby-zerosmtp.rb
 
+  elixir:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: erlef/setup-beam@v1
+        with:
+          elixir-version: '1.17.3'
+          otp-version: '26.2.5'
+      - name: Syntax-check Elixir example
+        run: elixir -e 'Code.string_to_quoted!(File.read!("elixir-zerosmtp.exs"))'
+
   php:
     needs: changes
     if: needs.changes.outputs.code == 'true'

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Ready-to-run, production-ready examples for `mx.msgwing.com:465` (SSL/TLS) or
 | Ruby | [ruby-zerosmtp.rb](ruby-zerosmtp.rb) |
 | Rust | [rust-zerosmtp.rs](rust-zerosmtp.rs) |
 | Kotlin | [kotlin-zerosmtp.kt](kotlin-zerosmtp.kt) |
+| Elixir | [elixir-zerosmtp.exs](elixir-zerosmtp.exs) |
 | Swift | [swift-zerosmtp.swift](swift-zerosmtp.swift) |
 | PowerShell | [pwsh-zerosmtp.ps1](pwsh-zerosmtp.ps1) |
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -161,6 +161,7 @@ Gotowe do użycia przykłady dla `mx.msgwing.com:465` (SSL/TLS) lub `:587`
 | Ruby | [ruby-zerosmtp.rb](ruby-zerosmtp.rb) |
 | Rust | [rust-zerosmtp.rs](rust-zerosmtp.rs) |
 | Kotlin | [kotlin-zerosmtp.kt](kotlin-zerosmtp.kt) |
+| Elixir | [elixir-zerosmtp.exs](elixir-zerosmtp.exs) |
 | Swift | [swift-zerosmtp.swift](swift-zerosmtp.swift) |
 | PowerShell | [pwsh-zerosmtp.ps1](pwsh-zerosmtp.ps1) |
 

--- a/elixir-zerosmtp.exs
+++ b/elixir-zerosmtp.exs
@@ -1,0 +1,71 @@
+defmodule ZeroSMTP do
+  @host 'mx.msgwing.com'
+  @port 465
+
+  defp recv(socket) do
+    case :ssl.recv(socket, 0, 10_000) do
+      {:ok, data} -> data
+      {:error, reason} -> raise "Failed to read SMTP response: #{inspect(reason)}"
+    end
+  end
+
+  defp send_line(socket, line) do
+    :ok = :ssl.send(socket, [line, "\r\n"])
+    recv(socket)
+  end
+
+  defp expect(response, prefix) do
+    if String.starts_with?(response, prefix) do
+      response
+    else
+      raise "Unexpected SMTP response, expected #{prefix}: #{inspect(response)}"
+    end
+  end
+
+  def run do
+    username = System.get_env("ZEROSMTP_USERNAME") || "your-username"
+    password = System.get_env("ZEROSMTP_PASSWORD") || "your-password"
+    from = System.get_env("ZEROSMTP_FROM") || "sender@example.com"
+    to = System.get_env("ZEROSMTP_TO") || "recipient@example.com"
+    subject = System.get_env("ZEROSMTP_SUBJECT") || "Test Email from ZeroSMTP"
+
+    {:ok, socket} =
+      :ssl.connect(@host, @port, [
+        :binary,
+        active: false,
+        verify: :verify_none
+      ])
+
+    try do
+      expect(recv(socket), "220")
+
+      expect(send_line(socket, "EHLO mx.msgwing.com"), "250")
+      expect(send_line(socket, "AUTH LOGIN"), "334")
+      expect(send_line(socket, Base.encode64(username)), "334")
+      expect(send_line(socket, Base.encode64(password)), "235")
+      expect(send_line(socket, "MAIL FROM:<#{from}>"), "250")
+      expect(send_line(socket, "RCPT TO:<#{to}>"), "250")
+      expect(send_line(socket, "DATA"), "354")
+
+      body = [
+        "From: #{from}",
+        "To: #{to}",
+        "Subject: #{subject}",
+        "MIME-Version: 1.0",
+        "Content-Type: text/plain; charset=utf-8",
+        "",
+        "Hello from ZeroSMTP! This is plain text.",
+        "."
+      ]
+      |> Enum.join("\r\n")
+
+      expect(send_line(socket, body), "250")
+      expect(send_line(socket, "QUIT"), "221")
+      IO.puts("Email sent via mx.msgwing.com:465")
+    after
+      :ssl.close(socket)
+    end
+  end
+end
+
+ZeroSMTP.run()


### PR DESCRIPTION
Closes #25.

Adds `elixir-zerosmtp.exs`, a no-Mix script that authenticates and sends through `mx.msgwing.com:465` over SSL using Elixir/OTP built-ins. Adds rows to both README tables and an Elixir syntax-check job to `lint.yml`.