### PR TITLE
chore: ignore Continue IDE config and internal strategy notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,14 @@
 # Local Claude Code tool config — machine-specific, not project source
 .claude/
 
+# Continue IDE extension config — machine-specific, not project source
+.continue/
+
+# Internal working documents. The repository is public, so anything
+# describing the production host, its addresses or its weak points must
+# stay out of it.
+STRATEGIA-*.md
+
 # Jekyll build output and Bundler cache for docs/
 docs/_site/
 docs/.jekyll-cache/


### PR DESCRIPTION
Two additions to `.gitignore`.

`.continue/` is machine-specific editor config that showed up in every
`git status`.

`STRATEGIA-*.md` is the one that matters. This repository is public, and
those working documents describe the production host and where it has no
redundancy. Keeping them out by pattern is safer than remembering not to
`git add .`.

Verified that nothing matching those patterns was ever committed —
`git log --all -S` over the full history returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)