### PR TITLE
Add Brother to the OAuth compatibility list

### DIFF
--- a/data/devices.json
+++ b/data/devices.json
@@ -16,7 +16,7 @@
     "  check-advisory  vendor publishes a per-model list we do not reproduce",
     "  unsupported     the product has no OAuth capability for this purpose"
   ],
-  "updated": "2026-08-11",
+  "updated": "2026-08-16",
   "entries": [
     {
       "vendor": "Konica Minolta / DEVELOP",
@@ -52,6 +52,14 @@
       "models": [],
       "evidence": "https://www.ricoh.com/info/2025/0526_1",
       "notes": "Ricoh publishes affected products with per-product firmware status. Not reproduced here because the list is long and revised; check the model against the advisory."
+    },
+    {
+      "vendor": "Brother",
+      "product": "printers, MFPs and document scanners",
+      "status": "check-advisory",
+      "models": [],
+      "evidence": "https://support.brother.com/g/b/oscontents.aspx?c=us&lang=en&ossid=42",
+      "notes": "Brother publishes a per-model Product Support List and states plainly that a machine not on it does not support OAuth 2.0, with no firmware promised - the vendor's own guidance for those owners is to use a different mail service. Listed models split into two tiers: OAuth already present, or present after a firmware update that is already downloadable. Affects Scan to Email Server, Internet Fax, Email Reports and Email Notifications. Check the exact model: support is firmware-dependent as well as model-dependent."
     },
     {
       "vendor": "Canon",

--- a/docs/DEVICE-COMPATIBILITY.md
+++ b/docs/DEVICE-COMPATIBILITY.md
@@ -37,6 +37,7 @@ answer.
 | **Microsoft** Dynamics NAV / Business Central | Some models or versions | — | [advisory](https://www.innovia.com/blog/microsoft-to-retire-basic-auth-smtp-for-exchange-online-what-bc-nav-users-need-to-know) |
 | **Veeam** Backup for Microsoft 365 and related products | Some models or versions | — | [advisory](https://helpcenter.veeam.com/docs/vbo365/guide/smtp_server.html) |
 | **Xerox** ConnectKey printers and MFPs | Some models or versions | `VersaLink B415`, `VersaLink C415`, `VersaLink B620`, `VersaLink C620`, `VersaLink B625`, `VersaLink C625`, `AltaLink`, `PrimeLink` | [advisory](https://www.xerox.com/en-us/office/insights/exchange-online-authentication) |
+| **Brother** printers, MFPs and document scanners | Check vendor advisory | — | [advisory](https://support.brother.com/g/b/oscontents.aspx?c=us&lang=en&ossid=42) |
 | **Cerberus** FTP Server | Check vendor advisory | — | [advisory](https://support.cerberusftp.com/hc/en-us/articles/24103821642643-Troubleshooting-SMTP-Setup-Error-on-Office365-com-Resolving-EHLO-Message-Failure-535-5-7-139-Authentication-Unsuccessful-Basic-Authentication-Disabled) |
 | **Cisco** Unity Connection | Check vendor advisory | — | [advisory](https://learn.microsoft.com/en-us/exchange/clients-and-mobile-in-exchange-online/deprecation-of-basic-authentication-exchange-online) |
 | **Faxination** fax server | Check vendor advisory | — | [advisory](https://faxination.com/microsoft-timeline-for-basic-authentication-deprecation-in-exchange-online-smtp-auth/) |
@@ -66,6 +67,9 @@ Older versions support SMTP basic auth only; newer versions added OAuth. Upgradi
 **Xerox — ConnectKey printers and MFPs**  
 Device Code Flow is supported broadly; Client Credentials Flow only on the ConnectKey models listed. Devices not on Xerox's supported-firmware list are the problem cases and are not promised an update. Affects Scan to Email, Internet Fax (Send), Fax Forward to Email and Auto Email Notifications.
 
+**Brother — printers, MFPs and document scanners**  
+Brother publishes a per-model Product Support List and states plainly that a machine not on it does not support OAuth 2.0, with no firmware promised - the vendor's own guidance for those owners is to use a different mail service. Listed models split into two tiers: OAuth already present, or present after a firmware update that is already downloadable. Affects Scan to Email Server, Internet Fax, Email Reports and Email Notifications. Check the exact model: support is firmware-dependent as well as model-dependent.
+
 **Cerberus — FTP Server**  
 Vendor support article covers the exact 535 5.7.139 failure.
 
@@ -90,7 +94,7 @@ Ricoh publishes affected products with per-product firmware status. Not reproduc
 **Microsoft — Teams Rooms**  
 Microsoft's own product. Enable modern auth on the resource account - no relay needed.
 
-*14 entries, last reviewed 2026-08-11.*
+*15 entries, last reviewed 2026-08-16.*
 
 <!-- END GENERATED TABLE -->
 


### PR DESCRIPTION
Brother publishes an [OAuth 2.0 Authentication Support Statement](https://support.brother.com/g/b/oscontents.aspx?c=us&lang=en&ossid=42)
with a per-model Product Support List, and states plainly that a machine
**not** on that list does not support OAuth 2.0 — with no firmware promised.
The vendor's own guidance for those owners is to use a different mail
service.

That is the same shape as the Konica Minolta and Xerox entries already in
the list, and Brother has a large enough SMB installed base that its absence
was a real gap.

**Recorded as `check-advisory`**, not by reproducing the model list: the list
is long, split across product categories (inkjet, mono laser, colour laser,
document scanners) and revised over time. Copying it here would mean
maintaining a stale second copy.

Two things from the advisory are in the notes because they change what a
reader should do:

- Listed models split into **two tiers** — OAuth already present, versus
  present only after a firmware update that is already downloadable. "My
  model is listed" does not mean "my machine works today".
- Affects Scan to Email Server, Internet Fax, Email Reports and Email
  Notifications.

## HP was researched and deliberately left out

The only HP-hosted document I found (FutureSmart scan-to-email with OAuth
2.0) would not load on two attempts, and every other source was a reseller
blog restating it. An entry whose evidence URL cannot be opened fails the
rule at the top of `data/devices.json` — a compatibility list is only worth
citing if each row can be checked. Worth a second attempt later.

## Note on verification

`docs/DEVICE-COMPATIBILITY.md` was regenerated **by hand**, not with
`tools/build-device-table.py` — there is no working Python on the machine
this was written on. I reproduced the script's sort order (status rank, then
vendor, then product) and its formatting manually. **The `device-table` CI
job is the actual verification here**; if it fails, the hand-generated table
drifted and needs the script run over it.
