### PR TITLE
fix(ci): naprawa workflow draft-release - usunięcie błędu MD

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -75,4 +75,3 @@ jobs:
             --title "$GITHUB_REF_NAME" \
             --notes "$BODY" \
             --repo "$GITHUB_REPOSITORY"
-MD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.5.0] - 2026-08-16
+
+### Added
+- `.github/workflows/draft-release.yml`: automatic Draft release notes from the
+  CHANGELOG whenever a `v*` tag is pushed. Draft, never published without a
+  click — releases are the project's public face and stay owner-controlled.
+
 ## [1.3.0] - 2026-07-26
 
 All 12 CI jobs (one per language/script surface) are green as of this


### PR DESCRIPTION
## Problem`n`nWorkflow .github/workflows/draft-release.yml nie działał - oba uruchomienia kończyły się błędem w 0 sekund.`n`n## Przyczyna`n`nNa końcu pliku pozostał literał MD (niezamknięty heredoc), który psuł YAML.`n`n## Rozwiązanie`n`n- Usunięto literał MD z końca pliku.`n- Dodano wpis CHANGELOG dla wersji v1.5.0.