### PR TITLE
docs: lead with the toolkit rather than the relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,13 @@
 
 ![ZeroSMTP](docs/assets/banner.png)
 
-**A free SMTP relay that still accepts plain username-and-password auth.**<br>
-Built for the printers, scanners, and legacy apps left behind when
-Microsoft 365 turns off SMTP AUTH Basic auth.<br>
-No OAuth to implement. No credit card. No mail server to run.<br>
-Scoped to **transactional email** (notifications, password resets, contact
-forms) on a shared domain, capped at **200 messages/day per account** — not
-built for bulk or marketing sending, at any price
-([why](docs/FAQ.md#do-you-offer-a-paid-plan-for-high-volumebulk-sending)).
+**Everything you need for the Microsoft 365 SMTP AUTH shutdown.**<br>
+Find out what breaks in your tenant, check whether your hardware has a way
+out, and keep it sending — including a free relay for the devices that will
+never speak OAuth.<br>
+The relay is free with no paid tier, capped at **200 messages/day**, and sends
+from a shared `@msgwing.com` address rather than your own
+([why](docs/FAQ.md#will-emails-be-sent-from-my-own-domain-eg-youyourdomaincom)).
 
 [![mx.msgwing.com status](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/status.json)](https://github.com/msgwing/ZeroSMTP/actions/workflows/service-healthcheck.yml)
 [![Exchange Online Basic auth countdown](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/countdown.json)](docs/EXCHANGE-ONLINE-SMTP-AUTH.md)
@@ -23,10 +22,22 @@ built for bulk or marketing sending, at any price
 
 </div>
 
+## What's in here
+
+| | |
+| --- | --- |
+| **1. Audit your tenant** | [`Find-SmtpAuthExposure.ps1`](Find-SmtpAuthExposure.ps1) — read-only. Reports every mailbox that can still use SMTP AUTH, counting the ones that *inherit* the tenant setting separately, because the usual `-eq $false` one-liner misses those entirely and can report zero on a fully exposed tenant. |
+| **2. Check your hardware** | [Compatibility list](docs/DEVICE-COMPATIBILITY.md) — machine-readable, backed by [`data/devices.json`](data/devices.json). Which models have OAuth firmware, and [which ones the vendor has ruled out](docs/NO-OAUTH-FIRMWARE.md) with a link to every vendor statement. |
+| **3. Keep it sending** | A free SMTP relay that still accepts a username and password, with [20 code examples across 18 languages](#code-examples) and [printer setup by brand](docs/PRINTERS.md). |
+
+Plus [what every error message actually means](docs/ERROR-MESSAGES.md), and a
+[migration guide](docs/EXCHANGE-ONLINE-SMTP-AUTH.md) that covers Graph API,
+Direct Send and paid relays — not just this one.
+
 > **Getting `535 5.7.139 Authentication unsuccessful, basic authentication is disabled`?**
-> That's Microsoft switching off Basic auth for SMTP AUTH — [here's what to do
-> about it](docs/EXCHANGE-ONLINE-SMTP-AUTH.md), including the options that
-> aren't this project.
+> That's Microsoft switching off Basic auth for SMTP AUTH — [start
+> here](docs/ERROR-MESSAGES.md). Three of the four causes are still reversible
+> until the end of December 2026.
 
 ---
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -2,15 +2,13 @@
 
 ![ZeroSMTP](docs/assets/banner.png)
 
-**Darmowy relay SMTP, który nadal przyjmuje zwykłe logowanie loginem i hasłem.**<br>
-Stworzony dla drukarek, skanerów i starszych aplikacji porzuconych, gdy
-Microsoft 365 wyłącza SMTP AUTH z uwierzytelnianiem Basic.<br>
-Bez wdrażania OAuth. Bez karty kredytowej. Bez własnego serwera pocztowego.<br>
-Ograniczony do poczty **transakcyjnej** (powiadomienia, resetowanie haseł,
-formularze kontaktowe) w domenie współdzielonej, z limitem **200
-wiadomości/dzień na konto** — nie jest przeznaczony do wysyłki masowej ani
-marketingowej, niezależnie od ceny
-([dlaczego](docs/FAQ.md#do-you-offer-a-paid-plan-for-high-volumebulk-sending)).
+**Wszystko, co potrzebne przy wyłączeniu SMTP AUTH w Microsoft 365.**<br>
+Sprawdź, co się zepsuje w Twoim tenancie, ustal czy Twój sprzęt ma jakieś
+wyjście, i utrzymaj wysyłkę — razem z darmowym relayem dla urządzeń, które
+nigdy nie będą mówić OAuth.<br>
+Relay jest darmowy bez planu płatnego, z limitem **200 wiadomości/dzień**, i
+wysyła ze współdzielonego adresu `@msgwing.com`, nie z Twojej domeny
+([dlaczego](docs/FAQ.md#will-emails-be-sent-from-my-own-domain-eg-youyourdomaincom)).
 
 [![mx.msgwing.com status](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/status.json)](https://github.com/msgwing/ZeroSMTP/actions/workflows/service-healthcheck.yml)
 [![Odliczanie do wyłączenia Basic auth w Exchange Online](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/countdown.json)](docs/EXCHANGE-ONLINE-SMTP-AUTH.md)
@@ -23,6 +21,18 @@ marketingowej, niezależnie od ceny
 [**Załóż darmowe konto →**](https://msgwing.com) · [**Migracja z Exchange Online →**](docs/EXCHANGE-ONLINE-SMTP-AUTH.md) · [Strona dokumentacji](https://docs.msgwing.com/) · [Szybki start](#szybki-start) · [Przykłady kodu](#przykłady-kodu) · [FAQ](docs/FAQ.md) · [English](README.md)
 
 </div>
+
+## Co tu jest
+
+| | |
+| --- | --- |
+| **1. Audyt tenanta** | [`Find-SmtpAuthExposure.ps1`](Find-SmtpAuthExposure.ps1) — tylko czyta. Raportuje każdą skrzynkę, która nadal może użyć SMTP AUTH, licząc osobno te, które **dziedziczą** ustawienie tenanta — bo typowy jednolinijkowiec `-eq $false` pomija je zupełnie i potrafi pokazać zero na w pełni narażonym tenancie. |
+| **2. Sprawdzenie sprzętu** | [Lista zgodności](docs/DEVICE-COMPATIBILITY.md) — maszynowo czytalna, oparta na [`data/devices.json`](data/devices.json). Które modele mają firmware z OAuth, a [które producent skreślił](docs/NO-OAUTH-FIRMWARE.md), z odnośnikiem do każdego oświadczenia. |
+| **3. Utrzymanie wysyłki** | Darmowy relay SMTP przyjmujący login i hasło, z [20 przykładami w 18 językach](#przykłady-kodu) i [konfiguracją drukarek per marka](docs/PRINTERS.md). |
+
+Plus [co dokładnie znaczy każdy komunikat błędu](docs/ERROR-MESSAGES.md) i
+[przewodnik migracji](docs/EXCHANGE-ONLINE-SMTP-AUTH.md), który omawia Graph
+API, Direct Send i płatne relaye — nie tylko ten jeden.
 
 > **Dostajesz `535 5.7.139 Authentication unsuccessful, basic authentication is disabled`?**
 > Microsoft domyślnie wyłącza uwierzytelnianie Basic dla SMTP AUTH z


### PR DESCRIPTION
Four and a half months old, one star. The content is not the problem — the positioning is.

The first line of the README was **"A free SMTP relay that still accepts plain username-and-password auth."** On GitHub that reads as a service advertisement, and developers do not star advertisements. They star tools and references, because those are things you come back to.

The repository already *is* a toolkit and just did not say so: a read-only tenant audit script, a machine-readable device compatibility list, a ruled-out-hardware page, an error-message reference, 20 code examples across 18 languages, per-brand printer guides. The relay is one component of that, and it was standing in the headline as though it were the whole thing.

## What changed

The headline now names the problem rather than the product, and a "What's in here" block puts the three things a reader can act on in order: audit your tenant, check your hardware, keep it sending.

The relay keeps its CTA, its facts table and its own row. Nothing is hidden — and the limitations stay on the first screen deliberately. The cap and the shared sender domain are still in the second paragraph rather than buried, because a toolkit framing bought at the cost of disclosure would be a worse trade than the star.

The repository description is updated to match.

## Why this over more content

Better pages multiplied by four visitors a day is still four visitors a day. This is the one lever that changes what a visitor does once they arrive, and it costs nothing to try.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
