### PR TITLE
docs: put the device model in the case-studies page title

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -163,7 +163,7 @@ defaults:
       # The model number belongs in the title: someone whose scan-to-email
       # just broke searches the model, not the words "case study". As more
       # devices are reported, name them here too.
-      title: "Canon Maxify MB2755 SMTP fix — printer and MFP case studies"
+      title: "Canon Maxify MB2755 and other device fixes"
       description: >-
         Confirmed, hardware-tested SMTP fixes for specific printer and MFP
         models, including the Canon Maxify MB2755 certificate-verification

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -160,10 +160,14 @@ defaults:
   - scope:
       path: "DEVICE-CASE-STUDIES.md"
     values:
-      title: "Device case studies: real printer fixes"
+      # The model number belongs in the title: someone whose scan-to-email
+      # just broke searches the model, not the words "case study". As more
+      # devices are reported, name them here too.
+      title: "Canon Maxify MB2755 SMTP fix — printer and MFP case studies"
       description: >-
-        Confirmed, hardware-tested fixes for specific printer and MFP models:
-        certificate quirks and firmware issues manuals don't mention.
+        Confirmed, hardware-tested SMTP fixes for specific printer and MFP
+        models, including the Canon Maxify MB2755 certificate-verification
+        issue: quirks and firmware limits the manuals don't mention.
   - scope:
       path: "MONITORING.md"
     values:


### PR DESCRIPTION
Someone whose scan-to-email just stopped working searches the printer
model, not the phrase "case studies". The page title and description
carried neither "Canon" nor "MB2755", so the one page on the site that
answers that exact question had nothing in its strongest on-page signal
to match it.

Worth doing because these long-tail model queries are uncontested —
unlike the generic error-message queries, where microsoft.com and
established blogs hold the entire first page and a four-month-old domain
will not displace them before December.

As more device reports come in, their models belong in this title too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)