### PR TITLE
fix(ci): notatki release przez plik - naprawa apostrofów

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -43,35 +43,23 @@ jobs:
           # Trim leading/trailing blank lines and keep the rest verbatim,
           # so markdown inside the entry survives untouched.
           NOTES=$(printf '%s\n' "$NOTES" | sed '/^[[:space:]]*$/d')
-          echo "notes<<EOF" >> "$GITHUB_OUTPUT"
-          printf '%s\n' "$NOTES" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+
+          # Write the notes to a file, not to a step output variable.
+          # Apostrophes in the notes (e.g. "Microsoft's") would break the
+          # shell quoting when the output is interpolated into a later step,
+          # so the entire body is assembled here and passed via --notes-file.
+          {
+            printf '%s\n' "$NOTES"
+            printf '\n---\n\n## First time here?\n\n- [Docs](https://docs.msgwing.com/) - setup, troubleshooting, migration guide\n- [Getting started](https://github.com/${{ github.repository }}#quickstart) - the whole API in four lines\n- [Code examples](https://github.com/${{ github.repository }}#code-examples) - 21 ready-to-run files across 19 languages\n\n_Draft prepared automatically. Publish when ready._\n'
+          } > body.md
 
       - name: Create the draft release
         run: |
           set -euo pipefail
-          NOTES='${{ steps.notes.outputs.notes }}'
-
-          # A release body that points at the right places makes the
-          # difference between "we shipped" and "look what shipped".
-          BODY=$(cat <<MD
-          $NOTES
-
-          ---
-
-          ## First time here?
-
-          - [Docs](https://docs.msgwing.com/) — setup, troubleshooting, migration guide
-          - [Getting started](https://github.com/${{ github.repository }}#quickstart) — the whole API in four lines
-          - [Code examples](https://github.com/${{ github.repository }}#code-examples) — 21 ready-to-run files across 19 languages
-
-          _Draft prepared automatically. Publish when ready._
-          MD
-          )
 
           # --draft is the entire point: nothing goes public without a click.
           gh release create "$GITHUB_REF_NAME" \
             --draft \
             --title "$GITHUB_REF_NAME" \
-            --notes "$BODY" \
+            --notes-file body.md \
             --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
## Problem`n`nWorkflow draft-release padał z błędem: `unexpected EOF while looking for matching .` - treść notatek CHANGELOG zawiera apostrofy (np. Microsoft.s), które psują składnię basha przy interpolacji zmiennej w późniejszym kroku.`n`n## Rozwiązanie`n`nNotatki są zapisywane do pliku `body.md` w kroku pierwszym i przekazywane przez `gh release create --notes-file` w kroku drugim. Żadna treść z apostrofami nie trafia do składni basha.`n`n## Test`n`nTag `v1.5.0` był już wygenerowany i padł. Po zmergowaniu utworzę go ponownie i sprawdzę.