### PR TITLE
docs: state the example count consistently (17 examples, 15 languages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ built for bulk or marketing sending, at any price
 [![mx.msgwing.com status](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/status.json)](https://github.com/msgwing/ZeroSMTP/actions/workflows/service-healthcheck.yml)
 [![Exchange Online Basic auth countdown](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/countdown.json)](docs/EXCHANGE-ONLINE-SMTP-AUTH.md)
 [![Lint examples](https://github.com/msgwing/ZeroSMTP/actions/workflows/lint.yml/badge.svg)](https://github.com/msgwing/ZeroSMTP/actions/workflows/lint.yml)
-[![16 languages](https://img.shields.io/badge/examples-16%20languages-blue)](#code-examples)
+[![17 ready-to-run examples](https://img.shields.io/badge/examples-17%20ready--to--run-blue)](#code-examples)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 [![Exchange Online Basic auth (SMTP AUTH) countdown](https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/countdown-card.svg)](docs/EXCHANGE-ONLINE-SMTP-AUTH.md)
@@ -72,8 +72,9 @@ with anything that already speaks SMTP.
   the whole point for old devices that will never get a firmware update.
 - **Managed reputation.** Accounts are randomly generated on a domain that's
   actively monitored for abuse, so you're not warming up an IP yourself.
-- **15 copy-paste examples**, all reading the same environment variables, plus
-  setup guides for Windows Server, Linux, and printers by brand.
+- **17 copy-paste examples** across 15 languages, all reading the same
+  environment variables, plus setup guides for Windows Server, Linux, and
+  printers by brand.
 - **Verifiably up** — the status badge above is a real check that runs against
   `mx.msgwing.com` every 6 hours, not a static image.
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -15,7 +15,7 @@ marketingowej, niezależnie od ceny
 [![mx.msgwing.com status](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/status.json)](https://github.com/msgwing/ZeroSMTP/actions/workflows/service-healthcheck.yml)
 [![Odliczanie do wyłączenia Basic auth w Exchange Online](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/countdown.json)](docs/EXCHANGE-ONLINE-SMTP-AUTH.md)
 [![Lint examples](https://github.com/msgwing/ZeroSMTP/actions/workflows/lint.yml/badge.svg)](https://github.com/msgwing/ZeroSMTP/actions/workflows/lint.yml)
-[![15 języków](https://img.shields.io/badge/przyk%C5%82ady-15%20j%C4%99zyk%C3%B3w-blue)](#przykłady-kodu)
+[![17 gotowych przykładów](https://img.shields.io/badge/przyk%C5%82ady-17%20gotowych-blue)](#przykłady-kodu)
 [![Licencja: MIT](https://img.shields.io/badge/licencja-MIT-green.svg)](LICENSE)
 
 [![Odliczanie do wyłączenia Basic auth w Exchange Online (SMTP AUTH)](https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/countdown-card.svg)](docs/EXCHANGE-ONLINE-SMTP-AUTH.md)
@@ -80,7 +80,7 @@ działają z czymkolwiek, co już obsługuje SMTP.
   właśnie sedno problemu dla starych urządzeń bez aktualizacji firmware'u.
 - **Zarządzana reputacja.** Konta są generowane losowo w domenie aktywnie
   monitorowanej pod kątem nadużyć, więc nie rozgrzewasz własnego IP.
-- **15 gotowych przykładów** korzystających z tych samych zmiennych
+- **17 gotowych przykładów** w 15 językach, korzystających z tych samych zmiennych
   środowiskowych, plus przewodniki dla Windows Server, Linuksa i drukarek.
 - **Sprawdzalnie działa** — odznaka statusu powyżej to realny test wykonywany
   na `mx.msgwing.com` co 6 godzin, a nie statyczny obrazek.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -145,7 +145,7 @@ defaults:
   - scope:
       path: "CODE-EXAMPLES.md"
     values:
-      title: "SMTP send-email code examples, 17 examples in 15 languages"
+      title: "SMTP send-email code examples, 15 languages"
       description: >-
         Ready-to-run SMTP send-email examples for mx.msgwing.com in Python,
         PHP, Node.js, TypeScript, Java, C#, Go, Ruby, Rust, Kotlin, Swift,

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -145,7 +145,7 @@ defaults:
   - scope:
       path: "CODE-EXAMPLES.md"
     values:
-      title: "SMTP send-email code examples, 15 languages"
+      title: "SMTP send-email code examples, 17 examples in 15 languages"
       description: >-
         Ready-to-run SMTP send-email examples for mx.msgwing.com in Python,
         PHP, Node.js, TypeScript, Java, C#, Go, Ruby, Rust, Kotlin, Swift,

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ Microsoft 365 tenants at the end of December 2026.
 | Have a printer or MFP to reconfigure | [Printer scan-to-email setup by brand](PRINTERS.md) |
 | Manage Windows Server / IIS / Exchange | [Windows Server guide](WINDOWS-SERVER.md) |
 | Manage Linux servers | [Linux](LINUX.md) · [system-wide relay](SYSTEM-MTA.md) |
-| Are sending from an app or script | [Code examples in 15 languages](CODE-EXAMPLES.md) |
+| Are sending from an app or script | [17 code examples across 15 languages](CODE-EXAMPLES.md) |
 | Have it failing or timing out | [Troubleshooting](TROUBLESHOOTING.md) |
 | Have monitoring/alerting tools that need to send mail | [Monitoring alerts](MONITORING.md) |
 | Want to see confirmed fixes for specific hardware | [Device case studies](DEVICE-CASE-STUDIES.md) |


### PR DESCRIPTION
The count had drifted apart across five places: the English badge said 16,
the Polish badge and both "why" bullets said 15, and the docs site said 15.
The table actually holds 17 examples spanning 15 distinct languages — PHP
and Bash each have two.

Standardised on "17 examples across 15 languages", which is countable from
the table and stays true when either number changes for a different reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)