### PR TITLE
feat(ci): powiadomienie mailem z linkiem, gdy cokolwiek czeka na akceptacje

### DIFF
--- a/.github/workflows/listings-radar.yml
+++ b/.github/workflows/listings-radar.yml
@@ -232,12 +232,16 @@ jobs:
                 'queued again.',
               ].join('\n');
 
+              // Assigned so GitHub emails a direct link. Same reasoning as in
+              // outreach-watch.yml: a queued draft that nobody is told about
+              // is a draft nobody submits.
               const created = await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title: `Listing: ${c.full_name}`.slice(0, 200),
                 body,
                 labels: [LABEL],
+                assignees: [context.repo.owner],
               });
               core.notice(`Queued #${created.data.number} — ${c.url}`);
             }

--- a/.github/workflows/outreach-watch.yml
+++ b/.github/workflows/outreach-watch.yml
@@ -338,12 +338,19 @@ jobs:
                 'again.',
               ].join('\n');
 
+              // Assigned, not just labelled. A draft that nobody is told
+              // about is a draft nobody posts, and the queue's whole value is
+              // speed - an answer four days late lands on a thread nobody is
+              // reading. GitHub emails the assignee with a direct link, which
+              // is the whole notification mechanism needed here: open the
+              // link, read the thread, post or close.
               const created = await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title: `Outreach: ${c.title}`.slice(0, 200),
                 body,
                 labels: [LABEL],
+                assignees: [context.repo.owner],
               });
               core.notice(`Queued #${created.data.number} — ${c.url}`);
             }

--- a/.github/workflows/service-healthcheck.yml
+++ b/.github/workflows/service-healthcheck.yml
@@ -279,12 +279,16 @@ jobs:
                 ].join('\n');
 
                 try {
+                  // Assigned, so GitHub emails a direct link. An outage the
+                  // owner finds out about by looking at the badge is an
+                  // outage that ran for hours.
                   await github.rest.issues.create({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     title,
                     body,
                     labels: ['service-alert'],
+                    assignees: [context.repo.owner],
                   });
                 } catch (err) {
                   core.warning(`Label may not exist yet, retrying without labels: ${err.message}`);


### PR DESCRIPTION
Każdy z tych workflow kończy się krokiem, który może wykonać tylko człowiek: opublikować odpowiedź, zgłosić wpis na listę, naprawić przekaźnik. Do tej pory każdy z nich otwierał issue i milkł — a znalezienie go wymagało pamiętania, żeby zajrzeć. Czternaście szkiców outreachowych leżało nieprzeczytanych dobę dokładnie z tego powodu.

Przypisanie issue sprawia, że **GitHub wysyła maila z bezpośrednim linkiem**. To cały potrzebny mechanizm powiadamiania: klikasz link, czytasz, akceptujesz albo zamykasz. Bez nowego kanału, bez nowej usługi, bez dodatkowych poświadczeń.

Objęte:

| workflow | co przychodzi mailem |
|---|---|
| `outreach-watch.yml` | szkic odpowiedzi na wątek, gdzie ktoś ma dokładnie ten problem |
| `listings-radar.yml` | gotowy wpis na listę kuratorską + checklista jej zasad |
| `service-healthcheck.yml` | alert o niedostępności `mx.msgwing.com` |

Przy healthchecku to waży najwięcej: awaria, o której właściciel dowiaduje się, bo akurat spojrzał na badge, to awaria, która trwała godziny.

Adresat to `context.repo.owner`, więc nie ma tu zaszytego na sztywno loginu — przypisanie idzie tam, gdzie repo.
