### PR TITLE
feat: add Perl and C examples

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -131,6 +131,36 @@ jobs:
       - name: Syntax-check Lua script
         run: luac -p lua-zerosmtp.lua
 
+  perl:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      # perl -c loads every `use`d module, so the two non-core ones have to
+      # be present or the syntax check fails for the wrong reason.
+      - name: Install Perl SMTP/TLS modules
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libio-socket-ssl-perl libauthen-sasl-perl
+      - name: Syntax-check Perl script
+        run: perl -c perl-zerosmtp.pl
+
+  c:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install libcurl development headers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev
+      # -Werror on purpose: an example that compiles with warnings is an
+      # example somebody copies into firmware with warnings.
+      - name: Build C example
+        run: cc -std=c99 -Wall -Wextra -Werror -o /tmp/c-zerosmtp c-zerosmtp.c -lcurl
+
   php:
     needs: changes
     if: needs.changes.outputs.code == 'true'

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ built for bulk or marketing sending, at any price
 [![mx.msgwing.com status](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/status.json)](https://github.com/msgwing/ZeroSMTP/actions/workflows/service-healthcheck.yml)
 [![Exchange Online Basic auth countdown](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/countdown.json)](docs/EXCHANGE-ONLINE-SMTP-AUTH.md)
 [![Lint examples](https://github.com/msgwing/ZeroSMTP/actions/workflows/lint.yml/badge.svg)](https://github.com/msgwing/ZeroSMTP/actions/workflows/lint.yml)
-[![17 ready-to-run examples](https://img.shields.io/badge/examples-17%20ready--to--run-blue)](#code-examples)
+[![19 ready-to-run examples](https://img.shields.io/badge/examples-19%20ready--to--run-blue)](#code-examples)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 [![Exchange Online Basic auth (SMTP AUTH) countdown](https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/countdown-card.svg)](docs/EXCHANGE-ONLINE-SMTP-AUTH.md)
@@ -72,7 +72,7 @@ with anything that already speaks SMTP.
   the whole point for old devices that will never get a firmware update.
 - **Managed reputation.** Accounts are randomly generated on a domain that's
   actively monitored for abuse, so you're not warming up an IP yourself.
-- **17 copy-paste examples** across 15 languages, all reading the same
+- **19 copy-paste examples** across 17 languages, all reading the same
   environment variables, plus setup guides for Windows Server, Linux, and
   printers by brand.
 - **Verifiably up** — the status badge above is a real check that runs against
@@ -160,6 +160,8 @@ Ready-to-run, production-ready examples for `mx.msgwing.com:465` (SSL/TLS) or
 | Kotlin | [kotlin-zerosmtp.kt](kotlin-zerosmtp.kt) |
 | Elixir | [elixir-zerosmtp.exs](elixir-zerosmtp.exs) |
 | Lua | [lua-zerosmtp.lua](lua-zerosmtp.lua) |
+| Perl | [perl-zerosmtp.pl](perl-zerosmtp.pl) |
+| C (libcurl) | [c-zerosmtp.c](c-zerosmtp.c) |
 | Swift | [swift-zerosmtp.swift](swift-zerosmtp.swift) |
 | PowerShell | [pwsh-zerosmtp.ps1](pwsh-zerosmtp.ps1) |
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -15,7 +15,7 @@ marketingowej, niezależnie od ceny
 [![mx.msgwing.com status](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/status.json)](https://github.com/msgwing/ZeroSMTP/actions/workflows/service-healthcheck.yml)
 [![Odliczanie do wyłączenia Basic auth w Exchange Online](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/countdown.json)](docs/EXCHANGE-ONLINE-SMTP-AUTH.md)
 [![Lint examples](https://github.com/msgwing/ZeroSMTP/actions/workflows/lint.yml/badge.svg)](https://github.com/msgwing/ZeroSMTP/actions/workflows/lint.yml)
-[![17 gotowych przykładów](https://img.shields.io/badge/przyk%C5%82ady-17%20gotowych-blue)](#przykłady-kodu)
+[![19 gotowych przykładów](https://img.shields.io/badge/przyk%C5%82ady-19%20gotowych-blue)](#przykłady-kodu)
 [![Licencja: MIT](https://img.shields.io/badge/licencja-MIT-green.svg)](LICENSE)
 
 [![Odliczanie do wyłączenia Basic auth w Exchange Online (SMTP AUTH)](https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/countdown-card.svg)](docs/EXCHANGE-ONLINE-SMTP-AUTH.md)
@@ -80,7 +80,7 @@ działają z czymkolwiek, co już obsługuje SMTP.
   właśnie sedno problemu dla starych urządzeń bez aktualizacji firmware'u.
 - **Zarządzana reputacja.** Konta są generowane losowo w domenie aktywnie
   monitorowanej pod kątem nadużyć, więc nie rozgrzewasz własnego IP.
-- **17 gotowych przykładów** w 15 językach, korzystających z tych samych zmiennych
+- **19 gotowych przykładów** w 17 językach, korzystających z tych samych zmiennych
   środowiskowych, plus przewodniki dla Windows Server, Linuksa i drukarek.
 - **Sprawdzalnie działa** — odznaka statusu powyżej to realny test wykonywany
   na `mx.msgwing.com` co 6 godzin, a nie statyczny obrazek.
@@ -163,6 +163,8 @@ Gotowe do użycia przykłady dla `mx.msgwing.com:465` (SSL/TLS) lub `:587`
 | Kotlin | [kotlin-zerosmtp.kt](kotlin-zerosmtp.kt) |
 | Elixir | [elixir-zerosmtp.exs](elixir-zerosmtp.exs) |
 | Lua | [lua-zerosmtp.lua](lua-zerosmtp.lua) |
+| Perl | [perl-zerosmtp.pl](perl-zerosmtp.pl) |
+| C (libcurl) | [c-zerosmtp.c](c-zerosmtp.c) |
 | Swift | [swift-zerosmtp.swift](swift-zerosmtp.swift) |
 | PowerShell | [pwsh-zerosmtp.ps1](pwsh-zerosmtp.ps1) |
 

--- a/c-zerosmtp.c
+++ b/c-zerosmtp.c
@@ -1,0 +1,185 @@
+/*
+ * c-zerosmtp.c
+ * C99 + libcurl - ZeroSMTP mx.msgwing.com:465 SSL/TLS
+ * Production-ready | Let's Encrypt | Certificate verification on
+ *
+ * libcurl is used rather than a hand-rolled TLS client: it is present on
+ * essentially every Linux system and every embedded toolchain that has
+ * networking at all, and getting certificate validation right by hand is
+ * how devices end up with verification switched off "temporarily".
+ *
+ *   Debian/Ubuntu   apt install libcurl4-openssl-dev
+ *   RHEL/Fedora     dnf install libcurl-devel
+ *   Alpine          apk add curl-dev
+ *
+ * Build:  cc -std=c99 -Wall -Wextra -o c-zerosmtp c-zerosmtp.c -lcurl
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include <curl/curl.h>
+
+#define SMTP_URL "smtps://mx.msgwing.com:465"
+
+/* One buffer holds the whole message. Transactional mail of the kind this
+ * relay is for is small; a device sending megabyte attachments wants a
+ * streaming read callback over a file instead. */
+#define MESSAGE_MAX 4096
+
+struct upload_status {
+    const char *payload;
+    size_t offset;
+};
+
+/* libcurl asks for the message in chunks, so we hand back whatever fits and
+ * remember how far we got. Returning 0 signals end of data. */
+static size_t payload_source(char *buffer, size_t size, size_t nitems,
+                             void *userdata)
+{
+    struct upload_status *upload = (struct upload_status *)userdata;
+    size_t room = size * nitems;
+    size_t remaining = strlen(upload->payload) - upload->offset;
+    size_t chunk;
+
+    if (room < 1 || remaining < 1) {
+        return 0;
+    }
+
+    chunk = (remaining < room) ? remaining : room;
+    memcpy(buffer, upload->payload + upload->offset, chunk);
+    upload->offset += chunk;
+
+    return chunk;
+}
+
+static const char *env_or(const char *name, const char *fallback)
+{
+    const char *value = getenv(name);
+    return (value && *value) ? value : fallback;
+}
+
+/* SMTP requires CRLF line endings, not the bare LF a C string literal gets
+ * from a newline - a message with LF-only headers is rejected or silently
+ * mangled by some servers. */
+static int build_message(char *out, size_t out_size,
+                         const char *from, const char *to, const char *subject)
+{
+    char boundary[64];
+    int written;
+
+    snprintf(boundary, sizeof(boundary),
+             "boundary_zerosmtp_%ld", (long)time(NULL));
+
+    written = snprintf(out, out_size,
+        "From: %s\r\n"
+        "To: %s\r\n"
+        "Subject: %s\r\n"
+        "MIME-Version: 1.0\r\n"
+        "Content-Type: multipart/alternative; boundary=\"%s\"\r\n"
+        "\r\n"
+        "--%s\r\n"
+        "Content-Type: text/plain; charset=\"UTF-8\"\r\n"
+        "\r\n"
+        "Hello from ZeroSMTP! This is plain text.\r\n"
+        "\r\n"
+        "--%s\r\n"
+        "Content-Type: text/html; charset=\"UTF-8\"\r\n"
+        "\r\n"
+        "<html><body><h1>Hello from ZeroSMTP!</h1>"
+        "<p>This is an HTML email sent via mx.msgwing.com:465</p>"
+        "</body></html>\r\n"
+        "\r\n"
+        "--%s--\r\n",
+        from, to, subject, boundary, boundary, boundary, boundary);
+
+    /* snprintf returns what it *would* have written, so a value at or past
+     * the buffer size means the message was truncated - sending that would
+     * produce a mail with a dangling MIME boundary. */
+    if (written < 0 || (size_t)written >= out_size) {
+        fprintf(stderr, "Message does not fit in %d bytes\n", (int)out_size);
+        return 0;
+    }
+
+    return 1;
+}
+
+int main(void)
+{
+    const char *username = env_or("ZEROSMTP_USERNAME", "your-username");
+    const char *password = env_or("ZEROSMTP_PASSWORD", "your-password");
+    const char *from     = env_or("ZEROSMTP_FROM", "sender@example.com");
+    const char *to       = env_or("ZEROSMTP_TO", "recipient@example.com");
+    const char *subject  = env_or("ZEROSMTP_SUBJECT", "Test Email from ZeroSMTP");
+
+    char message[MESSAGE_MAX];
+    char envelope_from[320];
+    char envelope_to[320];
+    struct upload_status upload = { message, 0 };
+    struct curl_slist *recipients = NULL;
+    CURL *curl;
+    CURLcode result;
+    int status = 1;
+
+    if (!build_message(message, sizeof(message), from, to, subject)) {
+        return 1;
+    }
+
+    /* The envelope addresses go in angle brackets, unlike the header ones. */
+    snprintf(envelope_from, sizeof(envelope_from), "<%s>", from);
+    snprintf(envelope_to, sizeof(envelope_to), "<%s>", to);
+
+    curl_global_init(CURL_GLOBAL_DEFAULT);
+
+    curl = curl_easy_init();
+    if (!curl) {
+        fprintf(stderr, "Could not initialise libcurl\n");
+        curl_global_cleanup();
+        return 1;
+    }
+
+    recipients = curl_slist_append(recipients, envelope_to);
+    if (!recipients) {
+        fprintf(stderr, "Out of memory building the recipient list\n");
+        curl_easy_cleanup(curl);
+        curl_global_cleanup();
+        return 1;
+    }
+
+    curl_easy_setopt(curl, CURLOPT_URL, SMTP_URL);
+    curl_easy_setopt(curl, CURLOPT_USERNAME, username);
+    curl_easy_setopt(curl, CURLOPT_PASSWORD, password);
+    curl_easy_setopt(curl, CURLOPT_MAIL_FROM, envelope_from);
+    curl_easy_setopt(curl, CURLOPT_MAIL_RCPT, recipients);
+    curl_easy_setopt(curl, CURLOPT_READFUNCTION, payload_source);
+    curl_easy_setopt(curl, CURLOPT_READDATA, &upload);
+    curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
+
+    /* On by default, set explicitly so that nobody "fixes" a certificate
+     * error later by flipping these to 0. If verification fails, the cause
+     * is a missing CA bundle on the device, not the server. */
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
+
+    result = curl_easy_perform(curl);
+
+    if (result == CURLE_OK) {
+        printf("Email sent to %s\n", to);
+        status = 0;
+    } else {
+        fprintf(stderr, "SMTP error: %s\n", curl_easy_strerror(result));
+        if (result == CURLE_PEER_FAILED_VERIFICATION) {
+            fprintf(stderr, "The device's CA store could not validate the "
+                            "server certificate.\n");
+        }
+    }
+
+    curl_slist_free_all(recipients);
+    curl_easy_cleanup(curl);
+    curl_global_cleanup();
+
+    return status;
+}

--- a/docs/LINUX.md
+++ b/docs/LINUX.md
@@ -48,6 +48,8 @@ Only install what you need for the example(s) you're using — see the
 | Node.js / TypeScript | `nodejs npm` | `nodejs npm` | `nodejs npm` |
 | Ruby | `ruby` | `ruby` | `ruby` |
 | Lua | `lua5.4 lua-socket lua-sec` | `lua lua-socket lua-sec` | `lua54 lua-socket lua-sec` |
+| Perl | `libio-socket-ssl-perl libauthen-sasl-perl` | `perl-IO-Socket-SSL perl-Authen-SASL` | `perl-IO-Socket-SSL perl-Authen-SASL` |
+| C (libcurl) | `gcc libcurl4-openssl-dev` | `gcc libcurl-devel` | `gcc libcurl-devel` |
 | Go | `golang-go` | `golang` | `go` |
 | Java | `default-jdk` | `java-21-openjdk-devel` | `java-21-openjdk-devel` |
 | Kotlin | install [Gradle](https://gradle.org/install/) manually (no build needed — `gradle build` fetches Kotlin itself) | same | same |

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -145,11 +145,11 @@ defaults:
   - scope:
       path: "CODE-EXAMPLES.md"
     values:
-      title: "SMTP send-email code examples, 15 languages"
+      title: "SMTP send-email code examples, 17 languages"
       description: >-
         Ready-to-run SMTP send-email examples for mx.msgwing.com in Python,
-        PHP, Node.js, TypeScript, Java, C#, Go, Ruby, Rust, Kotlin, Swift,
-        PowerShell and Bash.
+        PHP, Node.js, TypeScript, Java, C#, C, Go, Ruby, Perl, Rust, Kotlin,
+        Elixir, Lua, Swift, PowerShell and Bash.
   - scope:
       path: "RELIABILITY.md"
     values:

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ Microsoft 365 tenants at the end of December 2026.
 | Have a printer or MFP to reconfigure | [Printer scan-to-email setup by brand](PRINTERS.md) |
 | Manage Windows Server / IIS / Exchange | [Windows Server guide](WINDOWS-SERVER.md) |
 | Manage Linux servers | [Linux](LINUX.md) · [system-wide relay](SYSTEM-MTA.md) |
-| Are sending from an app or script | [17 code examples across 15 languages](CODE-EXAMPLES.md) |
+| Are sending from an app or script | [19 code examples across 17 languages](CODE-EXAMPLES.md) |
 | Have it failing or timing out | [Troubleshooting](TROUBLESHOOTING.md) |
 | Have monitoring/alerting tools that need to send mail | [Monitoring alerts](MONITORING.md) |
 | Want to see confirmed fixes for specific hardware | [Device case studies](DEVICE-CASE-STUDIES.md) |

--- a/perl-zerosmtp.pl
+++ b/perl-zerosmtp.pl
@@ -1,0 +1,102 @@
+#!/usr/bin/env perl
+
+# perl-zerosmtp.pl
+# Perl 5 Net::SMTP + IO::Socket::SSL - ZeroSMTP mx.msgwing.com:465 SSL/TLS
+# Production-ready | Let's Encrypt | Certificate verification on
+#
+# Net::SMTP and IO::Socket::SSL ship with most distributions' Perl. The auth
+# step additionally needs Authen::SASL, which does not come with core Perl:
+#
+#   Debian/Ubuntu   apt install libnet-smtp-ssl-perl libauthen-sasl-perl
+#   RHEL/Fedora     dnf install perl-Authen-SASL perl-IO-Socket-SSL
+#   any platform    cpanm Authen::SASL IO::Socket::SSL
+
+use strict;
+use warnings;
+
+use Net::SMTP;
+use IO::Socket::SSL qw(SSL_VERIFY_PEER);
+
+my %config = (
+    username => $ENV{ZEROSMTP_USERNAME} // 'your-username',
+    password => $ENV{ZEROSMTP_PASSWORD} // 'your-password',
+    from     => $ENV{ZEROSMTP_FROM}     // 'sender@example.com',
+    to       => $ENV{ZEROSMTP_TO}       // 'recipient@example.com',
+    subject  => $ENV{ZEROSMTP_SUBJECT}  // 'Test Email from ZeroSMTP',
+);
+
+# A multipart/alternative body, so clients that cannot render HTML still show
+# something readable. SMTP wants CRLF line endings; Net::SMTP's datasend
+# handles the conversion, so plain "\n" here is correct.
+sub build_message {
+    my ($boundary) = @_;
+
+    return <<"MAIL";
+From: $config{from}
+To: $config{to}
+Subject: $config{subject}
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="$boundary"
+
+--$boundary
+Content-Type: text/plain; charset="UTF-8"
+
+Hello from ZeroSMTP! This is plain text.
+
+--$boundary
+Content-Type: text/html; charset="UTF-8"
+
+<html><body><h1>Hello from ZeroSMTP!</h1><p>This is an HTML email sent via mx.msgwing.com:465</p></body></html>
+
+--$boundary--
+MAIL
+}
+
+sub send_email {
+    # SSL => 1 means implicit TLS on port 465, negotiated before the SMTP
+    # greeting. Use Port => 587 with SSL => 0, Starttls => 1 if you prefer
+    # STARTTLS - both are accepted.
+    my $smtp = Net::SMTP->new(
+        'mx.msgwing.com',
+        Port            => 465,
+        SSL             => 1,
+        SSL_verify_mode => SSL_VERIFY_PEER,
+        Timeout         => 30,
+    );
+
+    unless ($smtp) {
+        # $IO::Socket::SSL::SSL_ERROR carries the reason when the failure was
+        # in the TLS handshake rather than the TCP connection - without it a
+        # certificate problem is indistinguishable from an unreachable host.
+        warn "Connection failed: $@\n";
+        warn "TLS error: $IO::Socket::SSL::SSL_ERROR\n"
+            if $IO::Socket::SSL::SSL_ERROR;
+        return 0;
+    }
+
+    unless ($smtp->auth($config{username}, $config{password})) {
+        warn "Authentication failed: ", $smtp->message, "\n";
+        $smtp->quit;
+        return 0;
+    }
+
+    my $boundary = 'boundary_zerosmtp_' . time;
+    my $ok =
+           $smtp->mail($config{from})
+        && $smtp->to($config{to})
+        && $smtp->data
+        && $smtp->datasend(build_message($boundary))
+        && $smtp->dataend;
+
+    unless ($ok) {
+        warn "SMTP error: ", $smtp->message, "\n";
+        $smtp->quit;
+        return 0;
+    }
+
+    $smtp->quit;
+    print "Email sent to $config{to}\n";
+    return 1;
+}
+
+exit(send_email() ? 0 : 1);


### PR DESCRIPTION
Closes #24 (Perl), closes #23 (C).

Both serve audiences the README already claims — Perl for legacy sysadmin
scripting, C for the embedded/IoT devices where it is often the only
realistic option — and both had been sitting open with `help wanted`
since 2 August.

## Perl

`Net::SMTP` + `IO::Socket::SSL`, certificate verification on, matching
the shape of `ruby-zerosmtp.rb`.

Verified against the live server, not just `perl -c`: the TLS handshake
and certificate validation succeed and the server returns a real
authentication failure on the placeholder credentials, so every step
except the password is exercised.

`Authen::SASL` is needed for the auth step and is not core Perl, so the
package names for Debian/RHEL/cpanm are in the file header and in
`docs/LINUX.md`.

## C

libcurl rather than a hand-rolled TLS client. Getting certificate
validation right by hand is how devices end up shipping with
verification switched off, and libcurl exists anywhere that has
networking at all.

`CURLOPT_SSL_VERIFYPEER` and `CURLOPT_SSL_VERIFYHOST` are set explicitly
even though those are the defaults, so that a later "fix" for a
certificate error has to be a deliberate edit rather than a one-line
flip. The lint job builds with `-Werror`, because an example that
compiles with warnings is an example somebody copies into firmware with
warnings.

I have no C toolchain on this machine, so unlike the Perl one this is
verified by CI only.

## Also

Counts and tables were inconsistent and are brought in line: 19 examples
across 17 languages, both README tables, the per-distribution package
table in `docs/LINUX.md`, and the SEO description that lists supported
languages — which had drifted and was still missing Lua and Elixir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)