### PR TITLE
feat: machine-readable OAuth compatibility list

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,6 +46,16 @@ jobs:
             echo "code=false" >> "$GITHUB_OUTPUT"
           fi
 
+  device-table:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+      - name: Device table matches data/devices.json
+        run: python tools/build-device-table.py --check
+
   bash:
     needs: changes
     if: needs.changes.outputs.code == 'true'

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ scan-to-email · IoT and device notifications · homelabs.
 > answer for your own tenant. Read-only, and it counts the mailboxes that
 > inherit the tenant setting — the ones the usual one-liner misses.
 
-Setup guides: [Network printers](docs/PRINTERS.md) · [Popular applications](docs/APPS.md) · [Linux (Debian/Ubuntu/Rocky/Fedora/openSUSE)](docs/LINUX.md) · [System-wide mail relay (Postfix/msmtp/Exim4)](docs/SYSTEM-MTA.md) · [Windows Server](docs/WINDOWS-SERVER.md) · [Exchange Online SMTP AUTH migration](docs/EXCHANGE-ONLINE-SMTP-AUTH.md) · [Monitoring alerts](docs/MONITORING.md) · [No OAuth firmware coming](docs/NO-OAUTH-FIRMWARE.md) · [Device case studies](docs/DEVICE-CASE-STUDIES.md) · [Troubleshooting](docs/TROUBLESHOOTING.md) · [Reliability (retries)](docs/RELIABILITY.md) · [vs. other free relays](docs/ALTERNATIVES.md) · [FAQ](docs/FAQ.md)
+Setup guides: [Network printers](docs/PRINTERS.md) · [Popular applications](docs/APPS.md) · [Linux (Debian/Ubuntu/Rocky/Fedora/openSUSE)](docs/LINUX.md) · [System-wide mail relay (Postfix/msmtp/Exim4)](docs/SYSTEM-MTA.md) · [Windows Server](docs/WINDOWS-SERVER.md) · [Exchange Online SMTP AUTH migration](docs/EXCHANGE-ONLINE-SMTP-AUTH.md) · [Monitoring alerts](docs/MONITORING.md) · [OAuth compatibility list](docs/DEVICE-COMPATIBILITY.md) · [No OAuth firmware coming](docs/NO-OAUTH-FIRMWARE.md) · [Device case studies](docs/DEVICE-CASE-STUDIES.md) · [Troubleshooting](docs/TROUBLESHOOTING.md) · [Reliability (retries)](docs/RELIABILITY.md) · [vs. other free relays](docs/ALTERNATIVES.md) · [FAQ](docs/FAQ.md)
 
 ## How does this compare to other options?
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -100,7 +100,7 @@ monitoringu · skan-do-mail · powiadomień IoT · homelabów.
 > skrzynki dziedziczące ustawienie tenanta — te, które typowy jednolinijkowiec
 > pomija.
 
-Przewodniki konfiguracji: [Drukarki sieciowe](docs/PRINTERS.md) · [Popularne aplikacje](docs/APPS.md) · [Linux (Debian/Ubuntu/Rocky/Fedora/openSUSE)](docs/LINUX.md) · [Systemowy relay pocztowy (Postfix/msmtp/Exim4)](docs/SYSTEM-MTA.md) · [Windows Server](docs/WINDOWS-SERVER.md) · [Migracja z Exchange Online SMTP AUTH](docs/EXCHANGE-ONLINE-SMTP-AUTH.md) · [Alerty monitoringu](docs/MONITORING.md) · [Urządzenia bez firmware z OAuth](docs/NO-OAUTH-FIRMWARE.md) · [Przypadki konkretnych urządzeń](docs/DEVICE-CASE-STUDIES.md) · [Rozwiązywanie problemów](docs/TROUBLESHOOTING.md) · [Niezawodność (ponawianie prób)](docs/RELIABILITY.md) · [FAQ](docs/FAQ.md)
+Przewodniki konfiguracji: [Drukarki sieciowe](docs/PRINTERS.md) · [Popularne aplikacje](docs/APPS.md) · [Linux (Debian/Ubuntu/Rocky/Fedora/openSUSE)](docs/LINUX.md) · [Systemowy relay pocztowy (Postfix/msmtp/Exim4)](docs/SYSTEM-MTA.md) · [Windows Server](docs/WINDOWS-SERVER.md) · [Migracja z Exchange Online SMTP AUTH](docs/EXCHANGE-ONLINE-SMTP-AUTH.md) · [Alerty monitoringu](docs/MONITORING.md) · [Lista zgodności OAuth](docs/DEVICE-COMPATIBILITY.md) · [Urządzenia bez firmware z OAuth](docs/NO-OAUTH-FIRMWARE.md) · [Przypadki konkretnych urządzeń](docs/DEVICE-CASE-STUDIES.md) · [Rozwiązywanie problemów](docs/TROUBLESHOOTING.md) · [Niezawodność (ponawianie prób)](docs/RELIABILITY.md) · [FAQ](docs/FAQ.md)
 
 ## Jak to wypada na tle innych opcji?
 

--- a/data/devices.json
+++ b/data/devices.json
@@ -1,0 +1,145 @@
+{
+  "$comment": [
+    "Machine-readable OAuth 2.0 / SMTP AUTH status for systems affected by the",
+    "Microsoft 365 Basic auth shutdown. Source of truth for the table in",
+    "docs/DEVICE-COMPATIBILITY.md, which is generated from this file by",
+    "tools/build-device-table.py and checked in CI, so the two cannot drift.",
+    "",
+    "Every entry must carry an `evidence` URL. If nobody has published",
+    "anything, the entry does not belong here - a compatibility list is only",
+    "worth citing if each row can be checked.",
+    "",
+    "status values:",
+    "  none-planned    vendor has stated no OAuth firmware is coming",
+    "  available       OAuth support exists for the listed models or versions",
+    "  partial         some models or versions only; the list decides",
+    "  check-advisory  vendor publishes a per-model list we do not reproduce",
+    "  unsupported     the product has no OAuth capability for this purpose"
+  ],
+  "updated": "2026-08-11",
+  "entries": [
+    {
+      "vendor": "Konica Minolta / DEVELOP",
+      "product": "ineo and ineo+ MFPs",
+      "status": "none-planned",
+      "models": [
+        "ineo 306", "ineo 7228", "ineo 266",
+        "ineo+ 266", "ineo+ 256", "ineo+ 226",
+        "ineo 4750", "ineo 4050",
+        "ineo 4700P", "ineo 3301P", "ineo 4000P",
+        "ineo 165 variants", "ineo 185 variants"
+      ],
+      "evidence": "https://www.develop.eu/en/support/discontinuation-of-basic-authentication-for-smtp.html",
+      "notes": "Marked \"N/A\" in the vendor's own OAuth column. The advisory points these owners at a different mail service rather than at an update. Other ineo product groups in the same advisory do have OAuth firmware - check the exact model."
+    },
+    {
+      "vendor": "Xerox",
+      "product": "ConnectKey printers and MFPs",
+      "status": "partial",
+      "models": [
+        "VersaLink B415", "VersaLink C415",
+        "VersaLink B620", "VersaLink C620",
+        "VersaLink B625", "VersaLink C625",
+        "AltaLink", "PrimeLink"
+      ],
+      "evidence": "https://www.xerox.com/en-us/office/insights/exchange-online-authentication",
+      "notes": "Device Code Flow is supported broadly; Client Credentials Flow only on the ConnectKey models listed. Devices not on Xerox's supported-firmware list are the problem cases and are not promised an update. Affects Scan to Email, Internet Fax (Send), Fax Forward to Email and Auto Email Notifications."
+    },
+    {
+      "vendor": "Ricoh",
+      "product": "multifunction printers",
+      "status": "check-advisory",
+      "models": [],
+      "evidence": "https://www.ricoh.com/info/2025/0526_1",
+      "notes": "Ricoh publishes affected products with per-product firmware status. Not reproduced here because the list is long and revised; check the model against the advisory."
+    },
+    {
+      "vendor": "Canon",
+      "product": "Maxify MB2755",
+      "status": "unsupported",
+      "models": ["Maxify MB2755"],
+      "evidence": "https://github.com/msgwing/ZeroSMTP/blob/main/docs/DEVICE-CASE-STUDIES.md",
+      "notes": "Separate failure mode from OAuth: the firmware ships a fixed root CA store predating current Let's Encrypt roots, so certificate validation fails regardless of authentication. Hardware-confirmed, unchanged after a firmware update. Verification has to be disabled on the device."
+    },
+    {
+      "vendor": "Kyocera",
+      "product": "MFPs reporting send error 1102",
+      "status": "check-advisory",
+      "models": [],
+      "evidence": "https://github.com/msgwing/ZeroSMTP/blob/main/docs/ERROR-MESSAGES.md",
+      "notes": "1102 / 0x1102 is Kyocera's device-side code for an SMTP authentication failure, not a model list. No public per-model OAuth statement located; check with the vendor for a specific model."
+    },
+    {
+      "vendor": "QNAP",
+      "product": "NAS notification settings",
+      "status": "unsupported",
+      "models": [],
+      "evidence": "https://gist.github.com/msgwing/39958d909e085ae9cc0e6b3584d930bf",
+      "notes": "The notification settings accept username and password only; there is no OAuth option for Microsoft 365 SMTP."
+    },
+    {
+      "vendor": "Veeam",
+      "product": "Backup for Microsoft 365 and related products",
+      "status": "partial",
+      "models": [],
+      "evidence": "https://helpcenter.veeam.com/docs/vbo365/guide/smtp_server.html",
+      "notes": "Older versions support SMTP basic auth only; newer versions added OAuth. Upgrading is the fix where the version supports it."
+    },
+    {
+      "vendor": "Cisco",
+      "product": "Unity Connection",
+      "status": "check-advisory",
+      "models": [],
+      "evidence": "https://learn.microsoft.com/en-us/exchange/clients-and-mobile-in-exchange-online/deprecation-of-basic-authentication-exchange-online",
+      "notes": "Named in Microsoft's own deprecation documentation. OAuth support depends on the release; check yours before assuming either way."
+    },
+    {
+      "vendor": "Microsoft",
+      "product": "Teams Rooms",
+      "status": "available",
+      "models": [],
+      "evidence": "https://learn.microsoft.com/en-us/exchange/clients-and-mobile-in-exchange-online/deprecation-of-basic-authentication-exchange-online",
+      "notes": "Microsoft's own product. Enable modern auth on the resource account - no relay needed."
+    },
+    {
+      "vendor": "Microsoft",
+      "product": "Dynamics NAV / Business Central",
+      "status": "partial",
+      "models": [],
+      "evidence": "https://www.innovia.com/blog/microsoft-to-retire-basic-auth-smtp-for-exchange-online-what-bc-nav-users-need-to-know",
+      "notes": "Newer Business Central handles modern auth. Older on-prem NAV installs generally need the SMTP account repointed."
+    },
+    {
+      "vendor": "Laserfiche",
+      "product": "Workflow email",
+      "status": "check-advisory",
+      "models": [],
+      "evidence": "https://answers.laserfiche.com/questions/200557/Disabling-basic-authentication-causing-Workflow-emails-to-fail",
+      "notes": "Workflow emails failing on Basic auth removal, reported in the vendor's own community."
+    },
+    {
+      "vendor": "ManageEngine",
+      "product": "OpManager",
+      "status": "check-advisory",
+      "models": [],
+      "evidence": "https://www.manageengine.com/network-monitoring/how-to/fix-smtpclientauth-disabled-error.html",
+      "notes": "Vendor publishes a fix guide for the SMTPClientAuth error."
+    },
+    {
+      "vendor": "Cerberus",
+      "product": "FTP Server",
+      "status": "check-advisory",
+      "models": [],
+      "evidence": "https://support.cerberusftp.com/hc/en-us/articles/24103821642643-Troubleshooting-SMTP-Setup-Error-on-Office365-com-Resolving-EHLO-Message-Failure-535-5-7-139-Authentication-Unsuccessful-Basic-Authentication-Disabled",
+      "notes": "Vendor support article covers the exact 535 5.7.139 failure."
+    },
+    {
+      "vendor": "Faxination",
+      "product": "fax server",
+      "status": "check-advisory",
+      "models": [],
+      "evidence": "https://faxination.com/microsoft-timeline-for-basic-authentication-deprecation-in-exchange-online-smtp-auth/",
+      "notes": "Vendor published a timeline notice. Apply their update if one exists for the version in use; otherwise the outbound SMTP account has to be repointed."
+    }
+  ]
+}

--- a/docs/DEVICE-COMPATIBILITY.md
+++ b/docs/DEVICE-COMPATIBILITY.md
@@ -1,0 +1,137 @@
+# OAuth compatibility by device and product
+
+Vendors publish their Basic auth advisories as prose, PDFs and support pages,
+one vendor at a time. There is no single place to check whether the thing on
+your network has a way out. This is an attempt at one.
+
+The table is generated from
+[`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json),
+so it can be read by a script as well as by a person, and it cannot disagree
+with its own data — CI rejects the two drifting apart.
+
+**Every row carries a link to the vendor's own statement.** A compatibility
+list is only worth citing if each claim can be checked, so an entry with
+nothing published behind it does not get added.
+
+## How to read the status column
+
+| Status | Meaning |
+| --- | --- |
+| **No OAuth firmware planned** | The vendor has said it is not coming. Firmware is not a step you have skipped; it does not exist. |
+| No OAuth for this purpose | The feature has no OAuth option at all, regardless of firmware. |
+| Some models or versions | OAuth exists for part of the range. The model or version number decides. |
+| Check vendor advisory | The vendor publishes a per-model list, revised over time, that is not reproduced here. |
+| OAuth available | Supported — usually a configuration change rather than a migration. |
+
+The two top rows are the ones that matter for planning. Everything else means
+"go and read the advisory for your exact model", which is honest but is not an
+answer.
+
+<!-- BEGIN GENERATED TABLE -->
+
+| System | OAuth status | Named models | Evidence |
+| --- | --- | --- | --- |
+| **Konica Minolta / DEVELOP** ineo and ineo+ MFPs | **No OAuth firmware planned** | `ineo 306`, `ineo 7228`, `ineo 266`, `ineo+ 266`, `ineo+ 256`, `ineo+ 226`, `ineo 4750`, `ineo 4050`, `ineo 4700P`, `ineo 3301P`, `ineo 4000P`, `ineo 165 variants`, `ineo 185 variants` | [advisory](https://www.develop.eu/en/support/discontinuation-of-basic-authentication-for-smtp.html) |
+| **Canon** Maxify MB2755 | No OAuth for this purpose | `Maxify MB2755` | [advisory](https://github.com/msgwing/ZeroSMTP/blob/main/docs/DEVICE-CASE-STUDIES.md) |
+| **QNAP** NAS notification settings | No OAuth for this purpose | — | [advisory](https://gist.github.com/msgwing/39958d909e085ae9cc0e6b3584d930bf) |
+| **Microsoft** Dynamics NAV / Business Central | Some models or versions | — | [advisory](https://www.innovia.com/blog/microsoft-to-retire-basic-auth-smtp-for-exchange-online-what-bc-nav-users-need-to-know) |
+| **Veeam** Backup for Microsoft 365 and related products | Some models or versions | — | [advisory](https://helpcenter.veeam.com/docs/vbo365/guide/smtp_server.html) |
+| **Xerox** ConnectKey printers and MFPs | Some models or versions | `VersaLink B415`, `VersaLink C415`, `VersaLink B620`, `VersaLink C620`, `VersaLink B625`, `VersaLink C625`, `AltaLink`, `PrimeLink` | [advisory](https://www.xerox.com/en-us/office/insights/exchange-online-authentication) |
+| **Cerberus** FTP Server | Check vendor advisory | — | [advisory](https://support.cerberusftp.com/hc/en-us/articles/24103821642643-Troubleshooting-SMTP-Setup-Error-on-Office365-com-Resolving-EHLO-Message-Failure-535-5-7-139-Authentication-Unsuccessful-Basic-Authentication-Disabled) |
+| **Cisco** Unity Connection | Check vendor advisory | — | [advisory](https://learn.microsoft.com/en-us/exchange/clients-and-mobile-in-exchange-online/deprecation-of-basic-authentication-exchange-online) |
+| **Faxination** fax server | Check vendor advisory | — | [advisory](https://faxination.com/microsoft-timeline-for-basic-authentication-deprecation-in-exchange-online-smtp-auth/) |
+| **Kyocera** MFPs reporting send error 1102 | Check vendor advisory | — | [advisory](https://github.com/msgwing/ZeroSMTP/blob/main/docs/ERROR-MESSAGES.md) |
+| **Laserfiche** Workflow email | Check vendor advisory | — | [advisory](https://answers.laserfiche.com/questions/200557/Disabling-basic-authentication-causing-Workflow-emails-to-fail) |
+| **ManageEngine** OpManager | Check vendor advisory | — | [advisory](https://www.manageengine.com/network-monitoring/how-to/fix-smtpclientauth-disabled-error.html) |
+| **Ricoh** multifunction printers | Check vendor advisory | — | [advisory](https://www.ricoh.com/info/2025/0526_1) |
+| **Microsoft** Teams Rooms | OAuth available | — | [advisory](https://learn.microsoft.com/en-us/exchange/clients-and-mobile-in-exchange-online/deprecation-of-basic-authentication-exchange-online) |
+
+### Notes per entry
+
+**Konica Minolta / DEVELOP — ineo and ineo+ MFPs**  
+Marked "N/A" in the vendor's own OAuth column. The advisory points these owners at a different mail service rather than at an update. Other ineo product groups in the same advisory do have OAuth firmware - check the exact model.
+
+**Canon — Maxify MB2755**  
+Separate failure mode from OAuth: the firmware ships a fixed root CA store predating current Let's Encrypt roots, so certificate validation fails regardless of authentication. Hardware-confirmed, unchanged after a firmware update. Verification has to be disabled on the device.
+
+**QNAP — NAS notification settings**  
+The notification settings accept username and password only; there is no OAuth option for Microsoft 365 SMTP.
+
+**Microsoft — Dynamics NAV / Business Central**  
+Newer Business Central handles modern auth. Older on-prem NAV installs generally need the SMTP account repointed.
+
+**Veeam — Backup for Microsoft 365 and related products**  
+Older versions support SMTP basic auth only; newer versions added OAuth. Upgrading is the fix where the version supports it.
+
+**Xerox — ConnectKey printers and MFPs**  
+Device Code Flow is supported broadly; Client Credentials Flow only on the ConnectKey models listed. Devices not on Xerox's supported-firmware list are the problem cases and are not promised an update. Affects Scan to Email, Internet Fax (Send), Fax Forward to Email and Auto Email Notifications.
+
+**Cerberus — FTP Server**  
+Vendor support article covers the exact 535 5.7.139 failure.
+
+**Cisco — Unity Connection**  
+Named in Microsoft's own deprecation documentation. OAuth support depends on the release; check yours before assuming either way.
+
+**Faxination — fax server**  
+Vendor published a timeline notice. Apply their update if one exists for the version in use; otherwise the outbound SMTP account has to be repointed.
+
+**Kyocera — MFPs reporting send error 1102**  
+1102 / 0x1102 is Kyocera's device-side code for an SMTP authentication failure, not a model list. No public per-model OAuth statement located; check with the vendor for a specific model.
+
+**Laserfiche — Workflow email**  
+Workflow emails failing on Basic auth removal, reported in the vendor's own community.
+
+**ManageEngine — OpManager**  
+Vendor publishes a fix guide for the SMTPClientAuth error.
+
+**Ricoh — multifunction printers**  
+Ricoh publishes affected products with per-product firmware status. Not reproduced here because the list is long and revised; check the model against the advisory.
+
+**Microsoft — Teams Rooms**  
+Microsoft's own product. Enable modern auth on the resource account - no relay needed.
+
+*14 entries, last reviewed 2026-08-11.*
+
+<!-- END GENERATED TABLE -->
+
+## What this list is not
+
+It is not exhaustive, and it is not a substitute for the vendor's advisory. It
+records what vendors have published, which is a different thing from what is
+true of every unit in the field: firmware branches, regional model names and
+OEM rebadges all diverge from the headline list.
+
+It also says nothing about whether a device is *worth* keeping. A 2016 MFP with
+no OAuth path and no security updates is a decision about hardware, not about
+mail configuration.
+
+## Once firmware is ruled out
+
+Three options remain, and they differ from each other more than they look:
+
+- **Direct Send** — free, works only for recipients inside your own tenant,
+  needs a connector and a static IP
+- **A relay that still accepts a username and password** — works for any
+  recipient; check whether the sender domain has to be your own
+- **Replace the hardware** — the only option that also survives the next
+  deprecation
+
+[The migration guide](EXCHANGE-ONLINE-SMTP-AUTH.md) covers all three,
+including the ones that are not this project. [Devices that will never get
+OAuth firmware](NO-OAUTH-FIRMWARE.md) goes into the ruled-out cases in prose.
+
+## Adding an entry
+
+The list grows by report. If you have a model whose status is documented
+somewhere and is not here, or a vendor has since shipped firmware for
+something listed as ruled out, edit
+[`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json)
+and run:
+
+```bash
+python tools/build-device-table.py
+```
+
+That regenerates the table above. Entries need a vendor, a product, a status
+from the list, and an evidence URL — without the last one the build refuses
+the entry. Hardware-confirmed reports get credited by username.

--- a/docs/NO-OAUTH-FIRMWARE.md
+++ b/docs/NO-OAUTH-FIRMWARE.md
@@ -96,6 +96,9 @@ minutes of checking saves an afternoon:
 These lists come from vendor advisories, and vendors keep publishing. If your
 model is confirmed dead-end and is not named above — or if a vendor has since
 shipped firmware for one that is —
-[open an issue](https://github.com/msgwing/ZeroSMTP/issues/new/choose). A
+[open an issue](https://github.com/msgwing/ZeroSMTP/issues/new/choose), or
+edit [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json)
+directly — it backs the [machine-readable compatibility
+list](DEVICE-COMPATIBILITY.md). A
 report from someone holding the hardware is worth more than anything read off
 a datasheet, and gets credited by username.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -158,6 +158,14 @@ defaults:
         How to handle temporary SMTP failures correctly with backoff and
         retries instead of tight retry loops.
   - scope:
+      path: "DEVICE-COMPATIBILITY.md"
+    values:
+      title: "OAuth compatibility by device and product"
+      description: >-
+        Which printers, MFPs, NAS units and applications have an OAuth 2.0
+        path for the Microsoft 365 SMTP AUTH shutdown and which the vendor
+        has ruled out, with a link to every vendor statement.
+  - scope:
       path: "ERROR-MESSAGES.md"
     values:
       # People paste the error string verbatim, so this page exists to be

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@ Microsoft 365 tenants at the end of December 2026.
 | Have a printer or MFP to reconfigure | [Printer scan-to-email setup by brand](PRINTERS.md) |
 | Manage Windows Server / IIS / Exchange | [Windows Server guide](WINDOWS-SERVER.md) |
 | Manage Linux servers | [Linux](LINUX.md) · [system-wide relay](SYSTEM-MTA.md) |
+| Want to look up one device or product | [OAuth compatibility list](DEVICE-COMPATIBILITY.md) |
 | Have a printer whose vendor says no OAuth firmware is coming | [Devices that will never get OAuth firmware](NO-OAUTH-FIRMWARE.md) |
 | Are sending from an app or script | [20 code examples across 18 languages](CODE-EXAMPLES.md) |
 | Have an error message to look up | [535 5.7.139 and other SMTP AUTH errors](ERROR-MESSAGES.md) |

--- a/tools/build-device-table.py
+++ b/tools/build-device-table.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Render the compatibility table in docs/DEVICE-COMPATIBILITY.md from
+data/devices.json.
+
+The table is generated rather than hand-maintained because a compatibility
+list that disagrees with its own data is worse than no list: somebody acts on
+the wrong row. `--check` makes CI fail if the two have drifted, so the file
+cannot be edited by hand and left that way.
+
+    python tools/build-device-table.py            # rewrite the table
+    python tools/build-device-table.py --check    # fail if it would change
+"""
+
+import argparse
+import json
+import pathlib
+import sys
+
+KORZEN = pathlib.Path(__file__).resolve().parent.parent
+DANE = KORZEN / "data" / "devices.json"
+STRONA = KORZEN / "docs" / "DEVICE-COMPATIBILITY.md"
+
+POCZATEK = "<!-- BEGIN GENERATED TABLE -->"
+KONIEC = "<!-- END GENERATED TABLE -->"
+
+# Kolejnosc ma znaczenie: czytelnik szuka najpierw tego, czego nie da sie
+# naprawic aktualizacja, bo to jedyny przypadek zamykajacy droge firmware'u.
+PORZADEK = {
+    "none-planned": 0,
+    "unsupported": 1,
+    "partial": 2,
+    "check-advisory": 3,
+    "available": 4,
+}
+
+ETYKIETY = {
+    "none-planned": "**No OAuth firmware planned**",
+    "unsupported": "No OAuth for this purpose",
+    "partial": "Some models or versions",
+    "check-advisory": "Check vendor advisory",
+    "available": "OAuth available",
+}
+
+
+def komorka(tekst):
+    """Markdown tables break on unescaped pipes and literal newlines."""
+    return tekst.replace("|", "\\|").replace("\n", " ").strip()
+
+
+def zbuduj_tabele(wpisy):
+    linie = [
+        "| System | OAuth status | Named models | Evidence |",
+        "| --- | --- | --- | --- |",
+    ]
+
+    for w in sorted(
+        wpisy,
+        key=lambda w: (PORZADEK.get(w["status"], 9), w["vendor"], w["product"]),
+    ):
+        nazwa = f"**{komorka(w['vendor'])}** {komorka(w['product'])}"
+        stan = ETYKIETY.get(w["status"], komorka(w["status"]))
+        modele = ", ".join(f"`{komorka(m)}`" for m in w.get("models") or []) or "—"
+        dowod = f"[advisory]({w['evidence']})"
+        linie.append(f"| {nazwa} | {stan} | {modele} | {dowod} |")
+
+    return "\n".join(linie)
+
+
+def zbuduj_notatki(wpisy):
+    linie = []
+    for w in sorted(
+        wpisy,
+        key=lambda w: (PORZADEK.get(w["status"], 9), w["vendor"], w["product"]),
+    ):
+        linie.append(f"**{w['vendor']} — {w['product']}**  ")
+        linie.append(f"{w['notes']}")
+        linie.append("")
+    return "\n".join(linie).rstrip()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--check", action="store_true",
+                    help="exit 1 if the page is out of date instead of rewriting it")
+    args = ap.parse_args()
+
+    dane = json.loads(DANE.read_text(encoding="utf-8"))
+    wpisy = dane["entries"]
+
+    brak_dowodu = [w for w in wpisy if not w.get("evidence")]
+    if brak_dowodu:
+        print("Entries without an evidence URL, which the list does not allow:")
+        for w in brak_dowodu:
+            print(f"  {w['vendor']} - {w['product']}")
+        return 1
+
+    nieznany = {w["status"] for w in wpisy} - set(PORZADEK)
+    if nieznany:
+        print(f"Unknown status values: {sorted(nieznany)}")
+        return 1
+
+    tresc = STRONA.read_text(encoding="utf-8")
+    if POCZATEK not in tresc or KONIEC not in tresc:
+        print(f"Markers missing from {STRONA.name}")
+        return 1
+
+    przed = tresc.split(POCZATEK)[0]
+    po = tresc.split(KONIEC)[1]
+
+    nowa = (
+        przed
+        + POCZATEK
+        + "\n\n"
+        + zbuduj_tabele(wpisy)
+        + "\n\n### Notes per entry\n\n"
+        + zbuduj_notatki(wpisy)
+        + "\n\n"
+        + f"*{len(wpisy)} entries, last reviewed {dane['updated']}.*\n\n"
+        + KONIEC
+        + po
+    )
+
+    if args.check:
+        if nowa != tresc:
+            print(f"{STRONA.name} is out of date. Run:")
+            print("  python tools/build-device-table.py")
+            return 1
+        print(f"{STRONA.name} matches data/devices.json ({len(wpisy)} entries)")
+        return 0
+
+    if nowa == tresc:
+        print(f"{STRONA.name} already up to date ({len(wpisy)} entries)")
+        return 0
+
+    STRONA.write_bytes(nowa.encode())
+    print(f"{STRONA.name} rewritten ({len(wpisy)} entries)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Vendors publish their Basic auth advisories one at a time, as prose, PDFs and
support pages. There is no single place to check whether the thing on your
network has a way out. This is an attempt at one.

`data/devices.json` holds fourteen entries; `docs/DEVICE-COMPATIBILITY.md`
renders them.

## Why structured rather than another table

A JSON file can be read by a script. The audit script could eventually flag
"the mailbox is exposed *and* the device behind it is on the ruled-out list",
which is a decision rather than a report.

The wider reason is links. This project cannot ask anyone for backlinks
without it reading as spam, and it will not rank for the generic queries
before December. What it can do is be the list somebody cites when answering
a forum question about an ineo 266 — because no such list exists.

## Enforced rather than encouraged

**Every entry needs an evidence URL.** The build refuses one without it: a
compatibility list is only worth citing if each row can be checked, and that
property survives only if it cannot be skipped.

The table is generated, and CI runs `--check`. That job is deliberately *not*
gated on the `changes` job — hand-editing the generated page touches no code
file, so a gate on `code == 'true'` would skip precisely the case worth
catching. Verified all three failure modes locally: drift, missing evidence,
unknown status value.

## On accuracy

Only what the advisories document is encoded. No model numbers from memory.

Where a vendor publishes a long, revised per-model list (Ricoh), the entry
says `check-advisory` rather than reproducing numbers that would go stale and
be wrong in someone's hands. Where no public per-model statement was found
(Kyocera), the entry says that rather than implying one exists.

Konica Minolta's is the entry that matters: those ineo models are marked
"N/A" in the vendor's own OAuth column, and the advisory points their owners
at a different mail service instead of an update.

## Also

`docs/ERROR-MESSAGES.md` and `docs/NO-OAUTH-FIRMWARE.md` from the previous two
PRs are cross-linked, and both READMEs and the docs index point at the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)