### PR TITLE
fix(outreach): pace the searches, and stop a rate limit looking like a quiet week

### DIFF
--- a/.github/workflows/outreach-digest.yml
+++ b/.github/workflows/outreach-digest.yml
@@ -180,8 +180,18 @@ jobs:
 
             const seen = new Set();
             const candidates = [];
+            let failedQueries = 0;
 
-            for (const q of queries) {
+            const pause = (ms) => new Promise((r) => setTimeout(r, ms));
+
+            for (const [i, q] of queries.entries()) {
+              // The search API enforces a strict secondary rate limit on
+              // bursts. Firing all of these back to back got the last three
+              // 403'd on 2026-08-16, and because a failed search only warns,
+              // the run then reported "nothing found" - which is a different
+              // thing from "could not look".
+              if (i > 0) await pause(3000);
+
               // -commenter: drops threads already answered here. Replying
               // twice in one thread is the single most spam-looking thing
               // an account can do.
@@ -195,6 +205,7 @@ jobs:
               try {
                 res = await github.rest.search.issuesAndPullRequests({ q: full, per_page: 10 });
               } catch (err) {
+                failedQueries += 1;
                 core.warning(`Search failed for query "${full}": ${err.message}`);
                 continue;
               }
@@ -233,11 +244,24 @@ jobs:
             const results = candidates.slice(0, MAX_ITEMS);
             core.info(`${candidates.length} candidate(s), showing ${results.length}`);
 
+            // "Found nothing" and "could not look" must not produce the same
+            // report. A quiet week is fine; a week where every search was
+            // rejected and the run went green is how a broken bot survives.
+            if (failedQueries === queries.length) {
+              core.setFailed(
+                `All ${queries.length} searches failed - most likely the secondary ` +
+                'rate limit. No digest was written; nothing was missed, but nothing ' +
+                'was checked either.');
+              return;
+            }
+
             if (!results.length) {
-              core.summary
-                .addHeading('Weekly outreach digest')
-                .addRaw('No matching public issues found this week.')
-                .write();
+              const note = failedQueries
+                ? `No new threads found. Note: ${failedQueries} of ${queries.length} ` +
+                  'searches failed, so this is an incomplete look.'
+                : 'No new matching public issues this week.';
+              core.summary.addHeading('Weekly outreach digest').addRaw(note).write();
+              core.info(note);
               return;
             }
 
@@ -258,6 +282,10 @@ jobs:
               'questions come first — those are the ones where a reply is worth',
               'something.',
               '',
+              ...(failedQueries
+                ? [`⚠️ ${failedQueries} of ${queries.length} searches failed this run, so`,
+                   'this list is incomplete.', '']
+                : []),
               '---',
               '',
             ];


### PR DESCRIPTION
Ran the digest for real after merging #113. It went green and produced nothing, which looked like an uneventful week. The log said otherwise:

```
403 ... You have exceeded a secondary rate limit
0 candidate(s), showing 0
```

Seven search queries fired back to back hit GitHub's secondary rate limit on the fifth, and the last three were rejected. A failed search only emitted a warning and continued, so the run reported *"No matching public issues found this week"* — a different claim from *"three of the searches were refused"*.

That is the same failure shape as the growth bot in #111: a green tick over a bot that did not do its job.

## Changes

- **Three seconds between searches.** Seven queries now take about twenty seconds, which no scheduled workflow cares about.
- **Failures are counted.** If every search fails the job fails, so it shows red instead of pretending. If some fail, both the digest body and the run summary say the list is incomplete.

## What did work

The dedup added in #113 behaved correctly — it reported 30 threads carried over from earlier digests, which is why the four searches that did succeed returned nothing new. So the pipeline is sound; it was the pacing that was wrong.
