### PR TITLE
Support readiness for the December wave + monthly advisory review

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,48 @@
+# Routes people to an answer before they open an issue.
+#
+# The Microsoft 365 Basic auth default-off date is the end of December 2026,
+# and the questions arriving around it are overwhelmingly the same four:
+# "why 535 5.7.139", "does my printer have OAuth firmware", "why does the
+# send hang", "can I use my own domain". All four already have a written
+# answer. Pointing at it beats retyping it.
+#
+# Blank issues stay enabled: somebody hitting a genuinely new problem in the
+# middle of a broken-mail incident should not have to pick a category first.
+blank_issues_enabled: true
+
+contact_links:
+  - name: "535 5.7.139 or another SMTP error"
+    url: https://docs.msgwing.com/ERROR-MESSAGES.html
+    about: >-
+      What each SMTP AUTH error actually means, and which of them are still
+      reversible before the end of December 2026.
+
+  - name: "Does my printer, MFP or NAS support OAuth?"
+    url: https://docs.msgwing.com/DEVICE-COMPATIBILITY.html
+    about: >-
+      Vendor-by-vendor status, with a link to the advisory behind every row.
+      Models the vendor has ruled out are listed separately.
+
+  - name: "The send hangs or times out"
+    url: https://docs.msgwing.com/TROUBLESHOOTING.html
+    about: >-
+      Most first-run failures are a cloud provider blocking outbound port 587
+      or 465, not a misconfiguration. Start here.
+
+  - name: "Can I send from my own domain? What are the limits?"
+    url: https://docs.msgwing.com/FAQ.html
+    about: >-
+      No to the first (shared @msgwing.com sender) and 200 messages/day to
+      the second. The FAQ explains why both are the way they are.
+
+  - name: "Question about using the relay"
+    url: https://github.com/msgwing/ZeroSMTP/discussions/categories/q-a
+    about: >-
+      Ask in Discussions rather than Issues. Answers there stay findable for
+      the next person with the same question.
+
+  - name: "Report abuse coming from an @msgwing.com address"
+    url: mailto:abuse@msgwing.com
+    about: >-
+      Email abuse@msgwing.com with headers. Do not open a public issue -
+      abuse reports contain other people's addresses.

--- a/.github/ISSUE_TEMPLATE/device_report.yml
+++ b/.github/ISSUE_TEMPLATE/device_report.yml
@@ -1,0 +1,91 @@
+name: Device report
+description: Tell us what a specific printer, MFP, NAS or application actually did
+title: "[device] "
+labels: ["printers", "docs"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This is the part of the project nobody else can copy. Vendors publish
+        headline model lists; firmware branches, regional model names and OEM
+        rebadges drift away from them. A report from someone holding the
+        hardware is worth more than another row copied out of an advisory.
+
+        Confirming that a device **works** is just as useful as reporting one
+        that doesn't — an empty row is what makes the next reader unsure.
+
+  - type: input
+    id: vendor
+    attributes:
+      label: Vendor
+      placeholder: Ricoh, Kyocera, Konica Minolta, Synology, Veeam...
+    validations:
+      required: true
+
+  - type: input
+    id: model
+    attributes:
+      label: Exact model string
+      description: >-
+        As printed on the device or shown in its web interface, not the
+        marketing name. Regional variants differ.
+      placeholder: MP C4504ex
+    validations:
+      required: true
+
+  - type: dropdown
+    id: status
+    attributes:
+      label: OAuth status
+      description: The meanings are documented at the top of data/devices.json.
+      options:
+        - "none-planned — the vendor has said no OAuth firmware is coming"
+        - "available — OAuth works on this model"
+        - "partial — works on some firmware versions or sub-models only"
+        - "check-advisory — the vendor publishes a per-model list"
+        - "unsupported — no OAuth capability for this purpose"
+        - "I don't know — I just know what happened when I tried"
+    validations:
+      required: true
+
+  - type: input
+    id: firmware
+    attributes:
+      label: Firmware or software version
+      placeholder: "1.09 / DSM 7.2.1 / Veeam B&R 12.1"
+
+  - type: textarea
+    id: what_happened
+    attributes:
+      label: What happened
+      description: >-
+        What you configured, what it did, and the exact error if there was
+        one. If a menu was somewhere other than where the manual says, that
+        detail is worth more than it looks.
+      placeholder: |
+        Set SMTP to mx.msgwing.com:587 with STARTTLS. The device refused the
+        certificate until I ...
+    validations:
+      required: true
+
+  - type: input
+    id: evidence
+    attributes:
+      label: Evidence URL
+      description: >-
+        A vendor advisory, support article or forum thread anyone can open.
+        The build script refuses an entry without one — a compatibility list
+        is only worth citing if every row can be checked. Leave this blank if
+        all you have is your own experience; that still belongs in
+        docs/DEVICE-CASE-STUDIES.md, which credits you by username.
+      placeholder: https://www.ricoh.com/info/2025/0526_1
+
+  - type: checkboxes
+    id: contribute
+    attributes:
+      label: Optional
+      options:
+        - label: >-
+            I'd rather open the pull request myself — point me at the file and
+            I'll add the row.
+          required: false

--- a/.github/workflows/advisory-review.yml
+++ b/.github/workflows/advisory-review.yml
@@ -1,0 +1,132 @@
+name: Vendor advisory review
+
+# The compatibility list is only worth citing if it is current. Vendors keep
+# publishing and revising SMTP AUTH advisories through 2026, and a page that
+# quietly froze in August is worse than no page - it reads as authoritative
+# while being wrong.
+#
+# This opens one issue a month with a checklist built from data/devices.json
+# itself, so the vendor list cannot drift out of sync with the data the way a
+# hardcoded list would. It does not scrape anything: reading a vendor's
+# advisory and deciding what changed is the part that needs a person.
+
+on:
+  schedule:
+    # 07:00 UTC on the 1st of each month.
+    - cron: '0 7 1 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const data = JSON.parse(fs.readFileSync('data/devices.json', 'utf8'));
+
+            const LABEL = 'advisory-review';
+
+            // One open review issue at a time. If last month's is still open,
+            // the backlog is the problem and a second issue does not help.
+            const open = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: LABEL,
+            });
+            if (open.data.length > 0) {
+              core.notice(
+                `Issue #${open.data[0].number} is still open - not opening another.`);
+              return;
+            }
+
+            // `updated` is a plain YYYY-MM-DD string maintained by hand in the
+            // data file; treat a missing or unparseable value as "unknown"
+            // rather than guessing a date.
+            const updated = data.updated;
+            const parsed = Date.parse(updated);
+            const staleDays = Number.isNaN(parsed)
+              ? null
+              : Math.floor((Date.now() - parsed) / 86400000);
+
+            const entries = data.entries || [];
+
+            // Group by vendor so a vendor with several product lines is one
+            // checklist line, not four.
+            const byVendor = new Map();
+            for (const e of entries) {
+              if (!byVendor.has(e.vendor)) byVendor.set(e.vendor, []);
+              byVendor.get(e.vendor).push(e);
+            }
+
+            const checklist = [...byVendor.entries()]
+              .sort((a, b) => a[0].localeCompare(b[0]))
+              .map(([vendor, rows]) => {
+                const links = rows
+                  .map(r => r.evidence)
+                  .filter((url, i, all) => url && all.indexOf(url) === i)
+                  .map(url => `[advisory](${url})`)
+                  .join(' · ');
+                const statuses = [...new Set(rows.map(r => r.status))].join(', ');
+                return `- [ ] **${vendor}** — currently \`${statuses}\` — ${links}`;
+              })
+              .join('\n');
+
+            const staleLine = staleDays === null
+              ? `\`updated\` in data/devices.json is \`${updated}\`, which could not be parsed as a date.`
+              : `data/devices.json was last marked updated **${updated}** — ${staleDays} days ago.`;
+
+            const body = [
+              'Monthly check that the compatibility list still matches what the',
+              'vendors are publishing. Nothing here is automated on purpose:',
+              'deciding whether an advisory changed in a way that matters is the',
+              'part that needs reading.',
+              '',
+              staleLine,
+              '',
+              `Currently tracking **${entries.length} entries** across`,
+              `**${byVendor.size} vendors**.`,
+              '',
+              '## Re-check each advisory',
+              '',
+              checklist,
+              '',
+              '## What to look for',
+              '',
+              '- A model moving off the "no OAuth firmware" list — that is the',
+              '  single most valuable change to catch, because',
+              '  [NO-OAUTH-FIRMWARE.md](../blob/main/docs/NO-OAUTH-FIRMWARE.md)',
+              '  tells people their hardware is a write-off.',
+              '- New models added to an existing advisory.',
+              '- A vendor publishing an advisory for the first time — those are',
+              '  new rows, and the reason to keep doing this.',
+              '- A dead link. An entry whose evidence URL 404s cannot be checked',
+              '  by a reader and should be replaced or removed.',
+              '',
+              '## When something changed',
+              '',
+              '1. Edit [`data/devices.json`](../blob/main/data/devices.json) and',
+              '   bump its `updated` field.',
+              '2. Run `python tools/build-device-table.py` to regenerate the',
+              '   docs table. CI fails if you skip it.',
+              '',
+              'Close this issue when the pass is done, even if nothing changed —',
+              'that is a useful signal too.',
+            ].join('\n');
+
+            const created = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Vendor advisory review — ${new Date().toISOString().slice(0, 7)}`,
+              body,
+              labels: [LABEL, 'docs', 'printers'],
+            });
+            core.notice(`Opened #${created.data.number}`);

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -33,7 +33,11 @@ jobs:
           # Uwaga: "pinned" to ETYKIETA, nie przypiecie w interfejsie GitHuba.
           # actions/stale nie widzi przypietych issues, wiec samo przypiecie
           # niczego nie chroni.
-          exempt-issue-labels: 'service-alert,pinned,security,help wanted,good first issue'
+          # advisory-review is exempt because advisory-review.yml refuses to
+          # open a new one while the previous is still open. Letting the bot
+          # close it would silently switch the monthly check back on without
+          # anybody having done the pass.
+          exempt-issue-labels: 'service-alert,pinned,security,help wanted,good first issue,advisory-review'
           exempt-pr-labels: 'pinned'
           stale-issue-message: >
             This issue has had no activity for 60 days and will be closed in

--- a/README.md
+++ b/README.md
@@ -110,6 +110,15 @@ scan-to-email · IoT and device notifications · homelabs.
 
 Setup guides: [Network printers](docs/PRINTERS.md) · [Popular applications](docs/APPS.md) · [Linux (Debian/Ubuntu/Rocky/Fedora/openSUSE)](docs/LINUX.md) · [System-wide mail relay (Postfix/msmtp/Exim4)](docs/SYSTEM-MTA.md) · [Windows Server](docs/WINDOWS-SERVER.md) · [Exchange Online SMTP AUTH migration](docs/EXCHANGE-ONLINE-SMTP-AUTH.md) · [Monitoring alerts](docs/MONITORING.md) · [OAuth compatibility list](docs/DEVICE-COMPATIBILITY.md) · [No OAuth firmware coming](docs/NO-OAUTH-FIRMWARE.md) · [Device case studies](docs/DEVICE-CASE-STUDIES.md) · [Troubleshooting](docs/TROUBLESHOOTING.md) · [Reliability (retries)](docs/RELIABILITY.md) · [vs. other free relays](docs/ALTERNATIVES.md) · [FAQ](docs/FAQ.md)
 
+> **Did this get a specific device sending again?** Tell us which one — a
+> [device report](https://github.com/msgwing/ZeroSMTP/issues/new?template=device_report.yml)
+> takes a couple of minutes. Vendors publish headline model lists; firmware
+> branches, regional names and OEM rebadges drift away from them, so a report
+> from someone holding the hardware is the part of
+> [the compatibility list](docs/DEVICE-COMPATIBILITY.md) nobody else can copy.
+> Confirming a device that *works* is just as useful as reporting one that
+> doesn't.
+
 ## How does this compare to other options?
 
 |  | ZeroSMTP | Gmail SMTP relay | Amazon SES | Mailgun / SendGrid / Brevo (typical free tier) |

--- a/README.pl.md
+++ b/README.pl.md
@@ -113,6 +113,15 @@ monitoringu · skan-do-mail · powiadomień IoT · homelabów.
 
 Przewodniki konfiguracji: [Drukarki sieciowe](docs/PRINTERS.md) · [Popularne aplikacje](docs/APPS.md) · [Linux (Debian/Ubuntu/Rocky/Fedora/openSUSE)](docs/LINUX.md) · [Systemowy relay pocztowy (Postfix/msmtp/Exim4)](docs/SYSTEM-MTA.md) · [Windows Server](docs/WINDOWS-SERVER.md) · [Migracja z Exchange Online SMTP AUTH](docs/EXCHANGE-ONLINE-SMTP-AUTH.md) · [Alerty monitoringu](docs/MONITORING.md) · [Lista zgodności OAuth](docs/DEVICE-COMPATIBILITY.md) · [Urządzenia bez firmware z OAuth](docs/NO-OAUTH-FIRMWARE.md) · [Przypadki konkretnych urządzeń](docs/DEVICE-CASE-STUDIES.md) · [Rozwiązywanie problemów](docs/TROUBLESHOOTING.md) · [Niezawodność (ponawianie prób)](docs/RELIABILITY.md) · [FAQ](docs/FAQ.md)
 
+> **Udało Ci się dzięki temu przywrócić wysyłkę na konkretnym urządzeniu?**
+> Napisz na jakim — [zgłoszenie urządzenia](https://github.com/msgwing/ZeroSMTP/issues/new?template=device_report.yml)
+> zajmuje kilka minut. Producenci publikują ogólne listy modeli, ale gałęzie
+> firmware'u, nazwy regionalne i rebrandingi OEM się od nich rozjeżdżają —
+> dlatego zgłoszenie od kogoś, kto ma sprzęt pod ręką, to ta część
+> [listy zgodności](docs/DEVICE-COMPATIBILITY.md), której nikt inny nie
+> skopiuje. Potwierdzenie, że urządzenie *działa*, jest tak samo przydatne jak
+> zgłoszenie takiego, które nie działa.
+
 ## Jak to wypada na tle innych opcji?
 
 |  | ZeroSMTP | Gmail SMTP relay | Amazon SES | Mailgun / SendGrid / Brevo (typowy darmowy plan) |


### PR DESCRIPTION
Three items from the December 2026 plan. All of them have to be in place
*before* the traffic arrives, not during it.

## 1. Issue routing — `.github/ISSUE_TEMPLATE/config.yml`

The questions arriving around the Basic auth default-off date are
overwhelmingly the same four:

- what `535 5.7.139` means
- whether a given printer has OAuth firmware
- why the send hangs
- whether you can send from your own domain

All four already have a written answer, so `contact_links` point straight at
them, plus Discussions Q&A for anything else and `abuse@` for abuse reports
(which must not become public issues — they contain other people's
addresses).

Blank issues stay **enabled**. Somebody hitting a genuinely new problem in
the middle of a broken-mail incident should not have to pick a category
first.

## 2. Device report form — `.github/ISSUE_TEMPLATE/device_report.yml`

Structured fields matching `data/devices.json`, so a report arrives in a
shape that can become a row instead of needing a round-trip.

Two things it says on purpose:

- **Confirming a device that works is as useful as reporting one that
  doesn't.** An empty row is what leaves the next reader unsure.
- **No evidence URL is not a rejection.** The build refuses an entry without
  one, but that report still belongs in `docs/DEVICE-CASE-STUDIES.md`, which
  credits contributors by username. Turning those people away loses the
  reports that are hardest to get.

## 3. Monthly advisory review — `.github/workflows/advisory-review.yml`

`AFFECTED-SYSTEMS.md` and `data/devices.json` grow organically as vendors
publish through 2026. A compatibility page that quietly froze in August is
*worse* than not having one: it reads as authoritative while being wrong.

Opens one issue a month with a checklist **generated from
`data/devices.json` itself**, so the vendor list cannot drift from the data
the way a hardcoded list would. It deliberately scrapes nothing — deciding
whether an advisory changed in a way that matters is the part that needs a
person reading it.

Guards:

- Only one review issue open at a time. If last month's is still open, the
  backlog is the problem and a second issue doesn't help.
- `stale.yml` exempts the `advisory-review` label. Letting the bot close it
  would silently re-arm the monthly check without anybody having done the
  pass.
- An unparseable `updated` field reports "could not be parsed" instead of
  guessing a date.

The `advisory-review` label already exists in the repo.

## Verification

`workflow_dispatch` is enabled on the new workflow, so it can be run once
manually after merge to confirm it produces a sensible issue rather than
waiting for the 1st.
