### PR TITLE
feat: make the audit script publishable to the PowerShell Gallery

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,38 @@ covered, a platform/tool not documented, a confusing section). For anything
 beyond a small fix, opening the issue first avoids a PR that doesn't match
 what maintainers had in mind.
 
+## Publishing Find-SmtpAuthExposure.ps1 to the PowerShell Gallery
+
+The script carries a `<#PSScriptInfo#>` block so `Publish-Script` accepts it.
+Sysadmins search the Gallery; a script they can install in one command is a
+different proposition from a file they have to find and download.
+
+Validate first — this catches missing metadata before the upload rather than
+after:
+
+```powershell
+Test-ScriptFileInfo -Path .\Find-SmtpAuthExposure.ps1
+```
+
+Then publish, with an API key from your https://www.powershellgallery.com
+account:
+
+```powershell
+Publish-Script -Path .\Find-SmtpAuthExposure.ps1 -NuGetApiKey <key>
+```
+
+**A version can never be replaced or deleted**, only superseded, so bump
+`.VERSION` in the PSScriptInfo block for every publish. Keep `.GUID`
+unchanged — it identifies the script across versions, and a new GUID creates
+a second, competing listing.
+
+Once it is live, users install it with:
+
+```powershell
+Install-Script Find-SmtpAuthExposure
+```
+
+
 ## Adding a new language example
 
 This is the highest-value kind of contribution. Each example is a single,

--- a/Find-SmtpAuthExposure.ps1
+++ b/Find-SmtpAuthExposure.ps1
@@ -1,3 +1,32 @@
+<#PSScriptInfo
+
+.VERSION 1.0.0
+
+.GUID 699c5654-5dd9-4914-b032-fb8744cdb6ec
+
+.AUTHOR msgwing.com
+
+.COMPANYNAME msgwing.com
+
+.COPYRIGHT MIT
+
+.TAGS SMTP SMTPAUTH BasicAuthentication ExchangeOnline Microsoft365 Office365 Audit ReadOnly Deprecation
+
+.LICENSEURI https://github.com/msgwing/ZeroSMTP/blob/main/LICENSE
+
+.PROJECTURI https://github.com/msgwing/ZeroSMTP
+
+.RELEASENOTES
+Initial release. Reports which Exchange Online mailboxes can still authenticate
+with SMTP AUTH before Microsoft disables Basic authentication for it by default
+at the end of December 2026. Read-only.
+
+Handles all three states of SmtpClientAuthenticationDisabled, including $null
+which inherits the tenant setting - the state that the commonly repeated
+`-eq $false` filter misses entirely.
+
+#>
+
 #Requires -Version 5.1
 
 <#


### PR DESCRIPTION
Successful tools are `brew install`, `npm i`, `pip install`. This one was a file you had to find on GitHub and download by hand.

Sysadmins search the PowerShell Gallery. A script installable in one command is a different proposition from a file in a repository, and the Gallery brings its own search surface, its own indexing and an install count that works as social proof.

## What this adds

A `<#PSScriptInfo#>` block with version, a stable GUID, author, licence and project URIs, release notes, and tags a sysadmin would actually type: `SMTPAUTH`, `ExchangeOnline`, `Microsoft365`, `Office365`, `Audit`, `BasicAuthentication`.

The tags are the point. Without them a listing exists and nobody finds it.

## Verified both ways

`Test-ScriptFileInfo` passes with the block and resolves every required field including Description. Without it, the same cmdlet refuses outright — *"PSScriptInfo is not specified in the script file"* — and `Publish-Script` calls it internally. Checked against PowerShellGet 1.0.0.1, which is what ships with Windows PowerShell 5.1. Newer `Publish-PSResource` may be more lenient; the metadata is worth having regardless, because discoverability rather than permission is the reason for it.

## Not advertising it yet

`Install-Script` is deliberately absent from the README. The listing does not exist until someone publishes it with an API key, and a README promising a command that fails is worse than no line at all.

`CONTRIBUTING.md` documents the publish, including the two things that bite: a version can never be replaced or deleted once uploaded, and the GUID must stay fixed or the Gallery grows a second competing listing for the same script.

```powershell
Test-ScriptFileInfo -Path .\Find-SmtpAuthExposure.ps1
Publish-Script -Path .\Find-SmtpAuthExposure.ps1 -NuGetApiKey <key>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
