### PR TITLE
Drop Swift from the merge path; put the measurement in the countdown

### DIFF
--- a/.github/workflows/deadline-milestones.yml
+++ b/.github/workflows/deadline-milestones.yml
@@ -66,6 +66,45 @@ jobs:
           EXAMPLES=$(awk '/^\| Language \| File \|/,/^$/' README.md \
             | grep -c '^| .* | \[' || echo '?')
 
+          # A countdown on its own is a reminder, and reminders are ignored.
+          # The measurement from data/blast-radius.json is the part somebody
+          # might actually quote: it says whether the world is fixing this or
+          # not, which nobody else publishes. Built with jq rather than
+          # written here so it cannot go stale, and skipped silently if the
+          # data is missing or the latest sample failed to count.
+          # jq emits raw fields and the shell formats them. Doing the
+          # thousands separators inside jq is possible and unreadable; printf
+          # "%'d" is the same trick blast-radius.yml already uses.
+          RADIUS=""
+          if [ -f data/blast-radius.json ]; then
+            fields=$(jq -r '
+              (.samples | sort_by(.date)) as $s
+              | ($s | last)  as $now
+              | ($s | first) as $then
+              | [ .queries[]
+                  | select($now.counts[.id] != null)
+                  | { label, n: $now.counts[.id], base: $then.counts[.id] } ]
+              | if length == 0 then "none 0 0 -"
+                else (max_by(.n))
+                     | "\(.label) \(.n) \(.base // 0) \($then.date)" end
+            ' data/blast-radius.json 2>/dev/null || echo "none 0 0 -")
+
+            set -- $fields
+            label="$1"; now="$2"; base="$3"; since="$4"
+
+            if [ "$label" != "none" ]; then
+              pretty=$(printf "%'d" "$now" | tr ',' ' ')
+              RADIUS="**${pretty} public files on GitHub** still name \`${label}\`"
+              if [ "$base" -gt 0 ] && [ "$now" != "$base" ]; then
+                # Integer percentage; awk because the shell has no floats.
+                move=$(awk -v n="$now" -v b="$base" \
+                  'BEGIN{d=(n-b)/b*100; printf "%s %d", (d>0?"up":"down"), (d<0?-d:d)}')
+                RADIUS="${RADIUS}, ${move}% since this was first measured on ${since}"
+              fi
+              RADIUS="${RADIUS}."
+            fi
+          fi
+
           TITLE="${DAYS} days until Microsoft 365 disables SMTP AUTH Basic auth"
 
           {
@@ -76,6 +115,18 @@ jobs:
             echo ""
             echo "Source: [Microsoft's updated timeline](https://techcommunity.microsoft.com/blog/exchange/updated-exchange-online-smtp-auth-basic-authentication-deprecation-timeline/4489835)."
             echo ""
+            if [ -n "$RADIUS" ]; then
+              echo "## Is anybody actually fixing it?"
+              echo ""
+              echo "${RADIUS}"
+              echo ""
+              echo "That is a count of public files containing a hostname, not of systems"
+              echo "that will break — some are templates, tutorials or forks, and it sees"
+              echo "nothing private. It is a floor, not a census. [The method and its"
+              echo "limits](https://docs.msgwing.com/BLAST-RADIUS.html) are written out in"
+              echo "full, the raw data is in the repository, and both are free to cite."
+              echo ""
+            fi
             echo "## If you have not checked yet"
             echo ""
             echo "[\`Find-SmtpAuthExposure.ps1\`](https://github.com/${{ github.repository }}/blob/main/Find-SmtpAuthExposure.ps1)"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -380,17 +380,9 @@ jobs:
       - name: Build Rust example
         run: cargo build
 
-  swift:
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: swift-actions/setup-swift@v2
-        with:
-          # swift-actions/setup-swift@v2.4.0's newest installable toolchain is
-          # 6.2 (6.3 errors with "Version 6.3 is not available"); Package.swift
-          # pins swift-smtp to the last release built against tools-version 6.2.
-          swift-version: "6.2"
-      - name: Build Swift example
-        run: swift build
+  # Swift used to be here and is now in swift-weekly.yml. Measured over five
+  # runs it took 2.8-3.3 minutes while every other job finished in 0.2-0.8,
+  # so it alone decided how long a merge had to wait. It has also been
+  # removed from the required checks on main - deleting a job that branch
+  # protection still requires would leave every future PR waiting forever on
+  # a check that never reports.

--- a/.github/workflows/swift-weekly.yml
+++ b/.github/workflows/swift-weekly.yml
@@ -1,0 +1,43 @@
+name: Swift example (weekly)
+
+# Swift was pulled out of lint.yml because it was the merge bottleneck:
+# measured over five runs it took 2.8-3.3 minutes while every other job
+# finished in 0.2-0.8. Every push paid three minutes for one example.
+#
+# It runs here instead. The example is still built, so it cannot rot
+# unnoticed - which matters more than usual for this one, because
+# Package.swift is pinned to swift-smtp 2.16.0 only because
+# swift-actions/setup-swift cannot install the Swift 6.3 that 2.17+ needs.
+# That pin will break when something upstream moves, and a weekly build is
+# how we find out on a Monday rather than from a contributor.
+#
+# Deliberately not a required check on main. A slow build should tell us
+# something is wrong; it should not decide when a documentation fix merges.
+
+on:
+  schedule:
+    - cron: '0 5 * * 1'      # Mondays 05:00 UTC
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'swift-zerosmtp.swift'
+      - 'Package.swift'
+      - '.github/workflows/swift-weekly.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: swift-actions/setup-swift@v2
+        with:
+          # swift-actions/setup-swift@v2.4.0's newest installable toolchain is
+          # 6.2 (6.3 errors with "Version 6.3 is not available"); Package.swift
+          # pins swift-smtp to the last release built against tools-version 6.2.
+          swift-version: "6.2"
+      - name: Build Swift example
+        run: swift build


### PR DESCRIPTION
## Swift is out of the merge path

Measured across five runs:

| Job | Duration |
|---|---|
| **swift** | **2.8 – 3.3 min** |
| kotlin | 0.6 – 0.8 min |
| rust | 0.3 – 0.4 min |
| java | 0.2 – 0.3 min |

Four to ten times everything else. It alone decided how long every merge
waited, for one example.

Moved to `swift-weekly.yml`, which still builds it on a schedule and on any
push touching `swift-zerosmtp.swift` or `Package.swift`. Keeping *some*
coverage matters more than usual here: `Package.swift` pins swift-smtp 2.16.0
only because `setup-swift` cannot install the Swift 6.3 that 2.17+ requires.
That pin breaks the day something upstream moves, and a weekly build is how
we hear about it on a Monday rather than from a contributor.

**`swift` was removed from the required status checks on `main` first, and
deliberately.** Deleting a job that branch protection still requires leaves
every future PR waiting forever on a check that never reports — the exact
failure mode the comment at the top of `lint.yml` warns about. Required
checks are now the remaining eleven.

## The countdown bot now leads with the number

A countdown on its own is a reminder, and reminders get ignored. *"90 days
until Microsoft 365 disables SMTP AUTH"* is not news — everyone already knows
the date.

> **24,960 public files on GitHub** still name `smtp.office365.com`, down 3%
> since this was first measured on 2026-08-16.

*That* is news, because nobody else publishes it and it answers the question
the deadline itself does not: **is anyone actually fixing this?** Same
automation, same schedule — but now the post is worth quoting instead of
worth muting.

Details:

- The figure is read from `data/blast-radius.json`, never written into the
  workflow, so it cannot go stale.
- The whole section is **skipped** if the data is missing or the latest
  sample failed to count. A milestone post carrying a wrong number would be
  worse than one carrying none.
- The caveats travel with the figure — files containing a hostname, not
  systems that will break; a floor, not a census — with the method linked and
  stated as free to cite.
- `jq` emits raw fields and the shell formats them with `printf "%'d"`, the
  same approach `blast-radius.yml` already uses. Doing thousands separators
  inside jq is possible and unreadable.
