### PR TITLE
fix(ci): repair the growth bot and stop Maven 429 turning main red

### DIFF
--- a/.github/workflows/deadline-milestones.yml
+++ b/.github/workflows/deadline-milestones.yml
@@ -1,0 +1,163 @@
+name: Deadline milestone discussion
+
+# Posts a countdown reminder in Discussions at a handful of milestones before
+# Microsoft disables Basic auth for SMTP AUTH (end of December 2026).
+#
+# WHY MILESTONES AND NOT WEEKLY
+# A weekly digest would post the same content every Monday whether or not
+# anything changed. Announcements would fill with near-identical bot posts,
+# and a category that reads as machine-generated is worse for the project
+# than an empty one - it tells a visitor nobody is home. Six posts across
+# five months, each at a point where the number itself is news, is the
+# version of this that a reader might actually want.
+#
+# Runs daily but exits silently on every day that is not a milestone.
+
+on:
+  schedule:
+    - cron: '30 8 * * *'   # daily 08:30 UTC; almost every run is a no-op
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Post even if today is not a milestone day'
+        type: boolean
+        default: false
+
+permissions:
+  discussions: write
+  contents: read
+
+jobs:
+  milestone:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Is today a milestone?
+        id: check
+        run: |
+          set -euo pipefail
+          DEADLINE=$(date -u -d '2026-12-31' +%s)
+          NOW=$(date -u +%s)
+          DAYS=$(( (DEADLINE - NOW) / 86400 ))
+          echo "days=$DAYS" >> "$GITHUB_OUTPUT"
+
+          # Each of these is a point where the number is worth saying out
+          # loud. Between them the workflow does nothing.
+          case "$DAYS" in
+            90|60|30|14|7|1) POST=yes ;;
+            *)               POST=no  ;;
+          esac
+          if [ "${{ inputs.force }}" = "true" ]; then POST=yes; fi
+
+          echo "post=$POST" >> "$GITHUB_OUTPUT"
+          echo "$DAYS days left; post=$POST"
+
+      - name: Build the post
+        id: body
+        if: steps.check.outputs.post == 'yes'
+        run: |
+          set -euo pipefail
+          DAYS='${{ steps.check.outputs.days }}'
+
+          # Counts come from the README table rather than being written into
+          # this file, where they would silently go stale the next time
+          # somebody adds a language.
+          EXAMPLES=$(awk '/^\| Language \| File \|/,/^$/' README.md \
+            | grep -c '^| .* | \[' || echo '?')
+
+          TITLE="${DAYS} days until Microsoft 365 disables SMTP AUTH Basic auth"
+
+          {
+            echo "Microsoft disables Basic authentication for SMTP AUTH by default on"
+            echo "existing Microsoft 365 tenants at the **end of December 2026** —"
+            echo "**${DAYS} days from today**. Administrators can still re-enable it after"
+            echo "that; the final removal date is announced in the second half of 2027."
+            echo ""
+            echo "Source: [Microsoft's updated timeline](https://techcommunity.microsoft.com/blog/exchange/updated-exchange-online-smtp-auth-basic-authentication-deprecation-timeline/4489835)."
+            echo ""
+            echo "## If you have not checked yet"
+            echo ""
+            echo "[\`Find-SmtpAuthExposure.ps1\`](https://github.com/${{ github.repository }}/blob/main/Find-SmtpAuthExposure.ps1)"
+            echo "reports every mailbox in your tenant that can still authenticate this way."
+            echo "It is read-only, so it is safe to run before you have decided anything."
+            echo ""
+            echo "It counts the mailboxes that *inherit* the tenant setting separately,"
+            echo "which the widely-repeated \`-eq \$false\` one-liner misses entirely — on a"
+            echo "tenant nobody has locked down, that one-liner can report zero while every"
+            echo "mailbox is exposed."
+            echo ""
+            echo "## Then check whether your hardware has a way out"
+            echo ""
+            echo "- [Compatibility list](https://docs.msgwing.com/DEVICE-COMPATIBILITY.html) — what each vendor has published, with a link to every statement"
+            echo "- [Models the vendor has ruled out](https://docs.msgwing.com/NO-OAUTH-FIRMWARE.html) — where firmware is not a step you skipped, it does not exist"
+            echo "- [What the error messages mean](https://docs.msgwing.com/ERROR-MESSAGES.html)"
+            echo ""
+            echo "**If a firmware update exists for your model, apply it.** That keeps your"
+            echo "own domain as the sender and involves no third party. The"
+            echo "[migration guide](https://docs.msgwing.com/EXCHANGE-ONLINE-SMTP-AUTH.html)"
+            echo "covers every option in order, including Direct Send, which is free and is"
+            echo "often the right answer when every recipient is inside your own tenant."
+            echo ""
+            echo "This project's relay is the last resort on that list, for devices that"
+            echo "have no other path. There are ${EXAMPLES} ready-to-run examples if it turns out to"
+            echo "be yours."
+            echo ""
+            echo "---"
+            echo ""
+            echo "_Posted automatically at deadline milestones (90, 60, 30, 14, 7 and 1 days)._"
+            echo "_Replies are read — if you have migrated, what worked for your setup helps"
+            echo "whoever reads this next._"
+          } > body.md
+
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
+
+      - name: Post to Discussions
+        if: steps.check.outputs.post == 'yes'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TITLE: ${{ steps.body.outputs.title }}
+        run: |
+          set -euo pipefail
+
+          # Discussions cannot be created through the REST API - createDiscussion
+          # is GraphQL only, and it needs a category id. Looking the id up by
+          # slug keeps this working if the repository is forked or the category
+          # is recreated.
+          REPO_ID=$(gh api graphql -f query='
+            query($o:String!,$n:String!){ repository(owner:$o,name:$n){ id } }' \
+            -f o='${{ github.repository_owner }}' -f n='${{ github.event.repository.name }}' \
+            --jq '.data.repository.id')
+
+          CAT_ID=$(gh api graphql -f query='
+            query($o:String!,$n:String!){ repository(owner:$o,name:$n){
+              discussionCategories(first:25){ nodes{ id slug } } } }' \
+            -f o='${{ github.repository_owner }}' -f n='${{ github.event.repository.name }}' \
+            --jq '.data.repository.discussionCategories.nodes[]
+                  | select(.slug=="announcements") | .id')
+
+          if [ -z "$CAT_ID" ]; then
+            echo "::error::No 'announcements' discussion category found."
+            exit 1
+          fi
+
+          # A re-run on the same day must not produce a second copy.
+          EXISTING=$(gh api graphql -f query='
+            query($q:String!){ search(query:$q, type:DISCUSSION, first:1){ discussionCount } }' \
+            -f q="repo:${{ github.repository }} in:title \"$TITLE\"" \
+            --jq '.data.search.discussionCount')
+
+          if [ "${EXISTING:-0}" -gt 0 ]; then
+            echo "Already posted: $TITLE"
+            exit 0
+          fi
+
+          URL=$(gh api graphql -f query='
+            mutation($r:ID!,$c:ID!,$t:String!,$b:String!){
+              createDiscussion(input:{repositoryId:$r,categoryId:$c,title:$t,body:$b}){
+                discussion{ url } } }' \
+            -f r="$REPO_ID" -f c="$CAT_ID" -f t="$TITLE" -F b=@body.md \
+            --jq '.data.createDiscussion.discussion.url')
+
+          echo "Posted: $URL"
+          echo "### Posted [$TITLE]($URL)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -247,8 +247,17 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+          # Without caching every run re-downloads plugins and dependencies,
+          # which earns a 429 Too Many Requests from Maven Central and turns
+          # main red with nothing wrong in the code. Happened 2026-08-16.
+          cache: 'maven'
       - name: Build Java example
-        run: mvn -B compile
+        # Retry in case the cache is not enough: a transient 429 or 502 from
+        # Central should not look like a broken example.
+        run: >
+          mvn -B compile
+          -Dmaven.wagon.http.retryHandler.count=3
+          -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
 
   kotlin:
     needs: changes

--- a/c-zerosmtp.c
+++ b/c-zerosmtp.c
@@ -108,10 +108,27 @@ static int build_message(char *out, size_t out_size,
 
 int main(void)
 {
-    const char *username = env_or("ZEROSMTP_USERNAME", "your-username");
-    const char *password = env_or("ZEROSMTP_PASSWORD", "your-password");
-    const char *from     = env_or("ZEROSMTP_FROM", "sender@example.com");
-    const char *to       = env_or("ZEROSMTP_TO", "recipient@example.com");
+    /* Fail-fast: missing env vars exit with a clear error instead of silently
+     * using placeholder credentials that could leak into production. */
+    const char *required[] = {
+        "ZEROSMTP_USERNAME", "ZEROSMTP_PASSWORD",
+        "ZEROSMTP_FROM", "ZEROSMTP_TO", NULL
+    };
+    int missing_count = 0;
+    for (int i = 0; required[i] != NULL; i++) {
+        const char *v = getenv(required[i]);
+        if (!v || !*v) {
+            fprintf(stderr, "ERROR: missing required environment variable: %s\n", required[i]);
+            missing_count++;
+        }
+    }
+    if (missing_count > 0) {
+        return 1;
+    }
+    const char *username = getenv("ZEROSMTP_USERNAME");
+    const char *password = getenv("ZEROSMTP_PASSWORD");
+    const char *from     = getenv("ZEROSMTP_FROM");
+    const char *to       = getenv("ZEROSMTP_TO");
     const char *subject  = env_or("ZEROSMTP_SUBJECT", "Test Email from ZeroSMTP");
 
     char message[MESSAGE_MAX];

--- a/cs-zerosmtp.cs
+++ b/cs-zerosmtp.cs
@@ -83,11 +83,20 @@ public static class ZeroSMTPMailer
     {
         // NOTE: variable names are prefixed with ZEROSMTP_ to avoid colliding with
         // reserved/OS-level variables (e.g. USERNAME is auto-set on Windows).
+        // Fail-fast: missing env vars exit with a clear error instead of silently
+        // using placeholder credentials that could leak into production.
+        string[] required = { "ZEROSMTP_USERNAME", "ZEROSMTP_PASSWORD", "ZEROSMTP_FROM", "ZEROSMTP_TO" };
+        var missing = required.Where(v => string.IsNullOrEmpty(Environment.GetEnvironmentVariable(v))).ToList();
+        if (missing.Count > 0)
+        {
+            Console.Error.WriteLine($"ERROR: missing required environment variables: {string.Join(", ", missing)}");
+            Environment.Exit(1);
+        }
         var config = new EmailConfig(
-            Username: Environment.GetEnvironmentVariable("ZEROSMTP_USERNAME") ?? "your-username",
-            Password: Environment.GetEnvironmentVariable("ZEROSMTP_PASSWORD") ?? "your-password",
-            From: Environment.GetEnvironmentVariable("ZEROSMTP_FROM") ?? "sender@example.com",
-            To: Environment.GetEnvironmentVariable("ZEROSMTP_TO") ?? "recipient@example.com",
+            Username: Environment.GetEnvironmentVariable("ZEROSMTP_USERNAME")!,
+            Password: Environment.GetEnvironmentVariable("ZEROSMTP_PASSWORD")!,
+            From: Environment.GetEnvironmentVariable("ZEROSMTP_FROM")!,
+            To: Environment.GetEnvironmentVariable("ZEROSMTP_TO")!,
             Subject: Environment.GetEnvironmentVariable("ZEROSMTP_SUBJECT") ?? "Test Email from ZeroSMTP"
         );
         bool success = await SendEmailAsync(config);

--- a/dart-zerosmtp.dart
+++ b/dart-zerosmtp.dart
@@ -8,10 +8,26 @@ import 'package:mailer/smtp_server.dart';
 /// Run with: `dart run dart-zerosmtp.dart`
 /// Reads the same ZEROSMTP_* environment variables as the other examples.
 Future<void> main() async {
-  final username = Platform.environment['ZEROSMTP_USERNAME'] ?? 'your-username';
-  final password = Platform.environment['ZEROSMTP_PASSWORD'] ?? 'your-password';
-  final from = Platform.environment['ZEROSMTP_FROM'] ?? 'sender@example.com';
-  final to = Platform.environment['ZEROSMTP_TO'] ?? 'recipient@example.com';
+  // Fail-fast: missing env vars exit with a clear error instead of silently
+  // using placeholder credentials that could leak into production.
+  const requiredVars = [
+    'ZEROSMTP_USERNAME',
+    'ZEROSMTP_PASSWORD',
+    'ZEROSMTP_FROM',
+    'ZEROSMTP_TO',
+  ];
+  final missing = requiredVars
+      .where((v) => (Platform.environment[v] ?? '').isEmpty)
+      .toList();
+  if (missing.isNotEmpty) {
+    stderr.writeln('ERROR: missing required environment variables: ${missing.join(', ')}');
+    exitCode = 1;
+    return;
+  }
+  final username = Platform.environment['ZEROSMTP_USERNAME']!;
+  final password = Platform.environment['ZEROSMTP_PASSWORD']!;
+  final from = Platform.environment['ZEROSMTP_FROM']!;
+  final to = Platform.environment['ZEROSMTP_TO']!;
   final subject =
       Platform.environment['ZEROSMTP_SUBJECT'] ?? 'Test Email from ZeroSMTP';
 

--- a/elixir-zerosmtp.exs
+++ b/elixir-zerosmtp.exs
@@ -23,10 +23,18 @@ defmodule ZeroSMTP do
   end
 
   def run do
-    username = System.get_env("ZEROSMTP_USERNAME") || "your-username"
-    password = System.get_env("ZEROSMTP_PASSWORD") || "your-password"
-    from = System.get_env("ZEROSMTP_FROM") || "sender@example.com"
-    to = System.get_env("ZEROSMTP_TO") || "recipient@example.com"
+    # Fail-fast: missing env vars exit with a clear error instead of silently
+    # using placeholder credentials that could leak into production.
+    required_vars = ["ZEROSMTP_USERNAME", "ZEROSMTP_PASSWORD", "ZEROSMTP_FROM", "ZEROSMTP_TO"]
+    missing = Enum.filter(required_vars, fn v -> System.get_env(v) in [nil, ""] end)
+    if missing != [] do
+      IO.puts(:stderr, "ERROR: missing required environment variables: #{Enum.join(missing, ", ")}")
+      System.halt(1)
+    end
+    username = System.get_env("ZEROSMTP_USERNAME")
+    password = System.get_env("ZEROSMTP_PASSWORD")
+    from = System.get_env("ZEROSMTP_FROM")
+    to = System.get_env("ZEROSMTP_TO")
     subject = System.get_env("ZEROSMTP_SUBJECT") || "Test Email from ZeroSMTP"
 
     {:ok, socket} =

--- a/go-zerosmtp.go
+++ b/go-zerosmtp.go
@@ -115,14 +115,26 @@ func buildEmailBody(config EmailConfig) string {
 func main() {
 	// NOTE: variable names are prefixed with ZEROSMTP_ to avoid colliding with
 	// reserved/OS-level variables (e.g. USERNAME is auto-set on Windows).
-	config := EmailConfig{
-		Username: getEnv("ZEROSMTP_USERNAME", "your-username"),
-		Password: getEnv("ZEROSMTP_PASSWORD", "your-password"),
-		From:     getEnv("ZEROSMTP_FROM", "sender@example.com"),
-		To:       getEnv("ZEROSMTP_TO", "recipient@example.com"),
-		Subject:  getEnv("ZEROSMTP_SUBJECT", "Test Email from ZeroSMTP"),
+	// Fail-fast: missing env vars exit with a clear error instead of silently
+	// using placeholder credentials that could leak into production.
+	requiredVars := []string{"ZEROSMTP_USERNAME", "ZEROSMTP_PASSWORD", "ZEROSMTP_FROM", "ZEROSMTP_TO"}
+	var missing []string
+	for _, v := range requiredVars {
+		if os.Getenv(v) == "" {
+			missing = append(missing, v)
 	}
-
+	}
+	if len(missing) > 0 {
+		fmt.Fprintf(os.Stderr, "ERROR: missing required environment variables: %s\n", strings.Join(missing, ", "))
+		os.Exit(1)
+	}
+	config := EmailConfig{
+	Username: os.Getenv("ZEROSMTP_USERNAME"),
+	Password: os.Getenv("ZEROSMTP_PASSWORD"),
+	From:     os.Getenv("ZEROSMTP_FROM"),
+		To:       os.Getenv("ZEROSMTP_TO"),
+	Subject:  getEnv("ZEROSMTP_SUBJECT", "Test Email from ZeroSMTP"),
+	}
 	if err := sendEmailViaZeroSMTP(config); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
@@ -130,7 +142,6 @@ func main() {
 	fmt.Println("Email sent successfully")
 	os.Exit(0)
 }
-
 func getEnv(key, defaultVal string) string {
 	if value := os.Getenv(key); value != "" {
 		return value

--- a/java-zerosmtp.java
+++ b/java-zerosmtp.java
@@ -29,11 +29,26 @@ final class ZeroSMTPMailer {
     public static void main(String[] args) {
         // NOTE: variable names are prefixed with ZEROSMTP_ to avoid colliding with
         // reserved/OS-level variables (e.g. USERNAME is auto-set on Windows).
+        // Fail-fast: missing env vars exit with a clear error instead of silently
+        // using placeholder credentials that could leak into production.
+        String[] required = {"ZEROSMTP_USERNAME", "ZEROSMTP_PASSWORD", "ZEROSMTP_FROM", "ZEROSMTP_TO"};
+        StringBuilder missing = new StringBuilder();
+        for (String v : required) {
+            String value = System.getenv(v);
+            if (value == null || value.isEmpty()) {
+                if (missing.length() > 0) missing.append(", ");
+                missing.append(v);
+            }
+        }
+        if (missing.length() > 0) {
+            System.err.println("ERROR: missing required environment variables: " + missing);
+            System.exit(1);
+        }
         EmailConfig config = new EmailConfig(
-            System.getenv("ZEROSMTP_USERNAME") != null ? System.getenv("ZEROSMTP_USERNAME") : "your-username",
-            System.getenv("ZEROSMTP_PASSWORD") != null ? System.getenv("ZEROSMTP_PASSWORD") : "your-password",
-            System.getenv("ZEROSMTP_FROM") != null ? System.getenv("ZEROSMTP_FROM") : "sender@example.com",
-            System.getenv("ZEROSMTP_TO") != null ? System.getenv("ZEROSMTP_TO") : "recipient@example.com",
+            System.getenv("ZEROSMTP_USERNAME"),
+            System.getenv("ZEROSMTP_PASSWORD"),
+            System.getenv("ZEROSMTP_FROM"),
+            System.getenv("ZEROSMTP_TO"),
             System.getenv("ZEROSMTP_SUBJECT") != null ? System.getenv("ZEROSMTP_SUBJECT") : "Test Email from ZeroSMTP"
         );
         Thread thread = Thread.ofVirtual().start(() -> {

--- a/kotlin-zerosmtp.kt
+++ b/kotlin-zerosmtp.kt
@@ -88,11 +88,19 @@ suspend fun sendEmailViaZeroSMTP(config: EmailConfig): MailResult = runCatching 
 suspend fun main() {
     // NOTE: variable names are prefixed with ZEROSMTP_ to avoid colliding with
     // reserved/OS-level variables (e.g. USERNAME is auto-set on Windows).
+    // Fail-fast: missing env vars exit with a clear error instead of silently
+    // using placeholder credentials that could leak into production.
+    val required = listOf("ZEROSMTP_USERNAME", "ZEROSMTP_PASSWORD", "ZEROSMTP_FROM", "ZEROSMTP_TO")
+    val missing = required.filter { System.getenv(it).isNullOrEmpty() }
+    if (missing.isNotEmpty()) {
+        System.err.println("ERROR: missing required environment variables: ${missing.joinToString(", ")}")
+        System.exit(1)
+    }
     val config = EmailConfig(
-        username = System.getenv("ZEROSMTP_USERNAME") ?: "your-username",
-        password = System.getenv("ZEROSMTP_PASSWORD") ?: "your-password",
-        from     = System.getenv("ZEROSMTP_FROM") ?: "sender@example.com",
-        to       = System.getenv("ZEROSMTP_TO") ?: "recipient@example.com",
+        username = System.getenv("ZEROSMTP_USERNAME")!!,
+        password = System.getenv("ZEROSMTP_PASSWORD")!!,
+        from     = System.getenv("ZEROSMTP_FROM")!!,
+        to       = System.getenv("ZEROSMTP_TO")!!,
         subject  = System.getenv("ZEROSMTP_SUBJECT") ?: "Test Email from ZeroSMTP",
     )
 

--- a/lua-zerosmtp.lua
+++ b/lua-zerosmtp.lua
@@ -9,11 +9,24 @@ local mime = require("mime")
 
 -- NOTE: variable names are prefixed with ZEROSMTP_ to avoid colliding with
 -- reserved/OS-level variables (e.g. USERNAME is auto-set on Windows).
+-- Fail-fast: missing env vars exit with a clear error instead of silently
+-- using placeholder credentials that could leak into production.
+local required = {"ZEROSMTP_USERNAME", "ZEROSMTP_PASSWORD", "ZEROSMTP_FROM", "ZEROSMTP_TO"}
+local missing = {}
+for _, v in ipairs(required) do
+  if (os.getenv(v) or "") == "" then
+    table.insert(missing, v)
+  end
+end
+if #missing > 0 then
+  io.stderr:write("ERROR: missing required environment variables: " .. table.concat(missing, ", ") .. "\n")
+  os.exit(1)
+end
 local config = {
-  username = os.getenv("ZEROSMTP_USERNAME") or "your-username",
-  password = os.getenv("ZEROSMTP_PASSWORD") or "your-password",
-  from = os.getenv("ZEROSMTP_FROM") or "sender@example.com",
-  to = os.getenv("ZEROSMTP_TO") or "recipient@example.com",
+  username = os.getenv("ZEROSMTP_USERNAME"),
+  password = os.getenv("ZEROSMTP_PASSWORD"),
+  from = os.getenv("ZEROSMTP_FROM"),
+  to = os.getenv("ZEROSMTP_TO"),
   subject = os.getenv("ZEROSMTP_SUBJECT") or "Test Email from ZeroSMTP"
 }
 

--- a/node-zerosmtp.mjs
+++ b/node-zerosmtp.mjs
@@ -8,11 +8,19 @@ import nodemailer from 'nodemailer';
 
 // NOTE: variable names are prefixed with ZEROSMTP_ to avoid colliding with
 // reserved/OS-level variables (e.g. USERNAME is auto-set on Windows).
+// Fail-fast: missing env vars exit with a clear error instead of silently
+// using placeholder credentials that could leak into production.
+const requiredVars = ['ZEROSMTP_USERNAME', 'ZEROSMTP_PASSWORD', 'ZEROSMTP_FROM', 'ZEROSMTP_TO'];
+const missing = requiredVars.filter((v) => !process.env[v]);
+if (missing.length > 0) {
+  console.error(`ERROR: missing required environment variables: ${missing.join(', ')}`);
+  process.exit(1);
+}
 const config = {
-  username: process.env.ZEROSMTP_USERNAME || 'your-username',
-  password: process.env.ZEROSMTP_PASSWORD || 'your-password',
-  from: process.env.ZEROSMTP_FROM || 'sender@example.com',
-  to: process.env.ZEROSMTP_TO || 'recipient@example.com',
+  username: process.env.ZEROSMTP_USERNAME,
+  password: process.env.ZEROSMTP_PASSWORD,
+  from: process.env.ZEROSMTP_FROM,
+  to: process.env.ZEROSMTP_TO,
   subject: process.env.ZEROSMTP_SUBJECT || 'Test Email from ZeroSMTP',
 };
 

--- a/perl-zerosmtp.pl
+++ b/perl-zerosmtp.pl
@@ -17,12 +17,19 @@ use warnings;
 use Net::SMTP;
 use IO::Socket::SSL qw(SSL_VERIFY_PEER);
 
+# Fail-fast: missing env vars exit with a clear error instead of silently
+# using placeholder credentials that could leak into production.
+my @required = qw(ZEROSMTP_USERNAME ZEROSMTP_PASSWORD ZEROSMTP_FROM ZEROSMTP_TO);
+my @missing = grep { !defined $ENV{$_} || $ENV{$_} eq '' } @required;
+if (@missing) {
+    die "ERROR: missing required environment variables: " . join(', ', @missing) . "\n";
+}
 my %config = (
-    username => $ENV{ZEROSMTP_USERNAME} // 'your-username',
-    password => $ENV{ZEROSMTP_PASSWORD} // 'your-password',
-    from     => $ENV{ZEROSMTP_FROM}     // 'sender@example.com',
-    to       => $ENV{ZEROSMTP_TO}       // 'recipient@example.com',
-    subject  => $ENV{ZEROSMTP_SUBJECT}  // 'Test Email from ZeroSMTP',
+    username => $ENV{ZEROSMTP_USERNAME},
+    password => $ENV{ZEROSMTP_PASSWORD},
+    from     => $ENV{ZEROSMTP_FROM},
+    to       => $ENV{ZEROSMTP_TO},
+    subject  => $ENV{ZEROSMTP_SUBJECT} // 'Test Email from ZeroSMTP',
 );
 
 # A multipart/alternative body, so clients that cannot render HTML still show

--- a/php-symfony-mailer-zerosmtp.php
+++ b/php-symfony-mailer-zerosmtp.php
@@ -38,14 +38,22 @@ use Symfony\Component\Mime\Email;
 // ZeroSMTP configuration from environment variables
 // NOTE: variable names are prefixed with ZEROSMTP_ to avoid colliding with
 // reserved/OS-level variables (e.g. USERNAME is auto-set on Windows).
+// Fail-fast: missing env vars exit with a clear error instead of silently
+// using placeholder credentials that could leak into production.
+$required = ['ZEROSMTP_USERNAME', 'ZEROSMTP_PASSWORD', 'ZEROSMTP_FROM', 'ZEROSMTP_TO'];
+$missing = array_filter($required, fn($v) => getenv($v) === false || getenv($v) === '');
+if (!empty($missing)) {
+    fwrite(STDERR, "ERROR: missing required environment variables: " . implode(', ', $missing) . "\n");
+    exit(1);
+}
 $smtpConfig = [
     'host'     => 'mx.msgwing.com',
     'port'     => 465,
-    'username' => getenv('ZEROSMTP_USERNAME') ?: 'your-email@msgwing.com',
-    'password' => getenv('ZEROSMTP_PASSWORD') ?: 'your-password',
-    'from'     => getenv('ZEROSMTP_FROM') ?: 'your-email@msgwing.com',
+    'username' => getenv('ZEROSMTP_USERNAME'),
+    'password' => getenv('ZEROSMTP_PASSWORD'),
+    'from'     => getenv('ZEROSMTP_FROM'),
     'fromName' => 'ZeroSMTP User',
-    'to'       => getenv('ZEROSMTP_TO') ?: 'recipient@example.com',
+    'to'       => getenv('ZEROSMTP_TO'),
     'subject'  => getenv('ZEROSMTP_SUBJECT') ?: 'Hello from ZeroSMTP!',
 ];
 

--- a/php-zerosmtp.php
+++ b/php-zerosmtp.php
@@ -54,11 +54,19 @@ function sendEmailViaZeroSMTP(ZeroSMTPConfig $config): bool {
 
 // NOTE: variable names are prefixed with ZEROSMTP_ to avoid colliding with
 // reserved/OS-level variables (e.g. USERNAME is auto-set on Windows).
+// Fail-fast: missing env vars exit with a clear error instead of silently
+// using placeholder credentials that could leak into production.
+$required = ['ZEROSMTP_USERNAME', 'ZEROSMTP_PASSWORD', 'ZEROSMTP_FROM', 'ZEROSMTP_TO'];
+$missing = array_filter($required, fn($v) => getenv($v) === false || getenv($v) === '');
+if (!empty($missing)) {
+    fwrite(STDERR, "ERROR: missing required environment variables: " . implode(', ', $missing) . "\n");
+    exit(1);
+}
 $config = new ZeroSMTPConfig(
-    username: getenv('ZEROSMTP_USERNAME') ?: 'your-username',
-    password: getenv('ZEROSMTP_PASSWORD') ?: 'your-password',
-    from: getenv('ZEROSMTP_FROM') ?: 'sender@example.com',
-    to: getenv('ZEROSMTP_TO') ?: 'recipient@example.com',
+    username: getenv('ZEROSMTP_USERNAME'),
+    password: getenv('ZEROSMTP_PASSWORD'),
+    from: getenv('ZEROSMTP_FROM'),
+    to: getenv('ZEROSMTP_TO'),
     subject: getenv('ZEROSMTP_SUBJECT') ?: 'Test Email from ZeroSMTP',
 );
 

--- a/python-zerosmtp.py
+++ b/python-zerosmtp.py
@@ -70,11 +70,20 @@ def send_email_via_zerosmtp(
 if __name__ == '__main__':
     # NOTE: variable names are prefixed with ZEROSMTP_ to avoid colliding with
     # reserved/OS-level variables (e.g. USERNAME is auto-set on Windows).
+    # Fail-fast: missing env vars raise SystemExit instead of silently using
+    # placeholder credentials that could leak into production.
+    required_vars = ['ZEROSMTP_USERNAME', 'ZEROSMTP_PASSWORD',
+                     'ZEROSMTP_FROM', 'ZEROSMTP_TO']
+    missing = [v for v in required_vars if not os.getenv(v)]
+    if missing:
+        raise SystemExit(
+            f'ERROR: missing required environment variables: {", ".join(missing)}'
+        )
     config = {
-        'username': os.getenv('ZEROSMTP_USERNAME', 'your-username'),
-        'password': os.getenv('ZEROSMTP_PASSWORD', 'your-password'),
-        'from_addr': os.getenv('ZEROSMTP_FROM', 'sender@example.com'),
-        'to_addr': os.getenv('ZEROSMTP_TO', 'recipient@example.com'),
+        'username': os.environ['ZEROSMTP_USERNAME'],
+        'password': os.environ['ZEROSMTP_PASSWORD'],
+        'from_addr': os.environ['ZEROSMTP_FROM'],
+        'to_addr': os.environ['ZEROSMTP_TO'],
         'subject': os.getenv('ZEROSMTP_SUBJECT', 'Test Email from ZeroSMTP'),
     }
     success = send_email_via_zerosmtp(**config)

--- a/rust-zerosmtp.rs
+++ b/rust-zerosmtp.rs
@@ -28,11 +28,25 @@ struct EmailConfig {
 fn get_config() -> Result<EmailConfig> {
     // NOTE: variable names are prefixed with ZEROSMTP_ to avoid colliding with
     // reserved/OS-level variables (e.g. USERNAME is auto-set on Windows).
+    // Fail-fast: missing env vars return an error instead of silently using
+    // placeholder credentials that could leak into production.
+    let required = ["ZEROSMTP_USERNAME", "ZEROSMTP_PASSWORD", "ZEROSMTP_FROM", "ZEROSMTP_TO"];
+    let missing: Vec<&str> = required
+        .iter()
+        .filter(|v| env::var(v).is_err())
+        .copied()
+        .collect();
+    if !missing.is_empty() {
+        return Err(anyhow::anyhow!(
+            "missing required environment variables: {}",
+            missing.join(", ")
+        ));
+    }
     Ok(EmailConfig {
-        username: env::var("ZEROSMTP_USERNAME").unwrap_or_else(|_| "your-username".to_string()),
-        password: env::var("ZEROSMTP_PASSWORD").unwrap_or_else(|_| "your-password".to_string()),
-        from: env::var("ZEROSMTP_FROM").unwrap_or_else(|_| "sender@example.com".to_string()),
-        to: env::var("ZEROSMTP_TO").unwrap_or_else(|_| "recipient@example.com".to_string()),
+        username: env::var("ZEROSMTP_USERNAME")?,
+        password: env::var("ZEROSMTP_PASSWORD")?,
+        from: env::var("ZEROSMTP_FROM")?,
+        to: env::var("ZEROSMTP_TO")?,
         subject: env::var("ZEROSMTP_SUBJECT").unwrap_or_else(|_| "Test Email from ZeroSMTP".to_string()),
     })
 }

--- a/ts-zerosmtp.ts
+++ b/ts-zerosmtp.ts
@@ -26,11 +26,19 @@ interface ZeroSMTPConfig {
 
 // NOTE: variable names are prefixed with ZEROSMTP_ to avoid colliding with
 // reserved/OS-level variables (e.g. USERNAME is auto-set on Windows).
+// Fail-fast: missing env vars exit with a clear error instead of silently
+// using placeholder credentials that could leak into production.
+const requiredVars = ['ZEROSMTP_USERNAME', 'ZEROSMTP_PASSWORD', 'ZEROSMTP_FROM', 'ZEROSMTP_TO'] as const;
+const missing = requiredVars.filter((v) => !process.env[v]);
+if (missing.length > 0) {
+  console.error(`ERROR: missing required environment variables: ${missing.join(', ')}`);
+  process.exit(1);
+}
 const config = {
-  username: createUsername(process.env.ZEROSMTP_USERNAME || 'your-username'),
-  password: createPassword(process.env.ZEROSMTP_PASSWORD || 'your-password'),
-  from: createEmailAddress(process.env.ZEROSMTP_FROM || 'sender@example.com'),
-  to: createEmailAddress(process.env.ZEROSMTP_TO || 'recipient@example.com'),
+  username: createUsername(process.env.ZEROSMTP_USERNAME!),
+  password: createPassword(process.env.ZEROSMTP_PASSWORD!),
+  from: createEmailAddress(process.env.ZEROSMTP_FROM!),
+  to: createEmailAddress(process.env.ZEROSMTP_TO!),
   subject: process.env.ZEROSMTP_SUBJECT || 'Test Email from ZeroSMTP',
 } satisfies ZeroSMTPConfig;
 


### PR DESCRIPTION
Two problems found reviewing the workflows.

## The growth bot could never have worked

`growth-bot-weekly.yml` was staged but never committed, so it has never run. That turns out to be lucky, because it was broken four ways over:

- It created discussions with `gh api repos/{repo}/discussions`. **That REST endpoint does not exist** — `createDiscussion` is GraphQL only, and needs a category id the workflow never supplied.
- The failure was swallowed by `|| echo "Could not create (may need discussions enabled)"`, so the run would have reported success while posting nothing. A silent no-op is worse than a red X, because nobody investigates a green tick.
- The first step called `gh repo view` and `gh api` with no `GH_TOKEN` and no fallback, under `set -e`. It would have died there before ever reaching the broken call.
- Leftovers: an `$EOF` sentinel made of two escape characters that stripped nothing, and a `body=` parse that ran twice with the first result immediately discarded.

It also hardcoded *"20 examples across 18 languages"* — stale the moment anyone adds a language — and linked a superseded Microsoft article instead of the [current timeline](https://techcommunity.microsoft.com/blog/exchange/updated-exchange-online-smtp-auth-basic-authentication-deprecation-timeline/4489835).

## Weekly was the wrong cadence

Rewritten to post at **deadline milestones** — 90, 60, 30, 14, 7 and 1 days — rather than every Monday.

A weekly digest posts the same content whether or not anything changed. Announcements filling with near-identical bot posts does not signal an active project; it tells a visitor nobody is home. Six posts across five months, each at a point where the number itself is news, is the version of this somebody might actually want to read.

It runs daily and exits silently on every non-milestone day. Counts are read from the README table instead of written into the workflow. A re-run checks for an existing post before creating a second copy. Renamed to `deadline-milestones.yml` to match what it does.

## Maven 429

The `java` lint job failed on main on 2026-08-16:

```
[ERROR] Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.4.0
        status code: 429, reason phrase: Too Many Requests
```

No fault in the code, but indistinguishable from a real break — and a main branch that is red for reasons nobody can act on trains everyone to ignore CI.

Added `cache: 'maven'` to `setup-java`, which is also the fix for the rate limiting itself since it stops re-downloading the world every run, plus retry flags for when the cache is cold.

## Verification

Structure checked by hand; there is no YAML parser available on this machine at the moment, so the authoritative check is GitHub accepting the workflow on this branch. Worth a glance at the Actions tab before merging.
