### PR TITLE
npm: zerosmtp-check, a zero-dependency SMTP connectivity CLI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -277,6 +277,45 @@ jobs:
       - name: Type-check TypeScript example
         run: npm run typecheck
 
+  zerosmtp-check:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+      # The package has no dependencies, so there is nothing to install and
+      # the tool can simply be run. This is a functional test, not a syntax
+      # check: a diagnostic that compiles and lies is worse than none.
+      - name: Help text
+        run: node packages/zerosmtp-check/index.js --help
+      - name: Unresolvable host exits 2
+        run: |
+          set +e
+          node packages/zerosmtp-check/index.js this-host-does-not-exist.invalid --timeout 3000
+          code=$?
+          set -e
+          [ "$code" = "2" ] || { echo "::error::expected exit 2, got $code"; exit 1; }
+      - name: Real check against mx.msgwing.com produces valid JSON
+        # Exit 0 (all good) and exit 1 (a port unreachable) are both correct
+        # behaviour and depend on the relay, so the assertion is on the
+        # output shape rather than on the relay being up. That keeps this
+        # job honest without making it flaky.
+        run: |
+          set +e
+          out=$(node packages/zerosmtp-check/index.js --json)
+          code=$?
+          set -e
+          echo "$out"
+          [ "$code" = "0" ] || [ "$code" = "1" ] \
+            || { echo "::error::unexpected exit $code"; exit 1; }
+          echo "$out" | jq -e '.host and (.addresses | length > 0) and (.ports | length == 2) and has("ok")' > /dev/null
+      - name: Package metadata is publishable
+        run: npm pack --dry-run
+        working-directory: packages/zerosmtp-check
+
   csharp:
     needs: changes
     if: needs.changes.outputs.code == 'true'

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,82 @@
+name: Publish zerosmtp-check to npm
+
+# Publishes packages/zerosmtp-check to the PUBLIC npm registry.
+#
+# Not GitHub Packages. npm.pkg.github.com requires the person installing to
+# authenticate with a GitHub token even for a public package, which makes it
+# useless as a way for anybody to find or run the tool - and being findable
+# and runnable with one `npx` is the entire reason this package exists.
+#
+# Manual only. A package version is permanent: npm allows unpublish for 72
+# hours and then never again, and the name is claimed forever. That is not a
+# thing to do on every push to main.
+#
+# Requires an NPM_TOKEN secret - an automation token from npmjs.com with
+# publish rights. Until that secret exists this workflow cannot run, which is
+# the intended state: publishing is the owner's decision.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Pack and validate without publishing'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  id-token: write        # npm provenance
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/zerosmtp-check
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      # Publishing something that does not work is worse than not publishing.
+      # These are the same checks the lint workflow runs, repeated here so
+      # that a manual dispatch cannot skip them.
+      - name: It runs
+        run: node index.js --help
+      - name: It reports a real result
+        run: node index.js --json || [ $? = 1 ]
+
+      - name: Refuse to republish an existing version
+        run: |
+          name=$(node -p "require('./package.json').name")
+          version=$(node -p "require('./package.json').version")
+          if npm view "$name@$version" version >/dev/null 2>&1; then
+            echo "::error::$name@$version is already on npm. Bump the version."
+            exit 1
+          fi
+          echo "$name@$version is not published yet."
+
+      - name: Pack
+        run: npm pack --dry-run
+
+      - name: Publish
+        if: ${{ inputs.dry_run == false }}
+        # --provenance links the published tarball to this workflow run, so
+        # anyone can verify on npmjs.com that it was built from this commit
+        # in this repository rather than uploaded from somebody's laptop.
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Summary
+        run: |
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            echo "Dry run only - nothing was published." >> "$GITHUB_STEP_SUMMARY"
+          else
+            v=$(node -p "require('./package.json').version")
+            echo "Published zerosmtp-check@$v" >> "$GITHUB_STEP_SUMMARY"
+            echo "https://www.npmjs.com/package/zerosmtp-check" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,11 @@ obj/
 *.class
 .build/
 Packages/
+# ...but packages/ (lowercase) is ours - the published npm CLI lives there.
+# On a case-insensitive filesystem the Swift rule above swallows it, so this
+# exception is load-bearing rather than tidy-up. Removing it silently drops
+# packages/zerosmtp-check from every commit.
+!packages/
 .gradle/
 build/
 free-for-dev/

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ with anything that already speaks SMTP.
 1. Register and activate a free account at [msgwing.com](https://msgwing.com), then copy your randomly generated `@msgwing.com` login and password.
 2. Copy [`.env.example`](.env.example) to `.env` and fill in your credentials.
 3. Run the curl snippet above (`export $(grep -v '^#' .env | xargs)` first), or pick your language from the [Code Examples](#code-examples) table — every example reads the same `.env` variables.
-4. Having trouble? See [Error messages](docs/ERROR-MESSAGES.md) · [Troubleshooting](docs/TROUBLESHOOTING.md) — most first-run failures are a cloud provider blocking outbound SMTP ports, not a misconfiguration.
+4. Having trouble? Run `npx zerosmtp-check` first — it tells you in two seconds whether your network lets SMTP out at all, which is what most first-run failures turn out to be. Then see [Error messages](docs/ERROR-MESSAGES.md) · [Troubleshooting](docs/TROUBLESHOOTING.md).
 
 > Prefer not to install anything locally? Every runtime used below (Python, PHP,
 > Node, Ruby, Go, Java, Kotlin/Gradle, .NET, Rust) is preinstalled in the

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -23,6 +23,27 @@ to check. Run the connectivity-only healthcheck (no credentials needed, no
 email sent):
 
 ```bash
+npx zerosmtp-check
+```
+
+Nothing to install and nothing to clone. It resolves the host, connects on
+587 and 465, does the STARTTLS or implicit-TLS handshake, checks whether
+*this machine's* trust store accepts the certificate, and lists the `AUTH`
+mechanisms the server offers. No credentials are sent and no mail is
+delivered — the conversation stops after `EHLO`.
+
+It works against any SMTP host, which is the point when you are trying to
+establish whether the problem is the server or your network:
+
+```bash
+npx zerosmtp-check smtp.office365.com
+npx zerosmtp-check mail.example.com --port 25
+npx zerosmtp-check --json          # exit 0 = fine, 1 = a problem, 2 = DNS
+```
+
+If Node is not available, the repository has the same checks as scripts:
+
+```bash
 ./check-connection.sh
 ```
 

--- a/packages/zerosmtp-check/README.md
+++ b/packages/zerosmtp-check/README.md
@@ -1,0 +1,96 @@
+# zerosmtp-check
+
+Does outbound SMTP actually work from this machine?
+
+```bash
+npx zerosmtp-check smtp.office365.com
+```
+
+No install, no credentials, no mail sent, **no dependencies**.
+
+## Why this exists
+
+When a send fails, the symptom is almost always the same: it hangs, then it
+times out. That looks identical whether the server is down, the certificate
+is untrusted, or — by far the most common — the network simply will not let
+port 587 or 465 out.
+
+Cloud providers block outbound SMTP by default. So do a lot of corporate
+firewalls. You can spend an afternoon rotating credentials on a problem that
+was never authentication.
+
+This tells the cases apart in about two seconds.
+
+## What it checks
+
+For each port (587 and 465 by default):
+
+- DNS resolution
+- TCP connect, with a real timeout rather than hanging
+- `STARTTLS` offered (587) or implicit TLS (465)
+- TLS handshake, protocol version
+- **Certificate validation** — subject, issuer, expiry, and whether this
+  machine's trust store actually accepts it
+- The `AUTH` mechanisms the server advertises, and whether plain
+  username-and-password is among them
+
+The conversation stops after `EHLO`. Nothing is authenticated and nothing is
+delivered.
+
+## Usage
+
+```
+npx zerosmtp-check [host] [options]
+
+  host              SMTP host to test (default: mx.msgwing.com)
+
+  --port <n>        test one port only
+  --timeout <ms>    per-step timeout (default: 10000)
+  --insecure        continue past certificate errors and report them
+  --json            machine-readable output
+  -h, --help
+```
+
+```bash
+npx zerosmtp-check                            # the ZeroSMTP relay
+npx zerosmtp-check smtp.office365.com         # your own provider
+npx zerosmtp-check mail.example.com --port 25
+npx zerosmtp-check --json                     # for a monitoring job
+```
+
+`--insecure` does **not** turn verification off. It lets the check continue
+past a certificate failure so the report can tell you *why* it failed — which
+is the point of a diagnostic. Old printer firmware failing on a Let's Encrypt
+chain is a different problem from a hostname mismatch, and you cannot tell
+which without looking.
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | every tested port reachable, TLS fine, certificate valid |
+| `1` | at least one problem found |
+| `2` | the host could not be resolved |
+
+Suitable for a monitoring check: `zerosmtp-check --json` plus the exit code.
+
+## Zero dependencies, on purpose
+
+A diagnostic that needs `npm install` to work is useless on the machine where
+things are already broken. And a tool you point at your own mail
+infrastructure should not be dragging in a dependency tree you have to audit
+first. Node's `net`, `tls` and `dns` are enough.
+
+## Related
+
+Written alongside [ZeroSMTP](https://github.com/msgwing/ZeroSMTP), a free SMTP
+relay for devices that cannot do OAuth 2.0 — built for the Microsoft 365 Basic
+authentication shutdown at the end of December 2026. This tool is useful
+regardless of whether you use that relay: point it at whatever host you send
+through.
+
+- [What each SMTP error message means](https://docs.msgwing.com/ERROR-MESSAGES.html)
+- [Troubleshooting a send that hangs](https://docs.msgwing.com/TROUBLESHOOTING.html)
+- [Which printers and MFPs have OAuth firmware](https://docs.msgwing.com/DEVICE-COMPATIBILITY.html)
+
+MIT.

--- a/packages/zerosmtp-check/index.js
+++ b/packages/zerosmtp-check/index.js
@@ -1,0 +1,339 @@
+#!/usr/bin/env node
+// zerosmtp-check - does outbound SMTP actually work from here?
+//
+// The single most common reason a first send fails is not the credentials
+// and not the server: it is the network refusing to let port 587 or 465 out.
+// Cloud providers block those by default, and the symptom - a hang, then a
+// timeout - looks identical to a server being down. This tells the two apart.
+//
+// Zero dependencies, deliberately. A diagnostic that needs `npm install` to
+// work is useless on the machine where things are already broken, and a tool
+// people run against their own mail infrastructure should not be pulling in
+// a dependency tree they have to audit.
+
+import net from 'node:net';
+import tls from 'node:tls';
+import dns from 'node:dns/promises';
+
+const DEFAULT_HOST = 'mx.msgwing.com';
+const DEFAULT_PORTS = [587, 465];
+const TIMEOUT_MS = 10_000;
+
+const HELP = `
+zerosmtp-check - check whether outbound SMTP works from this machine
+
+  npx zerosmtp-check [host] [options]
+
+  host              SMTP host to test (default: ${DEFAULT_HOST})
+
+  --port <n>        test one port only (default: ${DEFAULT_PORTS.join(', ')})
+  --timeout <ms>    per-step timeout (default: ${TIMEOUT_MS})
+  --insecure        continue past certificate errors and report them
+  --json            machine-readable output
+  -h, --help        this
+
+Examples
+
+  npx zerosmtp-check                          the ZeroSMTP relay
+  npx zerosmtp-check smtp.office365.com       your own provider
+  npx zerosmtp-check mail.example.com --port 25
+
+No credentials are sent and no mail is delivered. The check stops after
+EHLO.
+
+Exit codes: 0 every tested port reachable with a valid certificate,
+1 at least one problem found, 2 the host could not be resolved.
+`.trim();
+
+// --- argument parsing -------------------------------------------------------
+
+function parseArgs(argv) {
+  const opts = {
+    host: DEFAULT_HOST,
+    ports: DEFAULT_PORTS,
+    timeout: TIMEOUT_MS,
+    insecure: false,
+    json: false,
+  };
+  const rest = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '-h' || a === '--help') return { help: true };
+    else if (a === '--insecure') opts.insecure = true;
+    else if (a === '--json') opts.json = true;
+    else if (a === '--port') opts.ports = [Number(argv[++i])];
+    else if (a === '--timeout') opts.timeout = Number(argv[++i]);
+    else if (a.startsWith('-')) return { error: `Unknown option: ${a}` };
+    else rest.push(a);
+  }
+
+  if (rest.length > 1) return { error: `Expected one host, got ${rest.length}` };
+  if (rest.length === 1) opts.host = rest[0];
+
+  if (opts.ports.some(p => !Number.isInteger(p) || p < 1 || p > 65535)) {
+    return { error: 'Port must be an integer between 1 and 65535' };
+  }
+  if (!Number.isFinite(opts.timeout) || opts.timeout <= 0) {
+    return { error: 'Timeout must be a positive number of milliseconds' };
+  }
+  return opts;
+}
+
+// --- SMTP conversation helpers ----------------------------------------------
+
+/** Read until a line of the form "250 text" - a code followed by a space
+ *  rather than a hyphen, which is how SMTP marks the end of a reply. */
+function readReply(socket, timeout) {
+  return new Promise((resolve, reject) => {
+    let buf = '';
+    const done = (fn, arg) => {
+      clearTimeout(timer);
+      socket.removeListener('data', onData);
+      socket.removeListener('error', onError);
+      fn(arg);
+    };
+    const timer = setTimeout(
+      () => done(reject, new Error('timed out waiting for a reply')), timeout);
+    const onData = chunk => {
+      buf += chunk.toString('utf8');
+      const lines = buf.split(/\r?\n/);
+      for (const line of lines) {
+        if (/^\d{3} /.test(line)) return done(resolve, buf);
+      }
+    };
+    const onError = err => done(reject, err);
+    socket.on('data', onData);
+    socket.on('error', onError);
+  });
+}
+
+function send(socket, line) {
+  socket.write(line + '\r\n');
+}
+
+function connectTcp(host, port, timeout) {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect({ host, port });
+    socket.setTimeout(timeout);
+    socket.once('connect', () => { socket.setTimeout(0); resolve(socket); });
+    socket.once('timeout', () => {
+      socket.destroy();
+      reject(Object.assign(new Error('timed out'), { code: 'ETIMEDOUT' }));
+    });
+    socket.once('error', err => { socket.destroy(); reject(err); });
+  });
+}
+
+function upgradeTls(socket, host, timeout, insecure) {
+  return new Promise((resolve, reject) => {
+    const secure = tls.connect({
+      socket,
+      servername: host,
+      // Verification stays on. --insecure does not disable it; it lets the
+      // check continue so the report can say *why* it failed, which is the
+      // whole point of a diagnostic.
+      rejectUnauthorized: !insecure,
+    });
+    secure.setTimeout(timeout);
+    secure.once('secureConnect', () => { secure.setTimeout(0); resolve(secure); });
+    secure.once('timeout', () => {
+      secure.destroy();
+      reject(Object.assign(new Error('TLS handshake timed out'), { code: 'ETIMEDOUT' }));
+    });
+    secure.once('error', err => { secure.destroy(); reject(err); });
+  });
+}
+
+function connectTlsDirect(host, port, timeout, insecure) {
+  return new Promise((resolve, reject) => {
+    const secure = tls.connect({
+      host, port, servername: host, rejectUnauthorized: !insecure,
+    });
+    secure.setTimeout(timeout);
+    secure.once('secureConnect', () => { secure.setTimeout(0); resolve(secure); });
+    secure.once('timeout', () => {
+      secure.destroy();
+      reject(Object.assign(new Error('timed out'), { code: 'ETIMEDOUT' }));
+    });
+    secure.once('error', err => { secure.destroy(); reject(err); });
+  });
+}
+
+function describeCert(secure) {
+  const cert = secure.getPeerCertificate();
+  if (!cert || !cert.subject) return null;
+  return {
+    subject: cert.subject.CN || null,
+    issuer: cert.issuer ? cert.issuer.CN || cert.issuer.O || null : null,
+    validTo: cert.valid_to || null,
+    authorized: secure.authorized,
+    authorizationError: secure.authorizationError
+      ? String(secure.authorizationError) : null,
+    protocol: secure.getProtocol(),
+  };
+}
+
+function authMechanisms(ehlo) {
+  const line = ehlo.split(/\r?\n/).find(l => /^250[ -]AUTH /i.test(l));
+  if (!line) return [];
+  return line.replace(/^250[ -]AUTH /i, '').trim().split(/\s+/);
+}
+
+// --- the check itself ---------------------------------------------------------
+
+async function checkPort(host, port, opts) {
+  const result = {
+    port, tcp: false, tls: false, starttls: null,
+    cert: null, auth: [], error: null,
+  };
+
+  let socket;
+  try {
+    socket = await connectTcp(host, port, opts.timeout);
+  } catch (err) {
+    result.error = err.code === 'ETIMEDOUT'
+      ? 'TCP connect timed out'
+      : `TCP connect failed: ${err.code || err.message}`;
+    return result;
+  }
+  result.tcp = true;
+
+  try {
+    let secure;
+    if (port === 465) {
+      // Implicit TLS: the socket is encrypted before any SMTP is spoken, so
+      // the plain socket we just opened is thrown away and reopened as TLS.
+      socket.destroy();
+      secure = await connectTlsDirect(host, port, opts.timeout, opts.insecure);
+      result.starttls = false;
+      await readReply(secure, opts.timeout);       // greeting
+    } else {
+      await readReply(socket, opts.timeout);       // greeting
+      send(socket, 'EHLO zerosmtp-check');
+      const ehlo = await readReply(socket, opts.timeout);
+
+      if (!/STARTTLS/i.test(ehlo)) {
+        result.starttls = false;
+        result.auth = authMechanisms(ehlo);
+        result.error = 'Server did not offer STARTTLS - the session would be '
+          + 'in cleartext';
+        socket.destroy();
+        return result;
+      }
+      result.starttls = true;
+      send(socket, 'STARTTLS');
+      await readReply(socket, opts.timeout);
+      secure = await upgradeTls(socket, host, opts.timeout, opts.insecure);
+    }
+
+    result.tls = true;
+    result.cert = describeCert(secure);
+
+    send(secure, 'EHLO zerosmtp-check');
+    const ehlo = await readReply(secure, opts.timeout);
+    result.auth = authMechanisms(ehlo);
+
+    send(secure, 'QUIT');
+    secure.destroy();
+  } catch (err) {
+    const code = err.code || '';
+    if (/CERT|SELF_SIGNED|UNABLE_TO_VERIFY|ALT_NAME/i.test(code)) {
+      result.error = `Certificate could not be verified: ${code}. Re-run with `
+        + `--insecure to see the certificate anyway.`;
+    } else {
+      result.error = `TLS/SMTP step failed: ${code || err.message}`;
+    }
+    try { socket.destroy(); } catch { /* already gone */ }
+  }
+
+  return result;
+}
+
+// --- output ---------------------------------------------------------------------
+
+const tick = ok => (ok ? '  ok  ' : ' FAIL ');
+
+function report(host, addresses, results) {
+  const out = [];
+  out.push(`SMTP connectivity check - ${host}`);
+  out.push('');
+  out.push(`DNS      ${addresses.length ? 'ok' : 'FAILED'}   `
+    + (addresses.join(', ') || 'no addresses'));
+
+  for (const r of results) {
+    out.push('');
+    out.push(`Port ${r.port}`);
+    out.push(`  [${tick(r.tcp)}] TCP connect`);
+    if (r.starttls !== null) {
+      out.push(r.port === 465
+        ? '  [  ok  ] implicit TLS (SMTPS)'
+        : `  [${tick(r.starttls)}] STARTTLS offered`);
+    }
+    out.push(`  [${tick(r.tls)}] TLS handshake`);
+
+    if (r.cert) {
+      out.push(`  [${tick(r.cert.authorized)}] certificate verified`
+        + (r.cert.authorizationError ? ` - ${r.cert.authorizationError}` : ''));
+      out.push(`           ${r.cert.protocol}, `
+        + `CN=${r.cert.subject || '?'}, issuer=${r.cert.issuer || '?'}`);
+      out.push(`           expires ${r.cert.validTo || 'unknown'}`);
+    }
+    if (r.auth.length) {
+      out.push(`           AUTH ${r.auth.join(' ')}`);
+      if (r.auth.some(m => /^(LOGIN|PLAIN)$/i.test(m))) {
+        out.push('           accepts a username and password');
+      }
+    }
+    if (r.error) out.push(`  ->       ${r.error}`);
+  }
+
+  const blocked = results.filter(r => !r.tcp);
+  if (blocked.length) {
+    out.push('');
+    out.push('Every connection attempt timed out or was refused'
+      + (blocked.length === results.length ? '.' : ` on port ${blocked.map(r => r.port).join(', ')}.`));
+    out.push('That is almost always the network rather than the server:');
+    out.push('  - most cloud providers block outbound 25, and many block 587');
+    out.push('    and 465 too, until you ask them to open it');
+    out.push('  - corporate firewalls commonly allow SMTP only from a');
+    out.push('    designated relay host');
+    out.push('Try the same command from a different network. If it works');
+    out.push('there, the host is fine and the block is local.');
+  }
+
+  return out.join('\n');
+}
+
+// --- main ------------------------------------------------------------------------
+
+const opts = parseArgs(process.argv.slice(2));
+
+if (opts.help) { console.log(HELP); process.exit(0); }
+if (opts.error) { console.error(`${opts.error}\n\n${HELP}`); process.exit(1); }
+
+let addresses = [];
+try {
+  addresses = (await dns.lookup(opts.host, { all: true })).map(a => a.address);
+} catch (err) {
+  const msg = `Could not resolve ${opts.host}: ${err.code || err.message}`;
+  if (opts.json) console.log(JSON.stringify({ host: opts.host, dns: false, error: msg }, null, 2));
+  else console.error(msg);
+  process.exit(2);
+}
+
+const results = [];
+for (const port of opts.ports) {
+  results.push(await checkPort(opts.host, port, opts));
+}
+
+const ok = results.every(r => r.tcp && r.tls && (!r.cert || r.cert.authorized) && !r.error);
+
+if (opts.json) {
+  console.log(JSON.stringify(
+    { host: opts.host, addresses, ports: results, ok }, null, 2));
+} else {
+  console.log(report(opts.host, addresses, results));
+}
+
+process.exit(ok ? 0 : 1);

--- a/packages/zerosmtp-check/package.json
+++ b/packages/zerosmtp-check/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "zerosmtp-check",
+  "version": "1.0.0",
+  "description": "Check whether outbound SMTP actually works from this machine: TCP, STARTTLS/implicit TLS, certificate validation and AUTH mechanisms, against any host. No credentials, no mail sent, no dependencies.",
+  "type": "module",
+  "bin": {
+    "zerosmtp-check": "./index.js"
+  },
+  "main": "./index.js",
+  "files": [
+    "index.js",
+    "README.md"
+  ],
+  "keywords": [
+    "smtp",
+    "smtp-test",
+    "smtp-check",
+    "smtp-auth",
+    "starttls",
+    "email",
+    "email-troubleshooting",
+    "port-587",
+    "port-465",
+    "office365",
+    "exchange-online",
+    "microsoft365",
+    "basic-authentication",
+    "connectivity",
+    "diagnostics",
+    "cli",
+    "sysadmin"
+  ],
+  "homepage": "https://docs.msgwing.com/TROUBLESHOOTING.html",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/msgwing/ZeroSMTP.git",
+    "directory": "packages/zerosmtp-check"
+  },
+  "bugs": {
+    "url": "https://github.com/msgwing/ZeroSMTP/issues"
+  },
+  "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  }
+}


### PR DESCRIPTION
## First: the linked docs point at the wrong registry

The [GitHub Packages npm registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry)
**requires whoever installs to authenticate with a GitHub token, even for a
public package.** They need a PAT in their `.npmrc` before `npm install` will
work at all.

As a discovery channel that is zero. Nobody debugging a broken printer at
4pm is going to mint a token to run a diagnostic. This publishes to the
**public npm registry** instead, where `npx zerosmtp-check` just works.

All four candidate names were free: `zerosmtp`, `msgwing`, `zerosmtp-check`,
`@msgwing/zerosmtp`.

## What to publish — deliberately not an SDK

The README's pitch is *"no SDK, no API key, just SMTP credentials that work
with anything that already speaks SMTP."* Shipping a sending library would
undercut exactly that, and it would be a twenty-line nodemailer wrapper
nobody needs.

What is worth publishing is the **diagnostic**. The most common first-run
failure is the network refusing to let 587 or 465 out, and the symptom — a
hang, then a timeout — is indistinguishable from a dead server or an
untrusted certificate. People spend an afternoon rotating credentials over a
problem that was never authentication.

```bash
npx zerosmtp-check                       # the relay
npx zerosmtp-check smtp.office365.com    # your own provider
npx zerosmtp-check --json                # for a monitoring job
```

Per port: TCP connect with a real timeout, STARTTLS or implicit TLS,
certificate validation **against this machine's trust store**, and the `AUTH`
mechanisms offered. Stops after `EHLO` — no credentials, no mail.

**It works against any host on purpose.** A tool that only helps this
project's users does not get shared. Being pointed at `smtp.office365.com`
is precisely how somebody discovers the rest of the project.

## Two decisions worth reviewing

- **Zero dependencies.** A diagnostic that needs `npm install` is useless on
  the machine where things are already broken, and a tool you point at your
  own mail infrastructure should not drag in a tree you have to audit first.
  `node:net`, `node:tls`, `node:dns` are enough.
- **`--insecure` does not disable verification.** It lets the check continue
  past a certificate failure so the report can say *why* it failed. Old
  printer firmware choking on a Let's Encrypt chain is a different problem
  from a hostname mismatch, and you cannot tell which without looking.

## Verification

There is no Node on the machine this was written on, so **CI is the
verification and it runs the tool for real** rather than syntax-checking it:

1. `--help` executes
2. an unresolvable host asserts **exit 2**
3. a live run against `mx.msgwing.com` asserts the **JSON shape**, not that
   the relay is up — exit 0 and exit 1 are both correct, so the job cannot go
   flaky
4. `npm pack --dry-run` guards the manifest

## Publishing is your call, not mine

`publish-npm.yml` is **manual dispatch only**, defaults to a dry run, refuses
to republish an existing version, and uses `--provenance` so anyone can
verify on npmjs.com that the tarball was built from this commit.

It needs an `NPM_TOKEN` secret that does not exist yet. That is intentional —
a version on npm is permanent (unpublishable after 72 hours, name claimed
forever), so nothing gets published until you add the token and run it.

## One footgun found

`.gitignore` had `Packages/` for Swift, which swallows `packages/` on a
case-insensitive filesystem. Without the `!packages/` exception the entire
package is silently missing from every commit. Commented so nobody tidies it
away.
