### PR TITLE
fix(ci): anulowanie nieaktualnych biegów lintera + Blast radius przestaje padać co tydzień

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -1,8 +1,8 @@
 name: Blast radius
 
 # Measures how much public code still points at Microsoft 365 SMTP, once a
-# week, and commits the result so the series can be checked rather than
-# taken on trust.
+# week, and publishes the result to the `status` branch so the series can be
+# checked rather than taken on trust.
 #
 # Why bother: nobody has published this number. Every article about the
 # December 2026 Basic auth shutdown says "many systems will be affected",
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write            # commits the sample and the rendered page
+  contents: write            # publishes the sample and the badge to `status`
 
 concurrency:
   group: blast-radius
@@ -103,47 +103,80 @@ jobs:
       - name: Render the page
         run: python tools/build-blast-radius.py
 
-      - name: Commit
+      - name: Publish the sample and the badge
         run: |
           set -euo pipefail
-          if git diff --quiet -- data/blast-radius.json docs/BLAST-RADIUS.md; then
-            echo "Counts unchanged - nothing to commit."
-            exit 0
-          fi
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add data/blast-radius.json docs/BLAST-RADIUS.md
-          git commit -m "data: blast radius measurement ${{ env.date }}"
-          git push
 
-      - name: Badge
-        run: |
-          set -euo pipefail
+          # This step used to `git push` the sample straight to main. main is
+          # protected with enforce_admins on, so every single run ended in
+          # `GH006: Protected branch update failed` - measuring the number
+          # correctly over two minutes and then throwing it away.
+          #
+          # A pull request is not a way out either: a PR opened with
+          # GITHUB_TOKEN does not trigger workflows, so the checks main
+          # requires would never report and it would sit unmergeable forever.
+          # Making that work needs a PAT in the repository secrets, and there
+          # are none.
+          #
+          # So the series lives on the unprotected `status` branch, which the
+          # badge already uses and which the bot can write to. Nothing here
+          # touches main. docs/BLAST-RADIUS.md on main is refreshed by a
+          # person running `tools/build-blast-radius.py` against this file -
+          # and `lint.yml` keeps the committed page honest against whatever
+          # data/blast-radius.json says at the time.
+
           # Largest single measured count. Deliberately not a sum: one file
           # can contain both hostnames, and a total would double-count.
-          read -r label value < <(
+          # Count first, label second: `read` splits on the first space, so a
+          # label that ever contains one would otherwise silently take part
+          # of the number with it. Today's labels are hostnames, but the
+          # queries are data and data changes.
+          read -r value label < <(
             jq -r '
               (.samples | last | .counts) as $c
               | [.queries[] | select($c[.id] != null) | {label, n: $c[.id]}]
-              | if length == 0 then "none 0"
-                else (max_by(.n) | "\(.label) \(.n)") end' \
+              | if length == 0 then "0 none"
+                else (max_by(.n) | "\(.n) \(.label)") end' \
               data/blast-radius.json)
 
-          [ "$label" = "none" ] && { echo "Nothing measured; badge unchanged."; exit 0; }
-
-          formatted=$(printf "%'d" "$value" | tr ',' ' ')
+          cp data/blast-radius.json /tmp/blast-radius-samples.json
 
           git fetch -q origin status
           git checkout -q -B status origin/status
-          cat > blast-radius.json <<JSON
+
+          cp /tmp/blast-radius-samples.json blast-radius-samples.json
+
+          if [ "$label" != "none" ]; then
+            formatted=$(printf "%'d" "$value" | tr ',' ' ')
+            cat > blast-radius.json <<JSON
           {"schemaVersion":1,"label":"$label in public code","message":"$formatted files","color":"critical"}
           JSON
+          else
+            echo "Nothing measured; badge left unchanged."
+          fi
+
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add blast-radius.json
+          git add blast-radius-samples.json blast-radius.json
           if git diff --cached --quiet; then
-            echo "Badge unchanged."
-          else
-            git commit -q -m "status: blast radius badge ${{ env.date }}"
-            git push -q origin status
+            echo "Sample and badge unchanged - nothing to publish."
+            exit 0
           fi
+
+          git commit -q -m "status: blast radius ${{ env.date }}"
+
+          # service-healthcheck.yml writes status.json to this same branch
+          # every 15 minutes, so a collision here is a matter of when, not if.
+          for attempt in 1 2 3; do
+            if git push -q origin status; then
+              echo "Published sample and badge for ${{ env.date }}."
+              exit 0
+            fi
+            echo "Push rejected (attempt ${attempt}/3) - rebasing onto origin/status."
+            git fetch -q origin status
+            git rebase -q origin/status || { git rebase --abort || true; }
+            sleep $((attempt * 3))
+          done
+
+          echo "::error::Could not publish the blast radius sample after 3 attempts."
+          exit 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,19 @@ on:
 permissions:
   contents: read
 
+# Three pushes to a pull request in a minute used to start three full
+# matrices, and the first two kept holding runners while answering a
+# question nobody was asking any more. With ~20 jobs each, plus CodeQL and
+# the dependency submissions competing for the same pool, that is what put
+# the later jobs in QUEUED and made a merge wait on nothing.
+#
+# Superseded pull-request runs are cancelled. Runs on main are not: main's
+# history should carry a completed result for every commit, and nothing is
+# waiting on them anyway.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # Branch protection requires each of the jobs below by name, so the
   # workflow itself can't use a top-level paths-ignore: a skipped *workflow*


### PR DESCRIPTION
Audyt wszystkich workflow na podstawie ostatnich 120 biegów. Dwie rzeczy realnie psuły szybkość i wiarygodność Actions.

## Zmierzone

| workflow | śr. czas | maks. | porażki |
|---|---|---|---|
| Swift example (weekly) | 179 s | 182 s | 0/2 |
| **Lint examples** | 105 s | **343 s** | 0/17 |
| CodeQL | 100 s | 125 s | 0/17 |
| **Blast radius** | 100 s | 100 s | **1/1** |
| Automatic Dependency Submission | 46 s | 102 s | 0/49 |
| Draft release | 6 s | 18 s | 5/6 — **naprawione 16.08**, ostatni bieg zielony |
| pozostałe | ≤45 s | | 0 |

## 1. `lint.yml` — brak grupy `concurrency`

Trzy pushe do PR-a w ciągu minuty startowały trzy pełne macierze, a dwie pierwsze trzymały runnery, odpowiadając na pytanie, którego już nikt nie zadaje. Przy ~20 jobach każda, plus CodeQL na ośmiu językach i trzy dependency submissions walczące o tę samą pulę — stąd joby w stanie QUEUED i merge czekający na nic.

Nieaktualne biegi PR-ów są teraz anulowane. Biegi na `main` nie — historia `main` ma nieść kompletny wynik dla każdego commita i nic na nie nie czeka.

## 2. `blast-radius.yml` — padał w 100% biegów

Mierzył liczbę poprawnie przez ~2 minuty, po czym próbował wypchnąć próbkę prosto na `main`. `main` jest chroniony z `enforce_admins`, więc kończyło się `GH006: Protected branch update failed` — i pomiar szedł do kosza. Za każdym razem.

Pull request nie jest wyjściem: PR otwarty przez `GITHUB_TOKEN` nie uruchamia workflow, więc wymagane checki nigdy by nie zaraportowały i PR wisiałby wiecznie jako niemergowalny. Do tego trzeba PAT-a w sekretach repo — **a repo nie ma żadnych sekretów.**

Seria żyje więc teraz na niechronionej gałęzi `status`, obok badge'a, który i tak już tam trafiał. Ten workflow nie dotyka `main` w ogóle.

Przy okazji:
- krok `Badge` wchłonięty do kroku publikacji — **nigdy ani razu się nie wykonał**, bo krok `Commit` padał wcześniej;
- push dostał ten sam rebase-and-retry co healthcheck, bo oba piszą do `status` (healthcheck co 15 minut — kolizja to kwestia czasu);
- badge czyta najpierw liczbę, potem etykietę: `read` dzieli po pierwszej spacji, więc etykieta ze spacją po cichu zabrałaby część liczby. Dziś etykiety to nazwy hostów, ale zapytania są danymi, a dane się zmieniają.

## Czego świadomie nie ruszyłem

- **CodeQL** (100 s × 8 języków na każdym PR) i **Automatic Dependency Submission** to GitHub *default setup*, nie pliki w repo. Nie blokują merge'a — nie ma ich wśród wymaganych checków. Ograniczenie ich do `main` + harmonogramu przyspieszyłoby feedback na PR-ach, ale to osłabienie skanowania bezpieczeństwa i decyzja właściciela, nie moja.
- **`Draft release`** — 5/6 porażek to iteracja z 16.08; ostatni bieg jest zielony. Nic do naprawy.
- **Swift weekly** (179 s) — najdłuższy, ale tygodniowy i celowo wyniesiony z lintera, żeby nie decydował o czasie merge'a.

## Weryfikacja

Składnia bash obu kroków `blast-radius` sprawdzona (`bash -n`). Logika wyboru badge'a odtworzona na prawdziwym `data/blast-radius.json`: `smtp.office365.com` → 24 960 plików.
