### PR TITLE
feat(ci): auto-draft release notes from CHANGELOG on version tags

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,78 @@
+name: Draft release
+
+# Turns the latest CHANGELOG entry into a GitHub Draft release the moment a
+# semantic-version tag is pushed. Draft, not published: a release is the
+# project's public face, and the person who owns the project decides when it
+# is ready. The workflow's only job is to make that decision a formality by
+# preparing the notes, the artifact list and the links.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Extract the CHANGELOG entry for this version
+        id: notes
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF#refs/tags/}"          # v1.4.0
+          VERSION="${TAG#v}"                       # 1.4.0
+
+          # The CHANGELOG uses "## [X.Y.Z] - date" headers. Pull everything
+          # from the first matching header up to (not including) the next one.
+          NOTES=$(awk -v v="$VERSION" '
+            $0 ~ "^## \\[" v "\\]" { found=1; next }
+            found && /^## \[/ { exit }
+            found { print }
+          ' CHANGELOG.md)
+
+          if [ -z "$NOTES" ]; then
+            echo "::error::No CHANGELOG entry for $VERSION. Add one before tagging."
+            exit 1
+          fi
+
+          # Trim leading/trailing blank lines and keep the rest verbatim,
+          # so markdown inside the entry survives untouched.
+          NOTES=$(printf '%s\n' "$NOTES" | sed '/^[[:space:]]*$/d')
+          echo "notes<<EOF" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "$NOTES" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Create the draft release
+        run: |
+          set -euo pipefail
+          NOTES='${{ steps.notes.outputs.notes }}'
+
+          # A release body that points at the right places makes the
+          # difference between "we shipped" and "look what shipped".
+          BODY=$(cat <<MD
+          $NOTES
+
+          ---
+
+          ## First time here?
+
+          - [Docs](https://docs.msgwing.com/) — setup, troubleshooting, migration guide
+          - [Getting started](https://github.com/${{ github.repository }}#quickstart) — the whole API in four lines
+          - [Code examples](https://github.com/${{ github.repository }}#code-examples) — 21 ready-to-run files across 19 languages
+
+          _Draft prepared automatically. Publish when ready._
+          MD
+          )
+
+          # --draft is the entire point: nothing goes public without a click.
+          gh release create "$GITHUB_REF_NAME" \
+            --draft \
+            --title "$GITHUB_REF_NAME" \
+            --notes "$BODY" \
+            --repo "$GITHUB_REPOSITORY"
+MD


### PR DESCRIPTION
**Co to robi:** Zamienia najnowszy wpis CHANGELOG.md w draft GitHub Release automatycznie, gdy pushujesz tag `v*`.

- Draft, nie publikacja — nic nie idzie publicznie bez kliknięcia.
- Weryfikuje, że wpis CHANGELOG istnieje — tag bez wpisu nie przejdzie.
- Dodaje linki do docs, quickstart i 21 przykładów.

Closes: brakująca automatyzacja release w pipeline promocji.