### PR TITLE
feat: give every decision-guide recommendation its own link

### DIFF
--- a/docs/EXCHANGE-ONLINE-SMTP-AUTH.md
+++ b/docs/EXCHANGE-ONLINE-SMTP-AUTH.md
@@ -121,8 +121,10 @@ outbound 587/465 to a new host is often firewalled.
 
 ## Quick decision guide
 
-Answer two or three questions for a straight recommendation, or read the
-same logic as a flowchart below.
+Answer up to four questions for a straight recommendation, or read the same
+logic as a flowchart below. **Each recommendation has its own link** — the
+address bar updates, so you can send someone straight to the answer for their
+case instead of describing it.
 
 <div id="zc-quiz"></div>
 
@@ -137,8 +139,11 @@ Does the mail have to come FROM your own domain?
 │                       ├── Yes ──► Direct Send / relay connector  (option 2)
 │                       └── No  ──► On-prem relay (option 3) or paid SMTP (option 4)
 └── No  ──► Low volume, non-critical (scans, device alerts)?
-            ├── Yes ──► ZeroSMTP                          (option 5)
-            └── No  ──► Paid SMTP service                 (option 4)
+            ├── No  ──► Paid SMTP service                 (option 4)
+            └── Yes ──► Has the vendor shipped OAuth firmware for your model?
+                        ├── Yes ──► Apply the firmware. Nothing else needed.
+                        ├── No  ──► ZeroSMTP                          (option 5)
+                        └── Don't know ──► Check the compatibility list first
 ```
 
 </details>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -413,8 +413,16 @@
         volume: {
           q: "Is this low volume and non-critical (scans, device alerts, notifications)?",
           options: [
-            { label: "Yes", next: "result_zerosmtp" },
+            { label: "Yes", next: "firmware" },
             { label: "No", next: "result_paid" }
+          ]
+        },
+        firmware: {
+          q: "Has the device's vendor shipped OAuth firmware for your exact model?",
+          options: [
+            { label: "Yes, an update exists", next: "result_firmware" },
+            { label: "No, or the vendor ruled it out", next: "result_zerosmtp" },
+            { label: "I don't know", next: "result_checklist" }
           ]
         }
       };
@@ -430,15 +438,23 @@
         },
         result_relay_or_paid: {
           title: "Options 3 or 4 — on-prem relay or a paid SMTP service",
-          body: "Without a static IP, you need either your own relay (Postfix/IIS &mdash; see SYSTEM-MTA.md) or a paid provider (SendGrid, Mailgun, SES...) that supports your own domain."
+          body: "Without a static IP, you need either your own relay (Postfix or IIS &mdash; see <a href=\"SYSTEM-MTA.html\">the system relay guide</a>) or a paid provider that supports your own domain. <a href=\"ALTERNATIVES.html\">What domain verification involves</a>."
+        },
+        result_firmware: {
+          title: "Update the firmware — nothing else needed",
+          body: "If the vendor shipped OAuth for your model, that is the cleanest fix: the device keeps sending from your own domain and no third party is involved. Apply it and stop here."
+        },
+        result_checklist: {
+          title: "Check your model first",
+          body: "Worth two minutes before changing anything. The <a href=\"DEVICE-COMPATIBILITY.html\">compatibility list</a> records what each vendor has published, and <a href=\"NO-OAUTH-FIRMWARE.html\">the ruled-out list</a> covers models whose vendor has stated no update is coming &mdash; including Konica Minolta ineo models marked N/A in their own advisory. If yours is ruled out, come back and answer \"No\"."
         },
         result_zerosmtp: {
           title: "Option 5 — ZeroSMTP fits this case",
-          body: "Free, three settings changed, done &mdash; as long as sending from <code>@msgwing.com</code> instead of your own domain is acceptable here. See the Quickstart."
+          body: "Free, three settings changed, done &mdash; as long as sending from <code>@msgwing.com</code> instead of your own domain is acceptable here, and you are under 200 messages a day. <a href=\"https://github.com/msgwing/ZeroSMTP#quickstart\">Quickstart</a> and <a href=\"PRINTERS.html\">per-brand settings</a>."
         },
         result_paid: {
           title: "Option 4 — a paid SMTP service",
-          body: "Higher volume or anything customer-facing needs a provider built for that (SendGrid, Mailgun, Brevo, SES...)."
+          body: "Higher volume or anything customer-facing needs a provider built for that &mdash; SendGrid, Mailgun, Brevo, SMTP2GO, Amazon SES. This project is the wrong tool for it and will not pretend otherwise. <a href=\"ALTERNATIVES.html\">What choosing one involves</a>."
         }
       };
 
@@ -457,19 +473,37 @@
         });
       }
 
-      function renderResult(key){
+      function renderResult(key, skipHash){
         var r = results[key];
+        // Every outcome gets its own address. Without this, somebody
+        // answering a question elsewhere cannot link to the answer, and a
+        // decision tool that cannot be cited is just a toy.
+        if (!skipHash) {
+          try { history.replaceState(null, '', '#' + key.replace(/_/g, '-')); }
+          catch (e) { location.hash = key.replace(/_/g, '-'); }
+        }
         el.innerHTML =
           '<div style="font-weight:600;margin-bottom:8px;">Recommendation</div>' +
           '<div style="background:#dafbe1;border:1px solid #2ea043;border-radius:6px;padding:12px 14px;"><strong>' + r.title + '</strong><p style="margin:8px 0 0;">' + r.body + '</p></div>' +
-          '<a href="#" id="zc-restart" style="display:inline-block;margin-top:10px;font-size:13px;">&larr; start over</a>';
+          '<div style="margin-top:10px;font-size:13px;">' +
+          '<a href="#" id="zc-restart">&larr; start over</a>' +
+          '<span style="color:#57606a;"> · this recommendation has its own link &mdash; copy the address bar to share it</span>' +
+          '</div>';
         document.getElementById('zc-restart').addEventListener('click', function(e){
           e.preventDefault();
+          try { history.replaceState(null, '', location.pathname + location.search); } catch (err) {}
           renderQuestion("start");
         });
       }
 
-      renderQuestion("start");
+      // A shared link opens straight at the recommendation rather than
+      // making the reader answer the questions again.
+      var zadany = (location.hash || '').replace(/^#/, '').replace(/-/g, '_');
+      if (zadany && results[zadany]) {
+        renderResult(zadany, true);
+      } else {
+        renderQuestion("start");
+      }
     })();
     </script>
     {% elsif page.widget == "printers" %}


### PR DESCRIPTION
Two defects in the decision guide, both commercial rather than cosmetic.

## A recommendation had no URL

Somebody answering a question — on a forum, in an issue, in a Slack channel — could not link *"here is the answer for your case"*. They had to describe the path in prose and hope the reader followed it.

A decision tool that cannot be cited is a toy. Results now write `location.hash` and are restored on load, so `#result-zerosmtp` or `#result-directsend` opens straight at the outcome instead of making the reader answer the questions again.

This matters more than it looks. Being the place where the decision gets made is the one position in this market that a vendor with a paid tier cannot occupy — and citations are how that position is actually held.

## The tree never asked about firmware

It never asked whether the vendor had shipped OAuth firmware for the model. That is the one question this project answers better than anyone, and the route into `docs/NO-OAUTH-FIRMWARE.md`.

An ineo 266 owner previously walked straight past it and was told to change SMTP settings, when the real first question is whether an update exists at all. Three outcomes now: apply the firmware and stop, no firmware so the relay fits, or don't know so check the compatibility list.

Note which one comes first. If a firmware update exists, that is the better answer and the guide says so.

## Recommendations now go somewhere

"SendGrid, Mailgun, SES" as bare text is a dead end on a page whose whole job is routing the reader. The paid-service outcome now says plainly that this project is the wrong tool for that case and links to what choosing one involves.

## Verification

The text flowchart — the version GitHub readers see, since the widget only renders on the docs site — is updated to match. The two cannot be allowed to disagree.

Checked with node: syntax valid, all seven paths terminate, every result is reachable from `start`, and the key-to-hash round trip holds for all of them including `result_relay_or_paid` with its multiple underscores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
