### PR TITLE
Give the generated pages a direct path to signing up

### DIFF
--- a/docs/devices/brother-printers-mfps-and-document-scanners.md
+++ b/docs/devices/brother-printers-mfps-and-document-scanners.md
@@ -30,7 +30,9 @@ Once firmware is ruled out, three options remain, and they differ more than they
 
 The [migration guide](../EXCHANGE-ONLINE-SMTP-AUTH.md) walks through all of them, including Graph API and paid relays, and the [quiz on that page](../EXCHANGE-ONLINE-SMTP-AUTH.md#zc-quiz) gives a recommendation you can link to.
 
-[ZeroSMTP](https://github.com/msgwing/ZeroSMTP#quickstart) is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+
+[Create a free account](https://msgwing.com) · [what to put in the device's SMTP fields](../PRINTERS.md) · [the code examples](../CODE-EXAMPLES.md)
 
 ## Related
 

--- a/docs/devices/canon-maxify-mb2755.md
+++ b/docs/devices/canon-maxify-mb2755.md
@@ -36,7 +36,9 @@ Once firmware is ruled out, three options remain, and they differ more than they
 
 The [migration guide](../EXCHANGE-ONLINE-SMTP-AUTH.md) walks through all of them, including Graph API and paid relays, and the [quiz on that page](../EXCHANGE-ONLINE-SMTP-AUTH.md#zc-quiz) gives a recommendation you can link to.
 
-[ZeroSMTP](https://github.com/msgwing/ZeroSMTP#quickstart) is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+
+[Create a free account](https://msgwing.com) · [what to put in the device's SMTP fields](../PRINTERS.md) · [the code examples](../CODE-EXAMPLES.md)
 
 ## Related
 

--- a/docs/devices/cerberus-ftp-server.md
+++ b/docs/devices/cerberus-ftp-server.md
@@ -30,7 +30,9 @@ Once firmware is ruled out, three options remain, and they differ more than they
 
 The [migration guide](../EXCHANGE-ONLINE-SMTP-AUTH.md) walks through all of them, including Graph API and paid relays, and the [quiz on that page](../EXCHANGE-ONLINE-SMTP-AUTH.md#zc-quiz) gives a recommendation you can link to.
 
-[ZeroSMTP](https://github.com/msgwing/ZeroSMTP#quickstart) is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+
+[Create a free account](https://msgwing.com) · [what to put in the device's SMTP fields](../PRINTERS.md) · [the code examples](../CODE-EXAMPLES.md)
 
 ## Related
 

--- a/docs/devices/cisco-unity-connection.md
+++ b/docs/devices/cisco-unity-connection.md
@@ -30,7 +30,9 @@ Once firmware is ruled out, three options remain, and they differ more than they
 
 The [migration guide](../EXCHANGE-ONLINE-SMTP-AUTH.md) walks through all of them, including Graph API and paid relays, and the [quiz on that page](../EXCHANGE-ONLINE-SMTP-AUTH.md#zc-quiz) gives a recommendation you can link to.
 
-[ZeroSMTP](https://github.com/msgwing/ZeroSMTP#quickstart) is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+
+[Create a free account](https://msgwing.com) · [what to put in the device's SMTP fields](../PRINTERS.md) · [the code examples](../CODE-EXAMPLES.md)
 
 ## Related
 

--- a/docs/devices/faxination-fax-server.md
+++ b/docs/devices/faxination-fax-server.md
@@ -30,7 +30,9 @@ Once firmware is ruled out, three options remain, and they differ more than they
 
 The [migration guide](../EXCHANGE-ONLINE-SMTP-AUTH.md) walks through all of them, including Graph API and paid relays, and the [quiz on that page](../EXCHANGE-ONLINE-SMTP-AUTH.md#zc-quiz) gives a recommendation you can link to.
 
-[ZeroSMTP](https://github.com/msgwing/ZeroSMTP#quickstart) is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+
+[Create a free account](https://msgwing.com) · [what to put in the device's SMTP fields](../PRINTERS.md) · [the code examples](../CODE-EXAMPLES.md)
 
 ## Related
 

--- a/docs/devices/konica-minolta-develop-ineo-and-ineo-mfps.md
+++ b/docs/devices/konica-minolta-develop-ineo-and-ineo-mfps.md
@@ -58,7 +58,9 @@ Once firmware is ruled out, three options remain, and they differ more than they
 
 The [migration guide](../EXCHANGE-ONLINE-SMTP-AUTH.md) walks through all of them, including Graph API and paid relays, and the [quiz on that page](../EXCHANGE-ONLINE-SMTP-AUTH.md#zc-quiz) gives a recommendation you can link to.
 
-[ZeroSMTP](https://github.com/msgwing/ZeroSMTP#quickstart) is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+
+[Create a free account](https://msgwing.com) · [what to put in the device's SMTP fields](../PRINTERS.md) · [the code examples](../CODE-EXAMPLES.md)
 
 ## Related
 

--- a/docs/devices/kyocera-mfps-reporting-send-error-1102.md
+++ b/docs/devices/kyocera-mfps-reporting-send-error-1102.md
@@ -30,7 +30,9 @@ Once firmware is ruled out, three options remain, and they differ more than they
 
 The [migration guide](../EXCHANGE-ONLINE-SMTP-AUTH.md) walks through all of them, including Graph API and paid relays, and the [quiz on that page](../EXCHANGE-ONLINE-SMTP-AUTH.md#zc-quiz) gives a recommendation you can link to.
 
-[ZeroSMTP](https://github.com/msgwing/ZeroSMTP#quickstart) is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+
+[Create a free account](https://msgwing.com) · [what to put in the device's SMTP fields](../PRINTERS.md) · [the code examples](../CODE-EXAMPLES.md)
 
 ## Related
 

--- a/docs/devices/laserfiche-workflow-email.md
+++ b/docs/devices/laserfiche-workflow-email.md
@@ -30,7 +30,9 @@ Once firmware is ruled out, three options remain, and they differ more than they
 
 The [migration guide](../EXCHANGE-ONLINE-SMTP-AUTH.md) walks through all of them, including Graph API and paid relays, and the [quiz on that page](../EXCHANGE-ONLINE-SMTP-AUTH.md#zc-quiz) gives a recommendation you can link to.
 
-[ZeroSMTP](https://github.com/msgwing/ZeroSMTP#quickstart) is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+
+[Create a free account](https://msgwing.com) · [what to put in the device's SMTP fields](../PRINTERS.md) · [the code examples](../CODE-EXAMPLES.md)
 
 ## Related
 

--- a/docs/devices/manageengine-opmanager.md
+++ b/docs/devices/manageengine-opmanager.md
@@ -30,7 +30,9 @@ Once firmware is ruled out, three options remain, and they differ more than they
 
 The [migration guide](../EXCHANGE-ONLINE-SMTP-AUTH.md) walks through all of them, including Graph API and paid relays, and the [quiz on that page](../EXCHANGE-ONLINE-SMTP-AUTH.md#zc-quiz) gives a recommendation you can link to.
 
-[ZeroSMTP](https://github.com/msgwing/ZeroSMTP#quickstart) is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+
+[Create a free account](https://msgwing.com) · [what to put in the device's SMTP fields](../PRINTERS.md) · [the code examples](../CODE-EXAMPLES.md)
 
 ## Related
 

--- a/docs/devices/microsoft-dynamics-nav-business-central.md
+++ b/docs/devices/microsoft-dynamics-nav-business-central.md
@@ -30,7 +30,9 @@ Once firmware is ruled out, three options remain, and they differ more than they
 
 The [migration guide](../EXCHANGE-ONLINE-SMTP-AUTH.md) walks through all of them, including Graph API and paid relays, and the [quiz on that page](../EXCHANGE-ONLINE-SMTP-AUTH.md#zc-quiz) gives a recommendation you can link to.
 
-[ZeroSMTP](https://github.com/msgwing/ZeroSMTP#quickstart) is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+
+[Create a free account](https://msgwing.com) · [what to put in the device's SMTP fields](../PRINTERS.md) · [the code examples](../CODE-EXAMPLES.md)
 
 ## Related
 

--- a/docs/devices/qnap-nas-notification-settings.md
+++ b/docs/devices/qnap-nas-notification-settings.md
@@ -30,7 +30,9 @@ Once firmware is ruled out, three options remain, and they differ more than they
 
 The [migration guide](../EXCHANGE-ONLINE-SMTP-AUTH.md) walks through all of them, including Graph API and paid relays, and the [quiz on that page](../EXCHANGE-ONLINE-SMTP-AUTH.md#zc-quiz) gives a recommendation you can link to.
 
-[ZeroSMTP](https://github.com/msgwing/ZeroSMTP#quickstart) is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+
+[Create a free account](https://msgwing.com) · [what to put in the device's SMTP fields](../PRINTERS.md) · [the code examples](../CODE-EXAMPLES.md)
 
 ## Related
 

--- a/docs/devices/ricoh-multifunction-printers.md
+++ b/docs/devices/ricoh-multifunction-printers.md
@@ -30,7 +30,9 @@ Once firmware is ruled out, three options remain, and they differ more than they
 
 The [migration guide](../EXCHANGE-ONLINE-SMTP-AUTH.md) walks through all of them, including Graph API and paid relays, and the [quiz on that page](../EXCHANGE-ONLINE-SMTP-AUTH.md#zc-quiz) gives a recommendation you can link to.
 
-[ZeroSMTP](https://github.com/msgwing/ZeroSMTP#quickstart) is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+
+[Create a free account](https://msgwing.com) · [what to put in the device's SMTP fields](../PRINTERS.md) · [the code examples](../CODE-EXAMPLES.md)
 
 ## Related
 

--- a/docs/devices/veeam-backup-for-microsoft-365-and-related-products.md
+++ b/docs/devices/veeam-backup-for-microsoft-365-and-related-products.md
@@ -30,7 +30,9 @@ Once firmware is ruled out, three options remain, and they differ more than they
 
 The [migration guide](../EXCHANGE-ONLINE-SMTP-AUTH.md) walks through all of them, including Graph API and paid relays, and the [quiz on that page](../EXCHANGE-ONLINE-SMTP-AUTH.md#zc-quiz) gives a recommendation you can link to.
 
-[ZeroSMTP](https://github.com/msgwing/ZeroSMTP#quickstart) is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+
+[Create a free account](https://msgwing.com) · [what to put in the device's SMTP fields](../PRINTERS.md) · [the code examples](../CODE-EXAMPLES.md)
 
 ## Related
 

--- a/docs/devices/xerox-connectkey-printers-and-mfps.md
+++ b/docs/devices/xerox-connectkey-printers-and-mfps.md
@@ -43,7 +43,9 @@ Once firmware is ruled out, three options remain, and they differ more than they
 
 The [migration guide](../EXCHANGE-ONLINE-SMTP-AUTH.md) walks through all of them, including Graph API and paid relays, and the [quiz on that page](../EXCHANGE-ONLINE-SMTP-AUTH.md#zc-quiz) gives a recommendation you can link to.
 
-[ZeroSMTP](https://github.com/msgwing/ZeroSMTP#quickstart) is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP AUTH, and is capped at 200 messages a day — and it sends from a shared `@msgwing.com` address, not your own domain. If the from-address has to be yours, it is the wrong answer and the migration guide covers the others.
+
+[Create a free account](https://msgwing.com) · [what to put in the device's SMTP fields](../PRINTERS.md) · [the code examples](../CODE-EXAMPLES.md)
 
 ## Related
 

--- a/docs/errors/535-5-7-139-basic-authentication-is-disabled.md
+++ b/docs/errors/535-5-7-139-basic-authentication-is-disabled.md
@@ -55,7 +55,9 @@ Three options remain, and they differ more than they look:
 - **Direct Send** — free, but delivers only to recipients inside your own tenant, and needs a connector and a static IP.
 - **A relay that still accepts a username and password** — works for any recipient, and is three fields on the device.
 
-[The migration guide](../EXCHANGE-ONLINE-SMTP-AUTH.md) covers all of them, Graph API and paid relays included. [ZeroSMTP](https://github.com/msgwing/ZeroSMTP#quickstart) is the third: free, no paid tier, 200 messages a day, and it sends from a shared `@msgwing.com` address rather than your own domain. If the from-address has to be yours, it is the wrong answer — the guide covers the others honestly.
+[The migration guide](../EXCHANGE-ONLINE-SMTP-AUTH.md) covers all of them, Graph API and paid relays included. ZeroSMTP is the third: free, no paid tier, 200 messages a day, and it sends from a shared `@msgwing.com` address rather than your own domain. If the from-address has to be yours, it is the wrong answer — the guide covers the others honestly.
+
+[Create a free account](https://msgwing.com) · [settings by printer brand](../PRINTERS.md) · [code examples in 19 languages](../CODE-EXAMPLES.md)
 
 ## Two things this is often confused with
 

--- a/docs/errors/535-5-7-139-smtpclientauthentication-is-disabled-for-the-mailbox.md
+++ b/docs/errors/535-5-7-139-smtpclientauthentication-is-disabled-for-the-mailbox.md
@@ -44,7 +44,9 @@ Three options remain, and they differ more than they look:
 - **Direct Send** — free, but delivers only to recipients inside your own tenant, and needs a connector and a static IP.
 - **A relay that still accepts a username and password** — works for any recipient, and is three fields on the device.
 
-[The migration guide](../EXCHANGE-ONLINE-SMTP-AUTH.md) covers all of them, Graph API and paid relays included. [ZeroSMTP](https://github.com/msgwing/ZeroSMTP#quickstart) is the third: free, no paid tier, 200 messages a day, and it sends from a shared `@msgwing.com` address rather than your own domain. If the from-address has to be yours, it is the wrong answer — the guide covers the others honestly.
+[The migration guide](../EXCHANGE-ONLINE-SMTP-AUTH.md) covers all of them, Graph API and paid relays included. ZeroSMTP is the third: free, no paid tier, 200 messages a day, and it sends from a shared `@msgwing.com` address rather than your own domain. If the from-address has to be yours, it is the wrong answer — the guide covers the others honestly.
+
+[Create a free account](https://msgwing.com) · [settings by printer brand](../PRINTERS.md) · [code examples in 19 languages](../CODE-EXAMPLES.md)
 
 ## Two things this is often confused with
 

--- a/docs/errors/535-5-7-139-smtpclientauthentication-is-disabled-for-the-tenant.md
+++ b/docs/errors/535-5-7-139-smtpclientauthentication-is-disabled-for-the-tenant.md
@@ -44,7 +44,9 @@ Three options remain, and they differ more than they look:
 - **Direct Send** — free, but delivers only to recipients inside your own tenant, and needs a connector and a static IP.
 - **A relay that still accepts a username and password** — works for any recipient, and is three fields on the device.
 
-[The migration guide](../EXCHANGE-ONLINE-SMTP-AUTH.md) covers all of them, Graph API and paid relays included. [ZeroSMTP](https://github.com/msgwing/ZeroSMTP#quickstart) is the third: free, no paid tier, 200 messages a day, and it sends from a shared `@msgwing.com` address rather than your own domain. If the from-address has to be yours, it is the wrong answer — the guide covers the others honestly.
+[The migration guide](../EXCHANGE-ONLINE-SMTP-AUTH.md) covers all of them, Graph API and paid relays included. ZeroSMTP is the third: free, no paid tier, 200 messages a day, and it sends from a shared `@msgwing.com` address rather than your own domain. If the from-address has to be yours, it is the wrong answer — the guide covers the others honestly.
+
+[Create a free account](https://msgwing.com) · [settings by printer brand](../PRINTERS.md) · [code examples in 19 languages](../CODE-EXAMPLES.md)
 
 ## Two things this is often confused with
 

--- a/docs/errors/535-5-7-3-authentication-unsuccessful.md
+++ b/docs/errors/535-5-7-3-authentication-unsuccessful.md
@@ -44,7 +44,9 @@ Three options remain, and they differ more than they look:
 - **Direct Send** — free, but delivers only to recipients inside your own tenant, and needs a connector and a static IP.
 - **A relay that still accepts a username and password** — works for any recipient, and is three fields on the device.
 
-[The migration guide](../EXCHANGE-ONLINE-SMTP-AUTH.md) covers all of them, Graph API and paid relays included. [ZeroSMTP](https://github.com/msgwing/ZeroSMTP#quickstart) is the third: free, no paid tier, 200 messages a day, and it sends from a shared `@msgwing.com` address rather than your own domain. If the from-address has to be yours, it is the wrong answer — the guide covers the others honestly.
+[The migration guide](../EXCHANGE-ONLINE-SMTP-AUTH.md) covers all of them, Graph API and paid relays included. ZeroSMTP is the third: free, no paid tier, 200 messages a day, and it sends from a shared `@msgwing.com` address rather than your own domain. If the from-address has to be yours, it is the wrong answer — the guide covers the others honestly.
+
+[Create a free account](https://msgwing.com) · [settings by printer brand](../PRINTERS.md) · [code examples in 19 languages](../CODE-EXAMPLES.md)
 
 ## Two things this is often confused with
 

--- a/tools/build-device-table.py
+++ b/tools/build-device-table.py
@@ -240,12 +240,15 @@ def zbuduj_strone(wpis, aktualizacja):
             "[quiz on that page](../EXCHANGE-ONLINE-SMTP-AUTH.md#zc-quiz) gives "
             "a recommendation you can link to.",
             "",
-            "[ZeroSMTP](https://github.com/msgwing/ZeroSMTP#quickstart) is the "
-            "second option. It is free with no paid tier, accepts plain SMTP "
-            "AUTH, and is capped at 200 messages a day — and it sends from a "
-            "shared `@msgwing.com` address, not your own domain. If the "
-            "from-address has to be yours, it is the wrong answer and the "
-            "migration guide covers the others.",
+            "ZeroSMTP is the second option. It is free with no paid tier, "
+            "accepts plain SMTP AUTH, and is capped at 200 messages a day — "
+            "and it sends from a shared `@msgwing.com` address, not your own "
+            "domain. If the from-address has to be yours, it is the wrong "
+            "answer and the migration guide covers the others.",
+            "",
+            "[Create a free account](https://msgwing.com) · "
+            "[what to put in the device's SMTP fields](../PRINTERS.md) · "
+            "[the code examples](../CODE-EXAMPLES.md)",
             "",
         ]
 

--- a/tools/build-error-pages.py
+++ b/tools/build-error-pages.py
@@ -186,12 +186,15 @@ def zbuduj(wpis, aktualizacja):
             "for any recipient, and is three fields on the device.",
             "",
             "[The migration guide](../EXCHANGE-ONLINE-SMTP-AUTH.md) covers all "
-            "of them, Graph API and paid relays included. "
-            "[ZeroSMTP](https://github.com/msgwing/ZeroSMTP#quickstart) is the "
+            "of them, Graph API and paid relays included. ZeroSMTP is the "
             "third: free, no paid tier, 200 messages a day, and it sends from a "
             "shared `@msgwing.com` address rather than your own domain. If the "
             "from-address has to be yours, it is the wrong answer — the guide "
             "covers the others honestly.",
+            "",
+            "[Create a free account](https://msgwing.com) · "
+            "[settings by printer brand](../PRINTERS.md) · "
+            "[code examples in 19 languages](../CODE-EXAMPLES.md)",
             "",
         ]
 


### PR DESCRIPTION
The device and error pages are where the highest-intent search traffic
lands. Both generators were sending that reader to the GitHub README's
`#quickstart` anchor — an extra hop through a page *about the repository*,
at exactly the moment they have already decided.

Each page now ends its recommendation with a plain three-way row:

> [Create a free account](https://msgwing.com) · [settings by printer brand](docs/PRINTERS.md) · [code examples in 19 languages](docs/CODE-EXAMPLES.md)

Whichever of the three they need, it is one click instead of two.

**The caveats are unchanged and stay ahead of the link** — the shared
`@msgwing.com` sender, the 200/day cap, and the sentence saying this is the
wrong answer if the from-address has to be your own domain.

That ordering is the whole point. A generated page that leads with a signup
button is a doorway page and gets treated as one. A page that states the
limits first and *then* makes the next step easy is a reference page. With
21 generated pages now live, which of those two this looks like is not a
detail.
