### PR TITLE
fix: stop the stale bot closing the contributor funnel, and patch CVE-2026-53914

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,7 +25,15 @@ jobs:
           days-before-close: 14
           stale-issue-label: stale
           stale-pr-label: stale
-          exempt-issue-labels: 'service-alert,pinned,security'
+          # "help wanted" i "good first issue" znacza "czekamy na ochotnika",
+          # a nie "porzucone". Bez tych wyjatkow lej kontrybutorow zamyka sie
+          # sam po 74 dniach - a zadania jezykowe potrafia czekac dluzej i to
+          # jest normalne, nie problem.
+          #
+          # Uwaga: "pinned" to ETYKIETA, nie przypiecie w interfejsie GitHuba.
+          # actions/stale nie widzi przypietych issues, wiec samo przypiecie
+          # niczego nie chroni.
+          exempt-issue-labels: 'service-alert,pinned,security,help wanted,good first issue'
           exempt-pr-labels: 'pinned'
           stale-issue-message: >
             This issue has had no activity for 60 days and will be closed in

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,18 @@
 plugins {
-    kotlin("jvm") version "2.4.10"
+    // 2.4.20-RC, nie 2.4.10, z powodu CVE-2026-53914 (GHSA-r937-wjx7-w2jp):
+    // niebezpieczna deserializacja w metadanych build cache, naprawiona
+    // od 2.4.20-Beta1. Stabilnej wersji z poprawka jeszcze nie ma -
+    // najnowsza w maven-metadata.xml to wlasnie 2.4.20-RC.
+    //
+    // Ten build kompiluje jeden przykladowy plik w CI i nie wlacza build
+    // cache, wiec realne ryzyko bylo znikome. Chodzi o to, ze Dependabot
+    // probowal to naprawic codziennie i padal z
+    // security_update_dependency_not_found, bo nie dopasowuje pluginu
+    // deklarowanego przez kotlin("jvm") - czyli czerwony przebieg kazdego
+    // ranka i alert, ktory nigdy sam nie znika.
+    //
+    // Wroc do stabilnej, gdy 2.4.20 wyjdzie.
+    kotlin("jvm") version "2.4.20-RC"
     application
 }
 


### PR DESCRIPTION
Two unrelated problems found while reviewing the repository.

## The stale bot was going to close the contributor funnel

`exempt-issue-labels` listed a label called `pinned`. Pinning an issue through the GitHub interface does not add that label, and `actions/stale` cannot see interface pins at all.

So the five `good first issue` tickets opened this week — including the three pinned ones — would have been labelled stale after 60 days and closed 14 days later, around **25 October**. A few weeks before the December wave they exist to catch, and silently.

`help wanted` and `good first issue` are now exempt. Those labels mean *waiting for a volunteer*, which is not the same thing as abandoned. Auto-closing them is how a project teaches contributors not to bother; the three PRs that arrived this month came through exactly these labels.

## CVE-2026-53914 in kotlin-gradle-plugin

Dependabot has been failing every morning with `security_update_dependency_not_found`. There is a real advisory behind that noise — unsafe deserialization in build cache metadata, fixed from 2.4.20-Beta1 — and Dependabot cannot generate the fix because it does not match a plugin declared through `kotlin("jvm") version`.

Bumped to `2.4.20-RC`. No stable release carries the fix yet: `maven-metadata.xml` lists 2.4.20-Beta1, Beta2 and RC, with 2.4.10 the newest stable. Worth revisiting when 2.4.20 ships.

### On dismissing it instead

Actual exposure was negligible. This build compiles one example file in CI and never enables the Gradle build cache — there is no `gradle.properties`, `org.gradle.caching` appears nowhere, and the run is a plain `gradle build --no-daemon`.

Dismissing the alert as not-applicable was the tempting option. I did not, because `gradle/actions/setup-gradle` is in the workflow and I did not verify whether it enables caching implicitly. On a public repository a security decision should not rest on an assumption I skipped checking, so the version moved instead — that removes the question rather than answering it from memory.
