### PR TITLE
fix(ci): add GH_TOKEN to gh release create step

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -54,6 +54,8 @@ jobs:
           } > body.md
 
       - name: Create the draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Problem`n`nWorkflow draft-release pada na kroku tworzenia release:`gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.`n`n## Rozwiązanie`n`nDodano `env: GH_TOKEN: ${{ github.token }}` do kroku `Create the draft release`.