### PR TITLE
feat(outreach): add reply drafts, dedup and ranking to the weekly digest

### DIFF
--- a/.github/workflows/outreach-digest.yml
+++ b/.github/workflows/outreach-digest.yml
@@ -6,9 +6,18 @@ name: Weekly outreach digest
 #
 # This workflow never posts, comments, or replies anywhere outside this
 # repository. It only reads public search results and creates one issue
-# here — a discovery aid, not an outreach tool. Whether and how to respond
-# to anything it surfaces is a human decision made by a real person in the
-# linked issue, not something this workflow does automatically.
+# here. Whether and how to respond to anything it surfaces is a human
+# decision made by a real person, not something this workflow does.
+#
+# WHY IT WILL NEVER POST AUTOMATICALLY
+# An account that drops the same reply into other people's threads gets
+# flagged as spam and banned, and deservedly so. The value of a reply is
+# that somebody read the question. A draft below is a starting point for
+# that person, not a substitute for them.
+#
+# The drafts are keyword-matched templates. They are frequently the wrong
+# answer for the thread, which is why every one of them has to be read
+# against the actual question before it goes anywhere.
 
 on:
   schedule:
@@ -31,25 +40,157 @@ jobs:
             // like '"free smtp"' still matches issues where those words
             // appear separately, which produced a lot of noise in testing.
             // Requiring several specific words together, restricted to the
-            // title, cuts that down a lot (a title mentioning all of
-            // "smtp", "free", and "relay" together is a strong signal).
+            // title, cuts that down a lot.
             const queries = [
               'smtp free relay in:title is:issue is:open',
               'smtp free server in:title is:issue is:open',
               'smtp relay recommend in:title is:issue is:open',
               'smtp alternative free in:title is:issue is:open',
               'transactional email free in:title is:issue is:open',
+              'smtp auth disabled in:title is:issue is:open',
+              '5.7.139 in:title is:issue is:open',
             ];
+
+            // Cap on how many candidates go in one digest. A list of forty
+            // is a list nobody reads, and a week where you reply to forty
+            // threads is a week you get reported.
+            const MAX_ITEMS = 8;
 
             const sinceDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
               .toISOString()
               .slice(0, 10);
 
+            // ---- reply drafts -------------------------------------------
+            // Each draft leads with the answer that is NOT this project
+            // where one exists, and discloses the affiliation. A reply that
+            // opens by recommending your own free service reads as an
+            // advert no matter how true it is.
+            const DISCLOSURE =
+              'Disclosure: I run the free relay linked below, so weigh that ' +
+              'accordingly — the first option above costs you nothing and ' +
+              'involves no third party.';
+
+            const DRAFTS = {
+              m365: {
+                label: 'Microsoft 365 SMTP AUTH shutdown',
+                text: [
+                  'That rejection is coming from Microsoft, not from your code.',
+                  'Basic authentication for SMTP AUTH is disabled by default on',
+                  'existing Microsoft 365 tenants at the end of December 2026, and',
+                  'is already off for many tenants through Security Defaults or a',
+                  'Conditional Access policy.',
+                  '',
+                  'Worth establishing which of those applies first, because three of',
+                  'the four causes are still reversible: <https://docs.msgwing.com/ERROR-MESSAGES.html>',
+                  '',
+                  'If it is a device or app that cannot do OAuth, the options in order:',
+                  '',
+                  '1. Firmware or software update, if the vendor shipped one — best answer',
+                  '2. Direct Send, free, if every recipient is inside your own tenant',
+                  '3. An SMTP relay that still accepts a username and password',
+                  '',
+                  DISCLOSURE,
+                  '<https://github.com/msgwing/ZeroSMTP>',
+                ].join('\n'),
+              },
+              printer: {
+                label: 'printer / scan-to-email',
+                text: [
+                  'Before changing SMTP settings, worth checking whether your exact',
+                  'model has an OAuth firmware update — several vendors shipped one,',
+                  'and that keeps mail coming from your own domain:',
+                  '<https://docs.msgwing.com/DEVICE-COMPATIBILITY.html>',
+                  '',
+                  'Some models are explicitly ruled out by the vendor. Konica Minolta',
+                  'marks a set of ineo models "N/A" in their own OAuth column, for',
+                  'instance: <https://docs.msgwing.com/NO-OAUTH-FIRMWARE.html>',
+                  '',
+                  'If the scanner only mails colleagues inside your own tenant,',
+                  'Direct Send is free and is usually the right answer. If it mails',
+                  'outside, it needs a relay that accepts a username and password.',
+                  '',
+                  DISCLOSURE,
+                  '<https://github.com/msgwing/ZeroSMTP>',
+                ].join('\n'),
+              },
+              generic: {
+                label: 'general "free SMTP" question',
+                text: [
+                  'Depends on one thing: does the mail have to come FROM your own',
+                  'domain?',
+                  '',
+                  'If yes, you want a provider where you verify a domain — SMTP2GO,',
+                  'Brevo, Mailgun, Amazon SES all have free tiers for that, and the',
+                  'DNS setup is the price of admission.',
+                  '',
+                  'If the from-address genuinely does not matter — a scanner, a cron',
+                  'job, device alerts — then a shared-domain relay skips the DNS work',
+                  'entirely.',
+                  '',
+                  DISCLOSURE,
+                  '<https://github.com/msgwing/ZeroSMTP>',
+                ].join('\n'),
+              },
+            };
+
+            // Threads where the honest answer is not this project. Drafting
+            // a reply for these is how you become the person who plugs their
+            // service into unrelated conversations.
+            const SKIP_WORDS = [
+              'self-host', 'selfhost', 'self host', 'docker-mailserver',
+              'mailcow', 'postfix config', 'own mail server', 'mailu',
+              'bulk', 'marketing', 'newsletter', 'campaign', 'mass email',
+              'testing', 'mailhog', 'mailpit', 'fake smtp', 'catch-all',
+            ];
+
+            function classify(title, body) {
+              const t = `${title} ${body}`.toLowerCase();
+              if (SKIP_WORDS.some((w) => t.includes(w))) return null;
+              if (/365|office|exchange|5\.7\.139|smtpclientauth|basic auth/.test(t))
+                return DRAFTS.m365;
+              if (/print|scan|mfp|copier|ricoh|kyocera|canon|xerox|konica|brother|epson/.test(t))
+                return DRAFTS.printer;
+              return DRAFTS.generic;
+            }
+
+            // Threads surfaced in earlier digests. Without this the same open
+            // issue reappears every Monday until it is closed, and the second
+            // time you see it you either waste the triage again or reply to a
+            // thread you already replied to.
+            const alreadySeen = new Set();
+            try {
+              const prev = await github.rest.issues.listForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: 'outreach-digest',
+                state: 'all',
+                per_page: 6,
+                sort: 'created',
+                direction: 'desc',
+              });
+              for (const iss of prev.data) {
+                const found = (iss.body || '')
+                  .match(/https:\/\/github\.com\/[^\s)\]]+\/issues\/\d+/g) || [];
+                for (const u of found) alreadySeen.add(u);
+              }
+              core.info(`${alreadySeen.size} thread(s) carried over from earlier digests`);
+            } catch (err) {
+              core.warning(`Could not read earlier digests: ${err.message}`);
+            }
+
             const seen = new Set();
-            const results = [];
+            const candidates = [];
 
             for (const q of queries) {
-              const full = `${q} created:>=${sinceDate} -repo:${context.repo.owner}/${context.repo.repo}`;
+              // -commenter: drops threads already answered here. Replying
+              // twice in one thread is the single most spam-looking thing
+              // an account can do.
+              const full = [
+                q,
+                `created:>=${sinceDate}`,
+                `-repo:${context.repo.owner}/${context.repo.repo}`,
+                `-commenter:${context.repo.owner}`,
+              ].join(' ');
               let res;
               try {
                 res = await github.rest.search.issuesAndPullRequests({ q: full, per_page: 10 });
@@ -60,16 +201,37 @@ jobs:
               for (const item of res.data.items) {
                 if (seen.has(item.html_url)) continue;
                 seen.add(item.html_url);
+                if (alreadySeen.has(item.html_url)) continue;
                 // Bot-authored issues are almost always auto-generated
-                // templates (e.g. recurring "daily challenge" issues) whose
-                // boilerplate body happens to contain enough of our keywords
-                // to match — genuine "I need a free SMTP relay" questions
-                // are asked by humans, not opened by github-actions[bot].
+                // templates whose boilerplate happens to match our keywords.
                 if (item.user && item.user.type === 'Bot') continue;
+
                 const repoPath = item.repository_url.split('/').slice(-2).join('/');
-                results.push(`- [${item.title}](${item.html_url}) — \`${repoPath}\``);
+                const raw = (item.body || '').replace(/\r/g, '').trim();
+                const snippet = raw ? raw.slice(0, 400) : '_(no body)_';
+                const draft = classify(item.title, raw);
+
+                candidates.push({
+                  title: item.title,
+                  url: item.html_url,
+                  repoPath,
+                  comments: item.comments,
+                  snippet,
+                  draft,
+                });
               }
             }
+
+            // Rank before capping, rather than taking whatever the first
+            // query happened to return: a question nobody has answered is
+            // worth more than one with fifteen replies, where anything you
+            // add is noise. Draftable threads sort above skips.
+            candidates.sort((a, b) => {
+              if (!!a.draft !== !!b.draft) return a.draft ? -1 : 1;
+              return a.comments - b.comments;
+            });
+            const results = candidates.slice(0, MAX_ITEMS);
+            core.info(`${candidates.length} candidate(s), showing ${results.length}`);
 
             if (!results.length) {
               core.summary
@@ -79,16 +241,54 @@ jobs:
               return;
             }
 
-            const body = [
-              `Found ${results.length} recent public issue(s) (last 7 days) that may be`,
-              `genuinely asking about free SMTP/email-sending options:`,
+            const parts = [
+              `${results.length} public issue(s) opened in the last 7 days that mention`,
+              'free SMTP or the Microsoft 365 SMTP AUTH shutdown.',
               '',
-              ...results,
+              '**Nothing has been posted anywhere.** These are drafts. Open each',
+              'thread, read the actual question, and only reply where the answer',
+              'genuinely helps that person — editing the draft to fit what they',
+              'actually asked.',
               '',
-              '_Discovery digest only — nothing was posted anywhere automatically._',
-              '_Read each one yourself and decide if/how a genuine, on-topic reply makes sense._',
-            ].join('\n');
+              'One reply per thread, no follow-ups. A thread that already has a',
+              'good answer does not need yours.',
+              '',
+              'Threads from earlier digests, and any thread this account has already',
+              'commented in, are filtered out. What is left is sorted so unanswered',
+              'questions come first — those are the ones where a reply is worth',
+              'something.',
+              '',
+              '---',
+              '',
+            ];
 
+            for (const r of results) {
+              parts.push(`### [${r.title}](${r.url})`);
+              parts.push(`\`${r.repoPath}\` · ${r.comments} comment(s)`);
+              parts.push('');
+              parts.push('> ' + r.snippet.split('\n').join('\n> '));
+              parts.push('');
+              if (!r.draft) {
+                parts.push('**No draft — this looks off-topic for us.** The keywords');
+                parts.push('suggest self-hosting, bulk sending, or a test server, none of');
+                parts.push('which this project is. Skip it unless reading proves otherwise.');
+              } else {
+                parts.push(`**Draft reply** (${r.draft.label}) — read the thread first:`);
+                parts.push('');
+                parts.push('```markdown');
+                parts.push(r.draft.text);
+                parts.push('```');
+              }
+              parts.push('');
+              parts.push('---');
+              parts.push('');
+            }
+
+            parts.push('_Discovery digest only. This workflow never posts outside this_');
+            parts.push('_repository — the drafts above are keyword-matched templates and_');
+            parts.push('_are often the wrong answer for the thread they are attached to._');
+
+            const body = parts.join('\n');
             const title = `Outreach digest — week of ${sinceDate}`;
 
             try {


### PR DESCRIPTION
The digest listed titles and links. Every candidate still meant opening the thread and writing a reply from scratch, so in practice it produced a list nobody worked through.

## Drafts

Each candidate now carries the first 400 characters of the question and a keyword-matched draft reply, in one of three shapes: the Microsoft 365 shutdown, a printer/scan-to-email case, or a general "which free SMTP" question.

**Every draft leads with the answer that is not this project** — re-enable the setting, apply vendor firmware, use Direct Send — and discloses the affiliation before the link. A reply that opens by recommending your own free service reads as an advert however true it is, and that reading is what gets an account reported.

Threads matching self-hosting, bulk-sending or test-server keywords get **no draft at all**, just a note that it looks off-topic. Those are precisely the threads where replying turns this account into the one that plugs its service into unrelated conversations.

## Fixes and additions

- **Candidates are gathered from every query, then ranked, then capped.** The cap previously broke out of the query loop, so once early queries filled it the later ones never ran at all.
- **Ranking puts unanswered questions first.** A thread with fifteen replies does not need a sixteenth; a question nobody has answered is where a reply is worth something.
- **Threads from the last six digests are filtered out.** Without this the same open issue reappears every Monday until it closes, and the second time you either re-triage it or reply twice.
- **`-commenter:` drops threads this account already replied in.** Two replies in one thread is the most spam-looking thing an account can do.

## What it still does not do

It posts nothing outside this repository, and the header says so twice. The drafts are keyword-matched templates, so they are frequently the wrong answer for the thread they are attached to — they are a starting point for somebody who has read the question, not a substitute for reading it.

## Verification

No node or python on this machine right now, so the `github-script` body could not be linted locally. CodeQL's Actions analysis on this PR is the check that matters, and I will run the workflow manually after merge to see the real output rather than assume it works — the growth bot in #111 is a reminder that a green tick and a working bot are different things.
