### PR TITLE
docs: canonical error-message page, and the missing Mailbox variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ with anything that already speaks SMTP.
 1. Register and activate a free account at [msgwing.com](https://msgwing.com), then copy your randomly generated `@msgwing.com` login and password.
 2. Copy [`.env.example`](.env.example) to `.env` and fill in your credentials.
 3. Run the curl snippet above (`export $(grep -v '^#' .env | xargs)` first), or pick your language from the [Code Examples](#code-examples) table — every example reads the same `.env` variables.
-4. Having trouble? See [Troubleshooting](docs/TROUBLESHOOTING.md) — most first-run failures are a cloud provider blocking outbound SMTP ports, not a misconfiguration.
+4. Having trouble? See [Error messages](docs/ERROR-MESSAGES.md) · [Troubleshooting](docs/TROUBLESHOOTING.md) — most first-run failures are a cloud provider blocking outbound SMTP ports, not a misconfiguration.
 
 > Prefer not to install anything locally? Every runtime used below (Python, PHP,
 > Node, Ruby, Go, Java, Kotlin/Gradle, .NET, Rust) is preinstalled in the

--- a/README.pl.md
+++ b/README.pl.md
@@ -61,7 +61,7 @@ działają z czymkolwiek, co już obsługuje SMTP.
 1. Zarejestruj i aktywuj darmowe konto na [msgwing.com](https://msgwing.com), a następnie skopiuj wygenerowany losowo login `@msgwing.com` i hasło.
 2. Skopiuj [`.env.example`](.env.example) do `.env` i uzupełnij swoimi danymi.
 3. Uruchom powyższy snippet curl (najpierw `export $(grep -v '^#' .env | xargs)`), albo wybierz swój język z tabeli [Przykłady kodu](#przykłady-kodu) — każdy przykład korzysta z tych samych zmiennych w `.env`.
-4. Coś nie działa? Zobacz [Rozwiązywanie problemów](docs/TROUBLESHOOTING.md) — najczęstszą przyczyną nieudanego pierwszego uruchomienia jest blokowanie wychodzących portów SMTP przez dostawcę chmury, a nie błąd w konfiguracji.
+4. Coś nie działa? Zobacz [Komunikaty błędów](docs/ERROR-MESSAGES.md) · [Rozwiązywanie problemów](docs/TROUBLESHOOTING.md) — najczęstszą przyczyną nieudanego pierwszego uruchomienia jest blokowanie wychodzących portów SMTP przez dostawcę chmury, a nie błąd w konfiguracji.
 
 > Wolisz nie instalować niczego lokalnie? Każde środowisko używane poniżej
 > (Python, PHP, Node, Ruby, Go, Java, Kotlin/Gradle, .NET, Rust) jest już

--- a/docs/ERROR-MESSAGES.md
+++ b/docs/ERROR-MESSAGES.md
@@ -1,0 +1,89 @@
+# SMTP AUTH error messages and what they mean
+
+If you searched or pasted an error and landed here, find it below. These are
+the messages Microsoft 365 and its clients produce when username-and-password
+authentication for SMTP is refused.
+
+**None of them mean your password is wrong.** They mean the authentication
+*method* is switched off, which is a different problem with a different fix.
+
+## Why the same error has four different causes
+
+Basic auth for SMTP AUTH gets refused in four situations, and the client-side
+message is identical in all of them. Knowing which one you are in decides
+whether you can simply turn it back on:
+
+| Cause | Can you re-enable it? |
+| --- | --- |
+| An admin disabled SMTP AUTH for the tenant or the mailbox | Yes, until the December 2026 default flip |
+| **Security Defaults** — on by default for tenants created recently | Yes, but it disables more than SMTP and turning it off weakens the tenant |
+| A **Conditional Access** policy blocking legacy authentication | Yes, by scoping the policy — usually deliberate, so ask why it exists first |
+| The **end-of-December-2026 default change** | No |
+
+Before December 2026 the first three are the likely answer, and the fix may be
+a setting rather than a migration. After it, re-enabling is no longer an
+option — see [the migration guide](EXCHANGE-ONLINE-SMTP-AUTH.md).
+
+## Microsoft 365 / Exchange Online
+
+| Error | What it means |
+| --- | --- |
+| `535 5.7.139 Authentication unsuccessful, basic authentication is disabled` | Microsoft 365 refused username/password auth. Credentials are fine; the method is off. |
+| `535 5.7.139 ... SmtpClientAuthentication is disabled for the Tenant` | Same cause, reported at tenant level — the setting applies to every mailbox that inherits it. |
+| `535 5.7.139 ... SmtpClientAuthentication is disabled for the Mailbox` | Same cause, reported for **this one mailbox**. Either it was disabled explicitly for this mailbox, or it inherits a tenant-wide block. Common on personal Outlook.com accounts and on single mailboxes an admin has locked down. |
+| `535 5.7.3 Authentication unsuccessful` | Generic refusal, same set of causes. |
+| `535 5.7.57 SMTP; Client was not authenticated to send anonymous mail` | The client sent no credentials at all, or sent them after `MAIL FROM`. Usually a client configured for anonymous relay pointed at an authenticated endpoint. |
+| `550 5.7.60 SMTP; Client does not have permissions to send as this sender` | Authentication succeeded, but the `From` address does not belong to the authenticated mailbox. A different problem from the ones above. |
+
+Which mailboxes are still exposed on your own tenant is answerable in one
+command — see
+[`Find-SmtpAuthExposure.ps1`](https://github.com/msgwing/ZeroSMTP/blob/main/Find-SmtpAuthExposure.ps1).
+It is read-only, and it counts the mailboxes that inherit the tenant setting
+rather than having their own, which the usual one-liner misses.
+
+## Device and application wording
+
+Vendors rarely pass the server's message through. These are the same refusal
+in local dress:
+
+| What you see | Where | What it means |
+| --- | --- | --- |
+| **Send error 1102** / `0x1102` | Kyocera MFPs | Kyocera's code for an SMTP authentication failure |
+| `Authentication failed` / `Login failed` on the panel | Most printer and scanner panels | Vendor wording for the above |
+| `SMTPAuthenticationError (535, ...)` | Python `smtplib` | The 535 above, wrapped |
+| `javax.mail.AuthenticationFailedException` | Java / JavaMail | Same |
+| `AuthenticationInvalidCredentials` / `5.7.139` | .NET, MailKit | Same |
+| Backup or monitoring job reports "email failed", no code | Veeam, Zabbix, Nagios, PRTG and similar | Check the tool's own SMTP log; the 535 is usually there |
+
+Alerting tools are the dangerous case: they fail **silently**, so you find out
+during the incident they were supposed to warn you about. [What
+breaks](AFFECTED-SYSTEMS.md) has the audit list.
+
+## Not authentication at all
+
+Two failures get mistaken for this and have unrelated fixes:
+
+| Symptom | Actual cause |
+| --- | --- |
+| Connection times out, no auth error ever appears | The network is blocking outbound SMTP. Cloud providers block port 25 and often 587 by default — see [troubleshooting](TROUBLESHOOTING.md). |
+| `Certificate verify failed` / `unable to get local issuer certificate` | The device's trust store cannot validate the server certificate. Common on hardware whose firmware predates current root CAs — see [the Canon Maxify MB2755 case](DEVICE-CASE-STUDIES.md). |
+
+## What to do next
+
+1. Establish which of the four causes applies. If it is one of the first
+   three, re-enabling may be the whole fix.
+2. If firmware or software is the blocker, check whether your vendor shipped
+   an OAuth update — and whether they have stated they will not. Models the
+   vendor has ruled out are listed in [devices that will never get OAuth
+   firmware](NO-OAUTH-FIRMWARE.md).
+3. If nothing on the device can change, the sending has to move: Direct Send
+   for internal-only recipients, or a relay that still accepts a username and
+   password. [The migration guide](EXCHANGE-ONLINE-SMTP-AUTH.md) covers every
+   option, including the ones that are not this project.
+
+## An error not listed here?
+
+[Open an issue](https://github.com/msgwing/ZeroSMTP/issues/new/choose) with
+the exact string and what produced it. Errors reported from real hardware and
+real software are worth more than anything transcribed from documentation, and
+get added here.

--- a/docs/NO-OAUTH-FIRMWARE.md
+++ b/docs/NO-OAUTH-FIRMWARE.md
@@ -85,7 +85,7 @@ minutes of checking saves an afternoon:
    use SMTP AUTH today, including the ones that inherit the tenant setting and
    are easy to miss.
 2. Check the exact error the device reports against
-   [the error list](PRINTERS.md#error-messages-and-what-they-mean). Several
+   [the error list](ERROR-MESSAGES.md). Several
    unrelated faults produce a similar-looking authentication failure.
 3. If your model is not on any list here, see
    [what breaks](AFFECTED-SYSTEMS.md) for the full inventory of affected

--- a/docs/PRINTERS.md
+++ b/docs/PRINTERS.md
@@ -79,21 +79,21 @@ and line-of-business apps, see [AFFECTED-SYSTEMS.md](AFFECTED-SYSTEMS.md).
 
 ## Error messages and what they mean
 
-If you searched an error and landed here, find it below. None of these are
-exclusive to the December 2026 default change — the identical error appears
-whenever Basic auth for SMTP AUTH is rejected, whether that's from an admin
-disabling it earlier, **Security Defaults** (on by default for newer
-tenants), a **Conditional Access** policy blocking legacy authentication, or
-the upcoming default flip. The client-side message is the same either way.
+What the panel shows, and what it actually means:
 
-| Error | What it means |
+| What you see | What it means |
 | --- | --- |
-| `535 5.7.139 Authentication unsuccessful, basic authentication is disabled` | Microsoft 365 rejected username/password auth. Your credentials are fine; the method is switched off — see above for which of the four causes it might be. |
-| `535 5.7.139 ... SmtpClientAuthentication is disabled for the Tenant` | Same cause, reported at tenant level. |
-| `535 5.7.3 Authentication unsuccessful` | Generic auth rejection — same set of possible causes as above. |
 | Kyocera **send error 1102** / `0x1102` | Kyocera's code for an SMTP authentication failure — same root cause when pointing at Microsoft 365. |
-| `Authentication failed` / `Login failed` on the panel | Vendor-specific wording for the above. |
+| `Authentication failed` / `Login failed` on the panel | Vendor wording for a refused username/password. Your credentials are fine; the method is switched off. |
+| `535` with any wording | The server refused Basic auth for SMTP AUTH. |
 | Connection times out, no auth error at all | Not authentication — the network is blocking outbound SMTP. See [TROUBLESHOOTING.md](TROUBLESHOOTING.md). |
+| `Certificate verify failed` on the panel | The device's trust store is too old for the server certificate, not an auth problem — see [the Canon Maxify MB2755 case](DEVICE-CASE-STUDIES.md). |
+
+The exact server-side strings, the four different reasons Basic auth gets
+refused, and the wording used by non-printer clients are all in
+[SMTP AUTH error messages](ERROR-MESSAGES.md). Worth reading if you can
+re-enable the setting, because three of those four causes are reversible until
+the end of December 2026.
 
 ## Your options
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -158,6 +158,16 @@ defaults:
         How to handle temporary SMTP failures correctly with backoff and
         retries instead of tight retry loops.
   - scope:
+      path: "ERROR-MESSAGES.md"
+    values:
+      # People paste the error string verbatim, so this page exists to be
+      # found by that paste - from any client, not only printers.
+      title: "535 5.7.139 and other SMTP AUTH errors"
+      description: >-
+        What 535 5.7.139, SmtpClientAuthentication is disabled for the Tenant
+        or Mailbox, 535 5.7.3 and Kyocera send error 1102 actually mean, the
+        four different causes behind them, and which are still reversible.
+  - scope:
       path: "NO-OAUTH-FIRMWARE.md"
     values:
       # Highest-intent page on the site: whoever lands here has been told by

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,7 @@ Microsoft 365 tenants at the end of December 2026.
 | Manage Linux servers | [Linux](LINUX.md) · [system-wide relay](SYSTEM-MTA.md) |
 | Have a printer whose vendor says no OAuth firmware is coming | [Devices that will never get OAuth firmware](NO-OAUTH-FIRMWARE.md) |
 | Are sending from an app or script | [20 code examples across 18 languages](CODE-EXAMPLES.md) |
+| Have an error message to look up | [535 5.7.139 and other SMTP AUTH errors](ERROR-MESSAGES.md) |
 | Have it failing or timing out | [Troubleshooting](TROUBLESHOOTING.md) |
 | Have monitoring/alerting tools that need to send mail | [Monitoring alerts](MONITORING.md) |
 | Want to see confirmed fixes for specific hardware | [Device case studies](DEVICE-CASE-STUDIES.md) |


### PR DESCRIPTION
The error table lived inside `PRINTERS.md`. People paste this error from NAS
boxes, backup jobs, monitoring tools and phone apps, and a page titled
"Printer scan-to-email SMTP setup by brand" does not serve that paste. It is
the cleanest long-tail query this project has — the reader types the string
verbatim — and it was scoped to one device class.

**It was also missing a variant.** The table had
`SmtpClientAuthentication is disabled for the Tenant` but not
`...for the Mailbox`, which is one of the two most common wordings and is
exactly what the reporter in
[mendhak/gpslogger#1302](https://github.com/mendhak/gpslogger/issues/1302)
received.

## What the new page adds beyond a move

- the `Mailbox` variant, and why it differs from `Tenant` in practice
- `535 5.7.57` and `550 5.7.60`, which look like the same failure and are not
- the four causes laid out with whether each is still reversible, since three
  of them are until the end of December 2026 and that changes the whole answer
- the same refusal as clients report it: Python `smtplib`, JavaMail, MailKit,
  and backup/monitoring tools that log "email failed" with no code
- the two failures routinely mistaken for this one — blocked outbound ports,
  and a trust store too old for the server certificate

## On duplication

`PRINTERS.md` keeps its `## Error messages and what they mean` heading, since
other pages anchor to it, but its table is now the panel-side wording only —
Kyocera 1102, `Authentication failed`, timeouts, certificate failures. The
server-side strings live on the new page and are not repeated, so the two
pages do not compete for the same query.

Verified: every internal link resolves, the anchor other pages depend on
survives, and the new SEO title is 38 characters against the file's
documented ~50 budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)