### PR TITLE
August advisory review: four entries corrected or expanded

### DIFF
--- a/data/devices.json
+++ b/data/devices.json
@@ -25,12 +25,16 @@
       "models": [
         "ineo 306", "ineo 7228", "ineo 266",
         "ineo+ 266", "ineo+ 256", "ineo+ 226",
+        "ineo 4752", "ineo 4052",
         "ineo 4750", "ineo 4050",
+        "ineo+ 3110", "ineo+ 3100P",
+        "ineo+ 754e", "ineo+ 654e",
+        "ineo 246", "ineo 236", "ineo 226", "ineo 216",
         "ineo 4700P", "ineo 3301P", "ineo 4000P",
         "ineo 165 variants", "ineo 185 variants"
       ],
       "evidence": "https://www.develop.eu/en/support/discontinuation-of-basic-authentication-for-smtp.html",
-      "notes": "Marked \"N/A\" in the vendor's own OAuth column. The advisory points these owners at a different mail service rather than at an update. Other ineo product groups in the same advisory do have OAuth firmware - check the exact model."
+      "notes": "Marked \"N/A\" in the vendor's own OAuth column. The advisory points these owners at a different mail service rather than at an update. Other ineo product groups in the same advisory do have OAuth firmware - check the exact model. A third category exists that is neither: several Product Group 10 models are listed as \"Under planning\" with no release date, so their owners have no answer yet in either direction."
     },
     {
       "vendor": "Xerox",
@@ -51,7 +55,7 @@
       "status": "check-advisory",
       "models": [],
       "evidence": "https://www.ricoh.com/info/2025/0526_1",
-      "notes": "Ricoh publishes affected products with per-product firmware status. Not reproduced here because the list is long and revised; check the model against the advisory."
+      "notes": "Ricoh publishes affected products with per-product firmware status, revised on 2026-01-30 into two tables - products with released OAuth firmware, and products newly added - plus a third group the Ricoh Firmware Update Tool cannot update, where the local representative has to do it. Not reproduced here because the list is long and still moving; check the model against the advisory. Ricoh does not say any product is permanently excluded, but for devices still waiting its own recommendation is to stop relying on email from the device or to use a mail service other than Exchange Online."
     },
     {
       "vendor": "Brother",
@@ -91,7 +95,7 @@
       "status": "partial",
       "models": [],
       "evidence": "https://helpcenter.veeam.com/docs/vbo365/guide/smtp_server.html",
-      "notes": "Older versions support SMTP basic auth only; newer versions added OAuth. Upgrading is the fix where the version supports it."
+      "notes": "Corrected 2026-08-16 - the previous note claimed newer versions added OAuth for SMTP, which the linked page does not support. The v8 documentation offers \"SMTP server (basic authentication)\" and does not describe an OAuth option for SMTP notifications; modern app-only authentication appears elsewhere in the product, for Entra applications, not here. So the fix is not \"upgrade and SMTP gets OAuth\" - check whether your build offers a notification method that is not SMTP at all, and treat the SMTP path as basic-auth only."
     },
     {
       "vendor": "Cisco",
@@ -131,7 +135,7 @@
       "status": "check-advisory",
       "models": [],
       "evidence": "https://www.manageengine.com/network-monitoring/how-to/fix-smtpclientauth-disabled-error.html",
-      "notes": "Vendor publishes a fix guide for the SMTPClientAuth error."
+      "notes": "OpManager supports OAuth 2.0 from build 126306, so for anyone on that build or later this is a settings change rather than a migration - the vendor's guide states it directly. The same page also documents re-enabling SMTP AUTH in the Exchange admin centre, which works until the end of December 2026 and not after; treat it as breathing room, not a fix."
     },
     {
       "vendor": "Cerberus",

--- a/docs/DEVICE-COMPATIBILITY.md
+++ b/docs/DEVICE-COMPATIBILITY.md
@@ -31,7 +31,7 @@ answer.
 
 | System | OAuth status | Named models | Evidence |
 | --- | --- | --- | --- |
-| **[Konica Minolta / DEVELOP](devices/konica-minolta-develop-ineo-and-ineo-mfps.md)** ineo and ineo+ MFPs | **No OAuth firmware planned** | `ineo 306`, `ineo 7228`, `ineo 266`, `ineo+ 266`, `ineo+ 256`, `ineo+ 226`, `ineo 4750`, `ineo 4050`, `ineo 4700P`, `ineo 3301P`, `ineo 4000P`, `ineo 165 variants`, `ineo 185 variants` | [advisory](https://www.develop.eu/en/support/discontinuation-of-basic-authentication-for-smtp.html) |
+| **[Konica Minolta / DEVELOP](devices/konica-minolta-develop-ineo-and-ineo-mfps.md)** ineo and ineo+ MFPs | **No OAuth firmware planned** | `ineo 306`, `ineo 7228`, `ineo 266`, `ineo+ 266`, `ineo+ 256`, `ineo+ 226`, `ineo 4752`, `ineo 4052`, `ineo 4750`, `ineo 4050`, `ineo+ 3110`, `ineo+ 3100P`, `ineo+ 754e`, `ineo+ 654e`, `ineo 246`, `ineo 236`, `ineo 226`, `ineo 216`, `ineo 4700P`, `ineo 3301P`, `ineo 4000P`, `ineo 165 variants`, `ineo 185 variants` | [advisory](https://www.develop.eu/en/support/discontinuation-of-basic-authentication-for-smtp.html) |
 | **[Canon](devices/canon-maxify-mb2755.md)** Maxify MB2755 | No OAuth for this purpose | `Maxify MB2755` | [advisory](https://github.com/msgwing/ZeroSMTP/blob/main/docs/DEVICE-CASE-STUDIES.md) |
 | **[QNAP](devices/qnap-nas-notification-settings.md)** NAS notification settings | No OAuth for this purpose | — | [advisory](https://gist.github.com/msgwing/39958d909e085ae9cc0e6b3584d930bf) |
 | **[Microsoft](devices/microsoft-dynamics-nav-business-central.md)** Dynamics NAV / Business Central | Some models or versions | — | [advisory](https://www.innovia.com/blog/microsoft-to-retire-basic-auth-smtp-for-exchange-online-what-bc-nav-users-need-to-know) |
@@ -50,7 +50,7 @@ answer.
 ### Notes per entry
 
 **Konica Minolta / DEVELOP — ineo and ineo+ MFPs**  
-Marked "N/A" in the vendor's own OAuth column. The advisory points these owners at a different mail service rather than at an update. Other ineo product groups in the same advisory do have OAuth firmware - check the exact model.
+Marked "N/A" in the vendor's own OAuth column. The advisory points these owners at a different mail service rather than at an update. Other ineo product groups in the same advisory do have OAuth firmware - check the exact model. A third category exists that is neither: several Product Group 10 models are listed as "Under planning" with no release date, so their owners have no answer yet in either direction.
 
 **Canon — Maxify MB2755**  
 Separate failure mode from OAuth: the firmware ships a fixed root CA store predating current Let's Encrypt roots, so certificate validation fails regardless of authentication. Hardware-confirmed, unchanged after a firmware update. Verification has to be disabled on the device.
@@ -62,7 +62,7 @@ The notification settings accept username and password only; there is no OAuth o
 Newer Business Central handles modern auth. Older on-prem NAV installs generally need the SMTP account repointed.
 
 **Veeam — Backup for Microsoft 365 and related products**  
-Older versions support SMTP basic auth only; newer versions added OAuth. Upgrading is the fix where the version supports it.
+Corrected 2026-08-16 - the previous note claimed newer versions added OAuth for SMTP, which the linked page does not support. The v8 documentation offers "SMTP server (basic authentication)" and does not describe an OAuth option for SMTP notifications; modern app-only authentication appears elsewhere in the product, for Entra applications, not here. So the fix is not "upgrade and SMTP gets OAuth" - check whether your build offers a notification method that is not SMTP at all, and treat the SMTP path as basic-auth only.
 
 **Xerox — ConnectKey printers and MFPs**  
 Device Code Flow is supported broadly; Client Credentials Flow only on the ConnectKey models listed. Devices not on Xerox's supported-firmware list are the problem cases and are not promised an update. Affects Scan to Email, Internet Fax (Send), Fax Forward to Email and Auto Email Notifications.
@@ -86,10 +86,10 @@ Vendor published a timeline notice. Apply their update if one exists for the ver
 Workflow emails failing on Basic auth removal, reported in the vendor's own community.
 
 **ManageEngine — OpManager**  
-Vendor publishes a fix guide for the SMTPClientAuth error.
+OpManager supports OAuth 2.0 from build 126306, so for anyone on that build or later this is a settings change rather than a migration - the vendor's guide states it directly. The same page also documents re-enabling SMTP AUTH in the Exchange admin centre, which works until the end of December 2026 and not after; treat it as breathing room, not a fix.
 
 **Ricoh — multifunction printers**  
-Ricoh publishes affected products with per-product firmware status. Not reproduced here because the list is long and revised; check the model against the advisory.
+Ricoh publishes affected products with per-product firmware status, revised on 2026-01-30 into two tables - products with released OAuth firmware, and products newly added - plus a third group the Ricoh Firmware Update Tool cannot update, where the local representative has to do it. Not reproduced here because the list is long and still moving; check the model against the advisory. Ricoh does not say any product is permanently excluded, but for devices still waiting its own recommendation is to stop relying on email from the device or to use a mail service other than Exchange Online.
 
 **Microsoft — Teams Rooms**  
 Microsoft's own product. Enable modern auth on the resource account - no relay needed.

--- a/docs/devices/konica-minolta-develop-ineo-and-ineo-mfps.md
+++ b/docs/devices/konica-minolta-develop-ineo-and-ineo-mfps.md
@@ -15,7 +15,7 @@ The vendor has stated that no OAuth firmware is coming for these models. This is
 
 ## What the vendor says
 
-Marked "N/A" in the vendor's own OAuth column. The advisory points these owners at a different mail service rather than at an update. Other ineo product groups in the same advisory do have OAuth firmware - check the exact model.
+Marked "N/A" in the vendor's own OAuth column. The advisory points these owners at a different mail service rather than at an update. Other ineo product groups in the same advisory do have OAuth firmware - check the exact model. A third category exists that is neither: several Product Group 10 models are listed as "Under planning" with no release date, so their owners have no answer yet in either direction.
 
 [Read the vendor's statement in full](https://www.develop.eu/en/support/discontinuation-of-basic-authentication-for-smtp.html)  
 Everything on this page comes from that document. If it and this page disagree, the vendor is right and this page is out of date — [say so](https://github.com/msgwing/ZeroSMTP/issues/new?template=device_report.yml).
@@ -28,8 +28,18 @@ Everything on this page comes from that document. If it and this page disagree, 
 - `ineo+ 266`
 - `ineo+ 256`
 - `ineo+ 226`
+- `ineo 4752`
+- `ineo 4052`
 - `ineo 4750`
 - `ineo 4050`
+- `ineo+ 3110`
+- `ineo+ 3100P`
+- `ineo+ 754e`
+- `ineo+ 654e`
+- `ineo 246`
+- `ineo 236`
+- `ineo 226`
+- `ineo 216`
 - `ineo 4700P`
 - `ineo 3301P`
 - `ineo 4000P`

--- a/docs/devices/manageengine-opmanager.md
+++ b/docs/devices/manageengine-opmanager.md
@@ -15,7 +15,7 @@ The vendor publishes a per-model list and revises it over time, so it is not cop
 
 ## What the vendor says
 
-Vendor publishes a fix guide for the SMTPClientAuth error.
+OpManager supports OAuth 2.0 from build 126306, so for anyone on that build or later this is a settings change rather than a migration - the vendor's guide states it directly. The same page also documents re-enabling SMTP AUTH in the Exchange admin centre, which works until the end of December 2026 and not after; treat it as breathing room, not a fix.
 
 [Read the vendor's statement in full](https://www.manageengine.com/network-monitoring/how-to/fix-smtpclientauth-disabled-error.html)  
 Everything on this page comes from that document. If it and this page disagree, the vendor is right and this page is out of date — [say so](https://github.com/msgwing/ZeroSMTP/issues/new?template=device_report.yml).

--- a/docs/devices/ricoh-multifunction-printers.md
+++ b/docs/devices/ricoh-multifunction-printers.md
@@ -15,7 +15,7 @@ The vendor publishes a per-model list and revises it over time, so it is not cop
 
 ## What the vendor says
 
-Ricoh publishes affected products with per-product firmware status. Not reproduced here because the list is long and revised; check the model against the advisory.
+Ricoh publishes affected products with per-product firmware status, revised on 2026-01-30 into two tables - products with released OAuth firmware, and products newly added - plus a third group the Ricoh Firmware Update Tool cannot update, where the local representative has to do it. Not reproduced here because the list is long and still moving; check the model against the advisory. Ricoh does not say any product is permanently excluded, but for devices still waiting its own recommendation is to stop relying on email from the device or to use a mail service other than Exchange Online.
 
 [Read the vendor's statement in full](https://www.ricoh.com/info/2025/0526_1)  
 Everything on this page comes from that document. If it and this page disagree, the vendor is right and this page is out of date — [say so](https://github.com/msgwing/ZeroSMTP/issues/new?template=device_report.yml).

--- a/docs/devices/veeam-backup-for-microsoft-365-and-related-products.md
+++ b/docs/devices/veeam-backup-for-microsoft-365-and-related-products.md
@@ -15,7 +15,7 @@ OAuth exists for part of the range. The model or version number decides, which m
 
 ## What the vendor says
 
-Older versions support SMTP basic auth only; newer versions added OAuth. Upgrading is the fix where the version supports it.
+Corrected 2026-08-16 - the previous note claimed newer versions added OAuth for SMTP, which the linked page does not support. The v8 documentation offers "SMTP server (basic authentication)" and does not describe an OAuth option for SMTP notifications; modern app-only authentication appears elsewhere in the product, for Entra applications, not here. So the fix is not "upgrade and SMTP gets OAuth" - check whether your build offers a notification method that is not SMTP at all, and treat the SMTP path as basic-auth only.
 
 [Read the vendor's statement in full](https://helpcenter.veeam.com/docs/vbo365/guide/smtp_server.html)  
 Everything on this page comes from that document. If it and this page disagree, the vendor is right and this page is out of date — [say so](https://github.com/msgwing/ZeroSMTP/issues/new?template=device_report.yml).


### PR DESCRIPTION
Working the checklist in #119. Five vendors re-read; four had moved since
their entries were written. One of those was our own error.

## Veeam — the entry was wrong

The note said *"newer versions added OAuth. Upgrading is the fix where the
version supports it."* The linked page does not support that. The v8
documentation offers **"SMTP server (basic authentication)"** and describes
no OAuth option for SMTP notifications at all. Modern app-only
authentication exists elsewhere in the product — for Entra applications —
not here.

Corrected to say what the evidence actually shows. "Upgrade and SMTP gets
OAuth" would have sent somebody down a path that does not exist, which is
the specific failure this list is supposed to prevent.

## Konica Minolta / DEVELOP — ten more dead-end models

The vendor's OAuth column marks these N/A too, and the entry did not list
them: `ineo 4752`, `4052`, `246`, `236`, `226`, `216`, `ineo+ 3110`,
`3100P`, `754e`, `654e`. 13 named models → 23.

Also records a category the entry missed entirely: several Product Group 10
models are **"Under planning"** with no release date. Their owners have no
answer in either direction, which is a different situation from being ruled
out and shouldn't be collapsed into it.

## Ricoh — advisory revised 2026-01-30

Now two tables (released firmware, newly added) plus a third group the Ricoh
Firmware Update Tool cannot update, where a local representative has to do
it. Ricoh still names no permanently excluded product — but its own advice
for devices still waiting is to stop relying on device email or use a mail
service other than Exchange Online. That is worth recording precisely
because it is the vendor saying it.

## ManageEngine — a concrete version number

OpManager supports OAuth 2.0 **from build 126306**. The entry had none of
that. The same page documents re-enabling SMTP AUTH in the Exchange admin
centre; recorded as breathing room until the end of December 2026, not a
fix.

## Unchanged

QNAP and Xerox re-read, no change. Xerox still lists the same six VersaLink
models for Client Credentials Flow.

## Still outstanding on #119

Eight vendors remain on the checklist, plus the HP gap noted there. Brother
was added and read today so it needs no re-check this cycle.
