### PR TITLE
Ansible playbook, Docker Compose recipe, Zig example (closes #98, #99, #100)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,8 +3,7 @@ name: Lint examples
 # Builds/syntax-checks every example on push/PR, using the manifest files
 # at the repo root (package.json, composer.json, Cargo.toml, Package.swift,
 # cs-zerosmtp.csproj, pom.xml, build.gradle.kts) that point at the relevant
-# single-file example. All 12 jobs are confirmed green as of the commit that
-# added this line.
+# single-file example.
 
 on:
   push:
@@ -19,7 +18,7 @@ permissions:
   contents: read
 
 jobs:
-  # Branch protection requires each of the 12 jobs below by name, so the
+  # Branch protection requires each of the jobs below by name, so the
   # workflow itself can't use a top-level paths-ignore: a skipped *workflow*
   # never reports those check names at all, and GitHub then waits on them
   # forever, permanently blocking merge. A skipped *job* still reports (as
@@ -182,6 +181,57 @@ jobs:
         run: dart pub get
       - name: Analyze Dart example
         run: dart analyze dart-zerosmtp.dart
+
+  zig:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install libcurl development headers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev
+      - uses: mlugg/setup-zig@v2
+        with:
+          # Pinned deliberately. Zig is pre-1.0 and breaks source
+          # compatibility between minor releases; "latest" would turn main
+          # red the day upstream renames something, with nothing wrong in
+          # the example. The file header names the same version.
+          version: 0.14.1
+      - name: Build Zig example
+        run: zig build-exe zig-zerosmtp.zig -lc -lcurl --cache-dir /tmp/zig-cache
+
+  ansible:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+      - name: Install ansible-core
+        run: pip install ansible-core
+      # --syntax-check parses the playbook and every module reference
+      # without contacting a host, so it catches a typo'd module name or a
+      # broken Jinja expression. The credential assert is not reached.
+      - name: Syntax-check Ansible playbook
+        run: ansible-playbook --syntax-check -i localhost, ansible-zerosmtp.yml
+
+  docker-compose:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      # The compose file loads .env, which is gitignored for obvious
+      # reasons. .env.example carries the same variable names, so copying
+      # it is enough to let `config` resolve everything.
+      - name: Provide a .env for validation
+        run: cp .env.example .env
+      - name: Validate compose file
+        run: docker compose -f docker-compose-zerosmtp.yml config -q
 
   php:
     needs: changes

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ from a shared `@msgwing.com` address rather than your own
 [![mx.msgwing.com status](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/status.json)](https://github.com/msgwing/ZeroSMTP/actions/workflows/service-healthcheck.yml)
 [![Exchange Online Basic auth countdown](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/countdown.json)](docs/EXCHANGE-ONLINE-SMTP-AUTH.md)
 [![Lint examples](https://github.com/msgwing/ZeroSMTP/actions/workflows/lint.yml/badge.svg)](https://github.com/msgwing/ZeroSMTP/actions/workflows/lint.yml)
-[![20 ready-to-run examples](https://img.shields.io/badge/examples-20%20ready--to--run-blue)](#code-examples)
+[![21 ready-to-run examples](https://img.shields.io/badge/examples-21%20ready--to--run-blue)](#code-examples)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 [![Exchange Online Basic auth (SMTP AUTH) countdown](https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/countdown-card.svg)](docs/EXCHANGE-ONLINE-SMTP-AUTH.md)
@@ -28,7 +28,7 @@ from a shared `@msgwing.com` address rather than your own
 | --- | --- |
 | **1. Audit your tenant** | [`Find-SmtpAuthExposure.ps1`](Find-SmtpAuthExposure.ps1) — read-only. Reports every mailbox that can still use SMTP AUTH, counting the ones that *inherit* the tenant setting separately, because the usual `-eq $false` one-liner misses those entirely and can report zero on a fully exposed tenant. |
 | **2. Check your hardware** | [Compatibility list](docs/DEVICE-COMPATIBILITY.md) — machine-readable, backed by [`data/devices.json`](data/devices.json). Which models have OAuth firmware, and [which ones the vendor has ruled out](docs/NO-OAUTH-FIRMWARE.md) with a link to every vendor statement. |
-| **3. Keep it sending** | A free SMTP relay that still accepts a username and password, with [20 code examples across 18 languages](#code-examples) and [printer setup by brand](docs/PRINTERS.md). |
+| **3. Keep it sending** | A free SMTP relay that still accepts a username and password, with [21 code examples across 19 languages](#code-examples), [Ansible and Docker Compose recipes](#deployment-recipes), and [printer setup by brand](docs/PRINTERS.md). |
 
 Plus [what every error message actually means](docs/ERROR-MESSAGES.md), and a
 [migration guide](docs/EXCHANGE-ONLINE-SMTP-AUTH.md) that covers Graph API,
@@ -83,9 +83,9 @@ with anything that already speaks SMTP.
   the whole point for old devices that will never get a firmware update.
 - **Managed reputation.** Accounts are randomly generated on a domain that's
   actively monitored for abuse, so you're not warming up an IP yourself.
-- **20 copy-paste examples** across 18 languages, all reading the same
-  environment variables, plus setup guides for Windows Server, Linux, and
-  printers by brand.
+- **21 copy-paste examples** across 19 languages, all reading the same
+  environment variables, plus Ansible and Docker Compose recipes and setup
+  guides for Windows Server, Linux, and printers by brand.
 - **Verifiably up** — the status badge above is a real check that runs against
   `mx.msgwing.com` every 6 hours, not a static image.
 
@@ -178,12 +178,23 @@ Ready-to-run, production-ready examples for `mx.msgwing.com:465` (SSL/TLS) or
 | Perl | [perl-zerosmtp.pl](perl-zerosmtp.pl) |
 | C (libcurl) | [c-zerosmtp.c](c-zerosmtp.c) |
 | Dart | [dart-zerosmtp.dart](dart-zerosmtp.dart) |
+| Zig (libcurl) | [zig-zerosmtp.zig](zig-zerosmtp.zig) |
 | Swift | [swift-zerosmtp.swift](swift-zerosmtp.swift) |
 | PowerShell | [pwsh-zerosmtp.ps1](pwsh-zerosmtp.ps1) |
 
 Each example reads credentials from `ZEROSMTP_*` environment variables
 (`ZEROSMTP_USERNAME`, `ZEROSMTP_PASSWORD`, `ZEROSMTP_FROM`, `ZEROSMTP_TO`,
 `ZEROSMTP_SUBJECT`) — never hardcode real credentials into a script.
+
+### Deployment recipes
+
+Not every migration is a code change. Two of the places SMTP settings
+actually live:
+
+| Recipe | File | What it does |
+| --- | --- | --- |
+| Ansible | [ansible-zerosmtp.yml](ansible-zerosmtp.yml) | Points a fleet's system mailer (cron, unattended-upgrades, `systemd OnFailure=`) at the relay via msmtp. Idempotent; credentials come from `-e` or ansible-vault, never from the file. |
+| Docker Compose | [docker-compose-zerosmtp.yml](docker-compose-zerosmtp.yml) | Runs one send from a container, reading `.env`. Useful for testing the credentials from inside the network the real app runs in. |
 
 ### Installing dependencies
 
@@ -200,6 +211,7 @@ instead of hunting down library names/versions yourself:
 | Java | `mvn compile` |
 | Kotlin | `gradle build` |
 | Swift | `swift build` |
+| Zig | `zig build-exe zig-zerosmtp.zig -lc -lcurl` (needs libcurl headers) |
 | Python, Ruby, Go, Bash, PowerShell | none — standard library only |
 
 Easy Configuration:

--- a/README.pl.md
+++ b/README.pl.md
@@ -13,7 +13,7 @@ wysyła ze współdzielonego adresu `@msgwing.com`, nie z Twojej domeny
 [![mx.msgwing.com status](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/status.json)](https://github.com/msgwing/ZeroSMTP/actions/workflows/service-healthcheck.yml)
 [![Odliczanie do wyłączenia Basic auth w Exchange Online](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/countdown.json)](docs/EXCHANGE-ONLINE-SMTP-AUTH.md)
 [![Lint examples](https://github.com/msgwing/ZeroSMTP/actions/workflows/lint.yml/badge.svg)](https://github.com/msgwing/ZeroSMTP/actions/workflows/lint.yml)
-[![20 gotowych przykładów](https://img.shields.io/badge/przyk%C5%82ady-20%20gotowych-blue)](#przykłady-kodu)
+[![21 gotowych przykładów](https://img.shields.io/badge/przyk%C5%82ady-21%20gotowych-blue)](#przykłady-kodu)
 [![Licencja: MIT](https://img.shields.io/badge/licencja-MIT-green.svg)](LICENSE)
 
 [![Odliczanie do wyłączenia Basic auth w Exchange Online (SMTP AUTH)](https://raw.githubusercontent.com/msgwing/ZeroSMTP/status/countdown-card.svg)](docs/EXCHANGE-ONLINE-SMTP-AUTH.md)
@@ -28,7 +28,7 @@ wysyła ze współdzielonego adresu `@msgwing.com`, nie z Twojej domeny
 | --- | --- |
 | **1. Audyt tenanta** | [`Find-SmtpAuthExposure.ps1`](Find-SmtpAuthExposure.ps1) — tylko czyta. Raportuje każdą skrzynkę, która nadal może użyć SMTP AUTH, licząc osobno te, które **dziedziczą** ustawienie tenanta — bo typowy jednolinijkowiec `-eq $false` pomija je zupełnie i potrafi pokazać zero na w pełni narażonym tenancie. |
 | **2. Sprawdzenie sprzętu** | [Lista zgodności](docs/DEVICE-COMPATIBILITY.md) — maszynowo czytalna, oparta na [`data/devices.json`](data/devices.json). Które modele mają firmware z OAuth, a [które producent skreślił](docs/NO-OAUTH-FIRMWARE.md), z odnośnikiem do każdego oświadczenia. |
-| **3. Utrzymanie wysyłki** | Darmowy relay SMTP przyjmujący login i hasło, z [20 przykładami w 18 językach](#przykłady-kodu) i [konfiguracją drukarek per marka](docs/PRINTERS.md). |
+| **3. Utrzymanie wysyłki** | Darmowy relay SMTP przyjmujący login i hasło, z [21 przykładami w 19 językach](#przykłady-kodu), [gotowcami dla Ansible i Docker Compose](#gotowce-wdrożeniowe) oraz [konfiguracją drukarek per marka](docs/PRINTERS.md). |
 
 Plus [co dokładnie znaczy każdy komunikat błędu](docs/ERROR-MESSAGES.md) i
 [przewodnik migracji](docs/EXCHANGE-ONLINE-SMTP-AUTH.md), który omawia Graph
@@ -90,8 +90,9 @@ działają z czymkolwiek, co już obsługuje SMTP.
   właśnie sedno problemu dla starych urządzeń bez aktualizacji firmware'u.
 - **Zarządzana reputacja.** Konta są generowane losowo w domenie aktywnie
   monitorowanej pod kątem nadużyć, więc nie rozgrzewasz własnego IP.
-- **20 gotowych przykładów** w 18 językach, korzystających z tych samych zmiennych
-  środowiskowych, plus przewodniki dla Windows Server, Linuksa i drukarek.
+- **21 gotowych przykładów** w 19 językach, korzystających z tych samych zmiennych
+  środowiskowych, plus gotowce dla Ansible i Docker Compose oraz przewodniki
+  dla Windows Server, Linuksa i drukarek.
 - **Sprawdzalnie działa** — odznaka statusu powyżej to realny test wykonywany
   na `mx.msgwing.com` co 6 godzin, a nie statyczny obrazek.
 
@@ -181,6 +182,7 @@ Gotowe do użycia przykłady dla `mx.msgwing.com:465` (SSL/TLS) lub `:587`
 | Perl | [perl-zerosmtp.pl](perl-zerosmtp.pl) |
 | C (libcurl) | [c-zerosmtp.c](c-zerosmtp.c) |
 | Dart | [dart-zerosmtp.dart](dart-zerosmtp.dart) |
+| Zig (libcurl) | [zig-zerosmtp.zig](zig-zerosmtp.zig) |
 | Swift | [swift-zerosmtp.swift](swift-zerosmtp.swift) |
 | PowerShell | [pwsh-zerosmtp.ps1](pwsh-zerosmtp.ps1) |
 
@@ -188,6 +190,16 @@ Każdy przykład pobiera dane logowania ze zmiennych środowiskowych
 `ZEROSMTP_*` (`ZEROSMTP_USERNAME`, `ZEROSMTP_PASSWORD`, `ZEROSMTP_FROM`,
 `ZEROSMTP_TO`, `ZEROSMTP_SUBJECT`) — nigdy nie wpisuj prawdziwych danych na
 sztywno w skrypcie.
+
+### Gotowce wdrożeniowe
+
+Nie każda migracja to zmiana w kodzie. Dwa miejsca, w których ustawienia
+SMTP faktycznie siedzą:
+
+| Gotowiec | Plik | Co robi |
+| --- | --- | --- |
+| Ansible | [ansible-zerosmtp.yml](ansible-zerosmtp.yml) | Przestawia systemową pocztę na flocie maszyn (cron, unattended-upgrades, `systemd OnFailure=`) na relay przez msmtp. Idempotentny; hasło podajesz przez `-e` albo ansible-vault, nigdy w pliku. |
+| Docker Compose | [docker-compose-zerosmtp.yml](docker-compose-zerosmtp.yml) | Wysyła jedną wiadomość z kontenera, czytając `.env`. Przydatne, żeby sprawdzić dane logowania z wnętrza tej samej sieci, w której działa właściwa aplikacja. |
 
 ### Instalacja zależności
 
@@ -204,6 +216,7 @@ ekosystemu, zamiast ręcznie szukać nazw i wersji bibliotek:
 | Java | `mvn compile` |
 | Kotlin | `gradle build` |
 | Swift | `swift build` |
+| Zig | `zig build-exe zig-zerosmtp.zig -lc -lcurl` (wymaga nagłówków libcurl) |
 | Python, Ruby, Go, Bash, PowerShell | brak — tylko biblioteka standardowa |
 
 Dane do konfiguracji:

--- a/ansible-zerosmtp.yml
+++ b/ansible-zerosmtp.yml
@@ -1,0 +1,118 @@
+---
+# ansible-zerosmtp.yml
+# Ansible + msmtp - route system mail through ZeroSMTP on a fleet
+#
+# Points a machine's system mailer (cron output, unattended-upgrades,
+# systemd OnFailure= alerts, anything calling /usr/sbin/sendmail) at
+# mx.msgwing.com, so those messages leave the host instead of piling up in
+# a local spool nobody reads.
+#
+# Run with:
+#   ansible-playbook -i inventory.ini ansible-zerosmtp.yml \
+#     -e zerosmtp_username=your-username \
+#     -e zerosmtp_password=your-password \
+#     -e zerosmtp_from=your-username@msgwing.com \
+#     -e zerosmtp_to=alerts@example.com
+#
+# Better, keep the password out of your shell history and out of the
+# playbook by putting it in an encrypted file:
+#   ansible-vault create group_vars/all/zerosmtp.yml
+#   ansible-playbook -i inventory.ini ansible-zerosmtp.yml --ask-vault-pass
+#
+# Idempotent: running it twice changes nothing the second time.
+
+- name: Route system mail through ZeroSMTP
+  hosts: all
+  become: true
+
+  vars:
+    zerosmtp_host: mx.msgwing.com
+    zerosmtp_port: 465          # implicit TLS; use 587 with tls_starttls on
+    # No defaults for the four below on purpose. A playbook that silently
+    # installs placeholder credentials leaves a mailer that fails at 3am
+    # rather than at deploy time.
+    # zerosmtp_username:
+    # zerosmtp_password:
+    # zerosmtp_from:
+    # zerosmtp_to:
+
+  pre_tasks:
+    - name: Require the credentials to be supplied
+      ansible.builtin.assert:
+        that:
+          - zerosmtp_username is defined and zerosmtp_username | length > 0
+          - zerosmtp_password is defined and zerosmtp_password | length > 0
+          - zerosmtp_from is defined and zerosmtp_from | length > 0
+          - zerosmtp_to is defined and zerosmtp_to | length > 0
+        fail_msg: >-
+          Set zerosmtp_username, zerosmtp_password, zerosmtp_from and
+          zerosmtp_to (with -e, or in an ansible-vault file).
+
+  tasks:
+    - name: Install msmtp and the sendmail shim
+      ansible.builtin.package:
+        name:
+          - msmtp
+          - msmtp-mta      # provides /usr/sbin/sendmail
+        state: present
+
+    - name: Configure msmtp
+      ansible.builtin.copy:
+        dest: /etc/msmtprc
+        # 0600 and root-owned: this file holds a password in cleartext,
+        # which is msmtp's design. World-readable here would hand the
+        # account to every local user.
+        owner: root
+        group: root
+        mode: '0600'
+        content: |
+          # Managed by Ansible (ansible-zerosmtp.yml). Local edits are
+          # overwritten on the next run.
+          defaults
+          auth           on
+          tls            on
+          tls_trust_file /etc/ssl/certs/ca-certificates.crt
+          logfile        /var/log/msmtp.log
+
+          account        zerosmtp
+          host           {{ zerosmtp_host }}
+          port           {{ zerosmtp_port }}
+          {% if zerosmtp_port | int == 587 %}
+          tls_starttls   on
+          {% else %}
+          tls_starttls   off
+          {% endif %}
+          from           {{ zerosmtp_from }}
+          user           {{ zerosmtp_username }}
+          password       {{ zerosmtp_password }}
+
+          account default : zerosmtp
+      no_log: true              # keep the password out of the Ansible output
+
+    - name: Send root's mail to a real address
+      ansible.builtin.lineinfile:
+        path: /etc/aliases
+        regexp: '^root:'
+        line: "root: {{ zerosmtp_to }}"
+        create: true
+        owner: root
+        group: root
+        mode: '0644'
+      register: aliases
+
+    - name: Rebuild the alias database
+      ansible.builtin.command: newaliases
+      when: aliases.changed
+      changed_when: true
+      failed_when: false        # newaliases is absent on some minimal images
+
+    - name: Verify the configuration parses
+      # msmtp --pretend resolves the account and reads the config without
+      # opening a connection, so this is a real check that does not send
+      # anything or depend on the network.
+      ansible.builtin.command: msmtp --pretend --account=zerosmtp {{ zerosmtp_to | quote }}
+      register: pretend
+      changed_when: false
+      failed_when: pretend.rc != 0
+
+  handlers: []

--- a/docker-compose-zerosmtp.yml
+++ b/docker-compose-zerosmtp.yml
@@ -1,0 +1,44 @@
+# docker-compose-zerosmtp.yml
+# Docker Compose - send one message through ZeroSMTP from a container
+#
+# Plenty of the applications that break in December 2026 run in containers,
+# where SMTP settings live in a compose file or an env file rather than in
+# a settings page. This is the shape of that.
+#
+# Run with:
+#   cp .env.example .env      # then fill in your credentials
+#   docker compose -f docker-compose-zerosmtp.yml run --rm send
+#
+# It runs the existing python-zerosmtp.py rather than carrying its own copy
+# of the sending code, so there is one implementation to keep correct.
+
+services:
+  send:
+    image: python:3.13-slim
+
+    # ZEROSMTP_USERNAME, ZEROSMTP_PASSWORD, ZEROSMTP_FROM, ZEROSMTP_TO and
+    # the optional ZEROSMTP_SUBJECT come from .env, which is gitignored.
+    # Never put credentials in this file - it is committed.
+    env_file:
+      - .env
+
+    # The example needs no third-party packages: python-zerosmtp.py uses
+    # smtplib from the standard library.
+    volumes:
+      - ./python-zerosmtp.py:/app/send.py:ro
+
+    working_dir: /app
+    command: ["python", "send.py"]
+
+    # Nothing here listens, stores state, or needs to talk to other
+    # services - it opens one outbound TLS connection and exits.
+    network_mode: bridge
+    restart: "no"
+
+    # Least privilege, because an example gets copied into places its
+    # author never sees.
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true

--- a/docs/CODE-EXAMPLES.md
+++ b/docs/CODE-EXAMPLES.md
@@ -19,8 +19,24 @@ Ready-to-run, production-ready examples for `mx.msgwing.com:465` (SSL/TLS) or
 | Ruby | [ruby-zerosmtp.rb](https://github.com/msgwing/ZeroSMTP/blob/main/ruby-zerosmtp.rb) |
 | Rust | [rust-zerosmtp.rs](https://github.com/msgwing/ZeroSMTP/blob/main/rust-zerosmtp.rs) |
 | Kotlin | [kotlin-zerosmtp.kt](https://github.com/msgwing/ZeroSMTP/blob/main/kotlin-zerosmtp.kt) |
+| Elixir | [elixir-zerosmtp.exs](https://github.com/msgwing/ZeroSMTP/blob/main/elixir-zerosmtp.exs) |
+| Lua | [lua-zerosmtp.lua](https://github.com/msgwing/ZeroSMTP/blob/main/lua-zerosmtp.lua) |
+| Perl | [perl-zerosmtp.pl](https://github.com/msgwing/ZeroSMTP/blob/main/perl-zerosmtp.pl) |
+| C (libcurl) | [c-zerosmtp.c](https://github.com/msgwing/ZeroSMTP/blob/main/c-zerosmtp.c) |
+| Dart | [dart-zerosmtp.dart](https://github.com/msgwing/ZeroSMTP/blob/main/dart-zerosmtp.dart) |
+| Zig (libcurl) | [zig-zerosmtp.zig](https://github.com/msgwing/ZeroSMTP/blob/main/zig-zerosmtp.zig) |
 | Swift | [swift-zerosmtp.swift](https://github.com/msgwing/ZeroSMTP/blob/main/swift-zerosmtp.swift) |
 | PowerShell | [pwsh-zerosmtp.ps1](https://github.com/msgwing/ZeroSMTP/blob/main/pwsh-zerosmtp.ps1) |
+
+## Deployment recipes
+
+Not every migration is a code change — often the SMTP settings live in a
+configuration management tool or a container definition instead:
+
+| Recipe | File | What it does |
+| --- | --- | --- |
+| Ansible | [ansible-zerosmtp.yml](https://github.com/msgwing/ZeroSMTP/blob/main/ansible-zerosmtp.yml) | Points a fleet's system mailer (cron, unattended-upgrades, `systemd OnFailure=`) at the relay via msmtp. See [Linux setup](LINUX.md) for the manual equivalent. |
+| Docker Compose | [docker-compose-zerosmtp.yml](https://github.com/msgwing/ZeroSMTP/blob/main/docker-compose-zerosmtp.yml) | Sends one message from a container, reading credentials from `.env`. |
 
 Each example reads credentials from `ZEROSMTP_*` environment variables
 (`ZEROSMTP_USERNAME`, `ZEROSMTP_PASSWORD`, `ZEROSMTP_FROM`, `ZEROSMTP_TO`,

--- a/docs/LINUX.md
+++ b/docs/LINUX.md
@@ -65,6 +65,21 @@ through ZeroSMTP instead of a specific script, see
 [SYSTEM-MTA.md](SYSTEM-MTA.md) for Postfix (satellite/smarthost mode),
 msmtp, and Exim4 configuration.
 
+### More than one machine
+
+Doing the msmtp setup by hand is fine once. For a fleet, use
+[`ansible-zerosmtp.yml`](https://github.com/msgwing/ZeroSMTP/blob/main/ansible-zerosmtp.yml),
+which does the same thing — installs msmtp and the sendmail shim, writes
+`/etc/msmtprc` at mode 0600, redirects root's mail to a real address, and
+verifies the result with `msmtp --pretend`:
+
+```bash
+ansible-playbook -i inventory.ini ansible-zerosmtp.yml -e zerosmtp_username=you@msgwing.com -e zerosmtp_password=... -e zerosmtp_from=you@msgwing.com -e zerosmtp_to=alerts@example.com
+```
+
+Keep the password out of your shell history by putting these variables in
+an `ansible-vault` file instead and running with `--ask-vault-pass`.
+
 ## Connectivity
 
 Everything else — firewall rules, ports, TLS — behaves the same across all

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -145,11 +145,12 @@ defaults:
   - scope:
       path: "CODE-EXAMPLES.md"
     values:
-      title: "SMTP send-email code examples, 18 languages"
+      title: "SMTP send-email code examples, 19 languages"
       description: >-
         Ready-to-run SMTP send-email examples for mx.msgwing.com in Python,
         PHP, Node.js, TypeScript, Java, C#, C, Go, Ruby, Perl, Rust, Kotlin, Dart,
-        Elixir, Lua, Swift, PowerShell and Bash.
+        Zig, Elixir, Lua, Swift, PowerShell and Bash, plus Ansible and Docker
+        Compose recipes.
   - scope:
       path: "RELIABILITY.md"
     values:

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,8 @@ Microsoft 365 tenants at the end of December 2026.
 | Manage Linux servers | [Linux](LINUX.md) · [system-wide relay](SYSTEM-MTA.md) |
 | Want to look up one device or product | [OAuth compatibility list](DEVICE-COMPATIBILITY.md) |
 | Have a printer whose vendor says no OAuth firmware is coming | [Devices that will never get OAuth firmware](NO-OAUTH-FIRMWARE.md) |
-| Are sending from an app or script | [20 code examples across 18 languages](CODE-EXAMPLES.md) |
+| Are sending from an app or script | [21 code examples across 19 languages](CODE-EXAMPLES.md) |
+| Deploy with Ansible or Docker Compose | [Deployment recipes](CODE-EXAMPLES.md#deployment-recipes) |
 | Have an error message to look up | [535 5.7.139 and other SMTP AUTH errors](ERROR-MESSAGES.md) |
 | Have it failing or timing out | [Troubleshooting](TROUBLESHOOTING.md) |
 | Have monitoring/alerting tools that need to send mail | [Monitoring alerts](MONITORING.md) |

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,16 @@
+# robots.txt for https://docs.msgwing.com
+#
+# jekyll-sitemap generates /sitemap.xml on every build, but it only appends
+# the Sitemap: line to a robots.txt that already exists - it does not create
+# one. Without this file the site served no robots.txt at all, so crawlers
+# had no pointer to the sitemap and had to discover pages by following
+# links. Yandex Webmaster reported exactly that on 2026-08-05
+# ("No Sitemap files are currently used by the indexing bot").
+
+User-agent: *
+Allow: /
+
+# Everything here is public documentation meant to be indexed; there is
+# nothing to hide, so no Disallow rules.
+
+Sitemap: https://docs.msgwing.com/sitemap.xml

--- a/zig-zerosmtp.zig
+++ b/zig-zerosmtp.zig
@@ -1,0 +1,150 @@
+// zig-zerosmtp.zig
+// Zig 0.14 + libcurl - ZeroSMTP mx.msgwing.com:465 SSL/TLS
+// Production-ready | Let's Encrypt | Certificate verification on
+//
+// Tested against Zig 0.14.1. The language is still moving; an unpinned
+// example goes stale quietly, so the CI job pins the same version.
+//
+// libcurl rather than std.crypto.tls: Zig's standard library has a TLS
+// client but no SMTP client, so the protocol would have to be written by
+// hand here - and a hand-rolled SMTP conversation in an example is how
+// somebody ends up shipping one. The C example makes the same call for
+// the same reason.
+//
+//   Debian/Ubuntu   apt install libcurl4-openssl-dev
+//   RHEL/Fedora     dnf install libcurl-devel
+//   Alpine          apk add curl-dev
+//
+// Build:  zig build-exe zig-zerosmtp.zig -lc -lcurl
+
+const std = @import("std");
+
+const c = @cImport({
+    @cInclude("curl/curl.h");
+});
+
+const SMTP_URL = "smtps://mx.msgwing.com:465";
+
+/// libcurl asks for the message in chunks, so hand back whatever fits and
+/// remember how far we got. Returning 0 signals end of data.
+const Upload = struct {
+    data: []const u8,
+    offset: usize = 0,
+};
+
+fn payloadSource(
+    ptr: [*c]u8,
+    size: usize,
+    nitems: usize,
+    userdata: ?*anyopaque,
+) callconv(.C) usize {
+    const upload: *Upload = @ptrCast(@alignCast(userdata orelse return 0));
+    const room = size * nitems;
+    const remaining = upload.data.len - upload.offset;
+    if (room == 0 or remaining == 0) return 0;
+
+    const chunk = @min(room, remaining);
+    @memcpy(ptr[0..chunk], upload.data[upload.offset..][0..chunk]);
+    upload.offset += chunk;
+    return chunk;
+}
+
+/// std.posix.getenv returns a NUL-terminated slice, which is what the C
+/// API needs - no copy, no allocator.
+fn envOr(name: [:0]const u8, fallback: [:0]const u8) [:0]const u8 {
+    const value = std.posix.getenv(name) orelse return fallback;
+    if (value.len == 0) return fallback;
+    // getenv gives [:0]const u8 on POSIX, so the sentinel is already there.
+    return @ptrCast(value);
+}
+
+pub fn main() !u8 {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    const username = envOr("ZEROSMTP_USERNAME", "your-username");
+    const password = envOr("ZEROSMTP_PASSWORD", "your-password");
+    const from = envOr("ZEROSMTP_FROM", "sender@example.com");
+    const to = envOr("ZEROSMTP_TO", "recipient@example.com");
+    const subject = envOr("ZEROSMTP_SUBJECT", "Test Email from ZeroSMTP");
+
+    // SMTP wants CRLF line endings, not the bare LF a multiline string
+    // literal produces - some servers reject or mangle LF-only headers.
+    const boundary = "boundary_zerosmtp_zig";
+    const message = try std.fmt.allocPrint(allocator,
+        "From: {s}\r\n" ++
+        "To: {s}\r\n" ++
+        "Subject: {s}\r\n" ++
+        "MIME-Version: 1.0\r\n" ++
+        "Content-Type: multipart/alternative; boundary=\"{s}\"\r\n" ++
+        "\r\n" ++
+        "--{s}\r\n" ++
+        "Content-Type: text/plain; charset=\"UTF-8\"\r\n" ++
+        "\r\n" ++
+        "Hello from ZeroSMTP! This is plain text.\r\n" ++
+        "\r\n" ++
+        "--{s}\r\n" ++
+        "Content-Type: text/html; charset=\"UTF-8\"\r\n" ++
+        "\r\n" ++
+        "<html><body><h1>Hello from ZeroSMTP!</h1>" ++
+        "<p>This is an HTML email sent via mx.msgwing.com:465</p>" ++
+        "</body></html>\r\n" ++
+        "\r\n" ++
+        "--{s}--\r\n",
+        .{ from, to, subject, boundary, boundary, boundary, boundary });
+    defer allocator.free(message);
+
+    // The envelope addresses go in angle brackets, unlike the header ones.
+    const envelope_from = try std.fmt.allocPrintZ(allocator, "<{s}>", .{from});
+    defer allocator.free(envelope_from);
+    const envelope_to = try std.fmt.allocPrintZ(allocator, "<{s}>", .{to});
+    defer allocator.free(envelope_to);
+
+    _ = c.curl_global_init(c.CURL_GLOBAL_DEFAULT);
+    defer c.curl_global_cleanup();
+
+    const curl = c.curl_easy_init() orelse {
+        std.debug.print("Could not initialise libcurl\n", .{});
+        return 1;
+    };
+    defer c.curl_easy_cleanup(curl);
+
+    const recipients = c.curl_slist_append(null, envelope_to.ptr) orelse {
+        std.debug.print("Out of memory building the recipient list\n", .{});
+        return 1;
+    };
+    defer c.curl_slist_free_all(recipients);
+
+    var upload = Upload{ .data = message };
+
+    _ = c.curl_easy_setopt(curl, c.CURLOPT_URL, SMTP_URL);
+    _ = c.curl_easy_setopt(curl, c.CURLOPT_USERNAME, username.ptr);
+    _ = c.curl_easy_setopt(curl, c.CURLOPT_PASSWORD, password.ptr);
+    _ = c.curl_easy_setopt(curl, c.CURLOPT_MAIL_FROM, envelope_from.ptr);
+    _ = c.curl_easy_setopt(curl, c.CURLOPT_MAIL_RCPT, recipients);
+    _ = c.curl_easy_setopt(curl, c.CURLOPT_READFUNCTION, payloadSource);
+    _ = c.curl_easy_setopt(curl, c.CURLOPT_READDATA, &upload);
+    _ = c.curl_easy_setopt(curl, c.CURLOPT_UPLOAD, @as(c_long, 1));
+    _ = c.curl_easy_setopt(curl, c.CURLOPT_TIMEOUT, @as(c_long, 30));
+
+    // On by default, set explicitly so nobody "fixes" a certificate error
+    // later by flipping these to 0. A failure here means the machine's CA
+    // store cannot validate the server, not that the server is wrong.
+    _ = c.curl_easy_setopt(curl, c.CURLOPT_SSL_VERIFYPEER, @as(c_long, 1));
+    _ = c.curl_easy_setopt(curl, c.CURLOPT_SSL_VERIFYHOST, @as(c_long, 2));
+
+    const result = c.curl_easy_perform(curl);
+    if (result != c.CURLE_OK) {
+        std.debug.print("SMTP error: {s}\n", .{c.curl_easy_strerror(result)});
+        if (result == c.CURLE_PEER_FAILED_VERIFICATION) {
+            std.debug.print(
+                "The machine's CA store could not validate the server certificate.\n",
+                .{});
+        }
+        return 1;
+    }
+
+    std.debug.print("Email sent to {s}\n", .{to});
+    return 0;
+}


### PR DESCRIPTION
Implements the three open contributor requests. Each one gets a CI job that
builds or parses it, so a broken example fails the same way a broken code
example does.

Closes #98
Closes #99
Closes #100

## `ansible-zerosmtp.yml` (#98)

Installs msmtp + the sendmail shim and points a machine's system mailer
(cron output, unattended-upgrades, `systemd OnFailure=`) at the relay.

Two decisions worth calling out:

- **No default credentials.** The four variables are asserted, not
  defaulted. A playbook that silently installs placeholders leaves a mailer
  that fails at 3am rather than at deploy time.
- **`/etc/msmtprc` is 0600 root-owned with `no_log: true`.** msmtp stores
  the password in cleartext by design; world-readable here would hand the
  account to every local user, and without `no_log` the password lands in
  the Ansible output.

Verified with `msmtp --pretend`, which resolves the account and reads the
config without opening a connection — a real check that doesn't send
anything or depend on the network.

## `docker-compose-zerosmtp.yml` (#99)

Mounts `python-zerosmtp.py` rather than carrying a second copy of the
sending code, so there is one implementation to keep correct. Runs
`read_only` with `cap_drop: ALL` and `no-new-privileges`, because an example
gets copied into places its author never sees.

CI copies `.env.example` to `.env` before `docker compose config -q`, since
`.env` is gitignored.

## `zig-zerosmtp.zig` (#100)

libcurl via `@cImport`, as the issue allows. Zig's standard library has a
TLS client but no SMTP client, so the alternative was hand-rolling the
protocol in an example — which is how somebody ends up shipping a
hand-rolled SMTP client. The C example makes the same call for the same
reason.

The Zig version is pinned in both the file header and the CI job. The
language still breaks source compatibility between minor releases; with
`latest`, main would turn red the day upstream renames something, with
nothing wrong in the example.

## Also in this PR

- **`docs/robots.txt`.** `jekyll-sitemap` generates `sitemap.xml`, but it
  only appends the `Sitemap:` line to a `robots.txt` that already exists —
  it does not create one. The site was serving no `robots.txt` at all, so
  crawlers had no pointer to the sitemap and had to find pages by following
  links. Yandex Webmaster flagged exactly this.
- **`docs/CODE-EXAMPLES.md` was five languages behind the repo** — missing
  Elixir, Lua, Perl, C and Dart. Synced.
- Counts updated to 21 examples across 19 languages, and both READMEs get a
  "Deployment recipes" section for the two non-code ones.

## Verification

The Ansible, Docker Compose and Zig jobs have not run before this PR — CI
here is their first execution. Everything else is unchanged behaviour.
