### PR TITLE
chore: remove a scratch file that reached main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,11 @@
 # Continue IDE extension config — machine-specific, not project source
 .continue/
 
+# Scratch files from ad-hoc API calls. One of these reached main because
+# `git add -A` swept it in during a merge resolution.
+*.tmp.json
+*.tmp
+
 # Internal working documents. The repository is public, so anything
 # describing the production host, its addresses or its weak points must
 # stay out of it.


### PR DESCRIPTION
`u.tmp.json` was an empty scratch file from an ad-hoc API call. It got
committed in #84 because the merge resolution used `git add -A`, which
swept up everything untracked rather than only the files being merged.

Removing it, and ignoring `*.tmp.json` / `*.tmp` so the same slip cannot
land the next one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)