### PR TITLE
fix(ci): blast-radius przeczekuje limit code search i mowi dlaczego padl

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -60,19 +60,38 @@ jobs:
             total=$((total + 1))
 
             n=""
-            # The broadest phrases make GitHub's search API time out. Retry
-            # a few times before giving up; a transient 408 is common.
-            for attempt in 1 2 3 4; do
-              n=$(gh api -X GET search/code -f q="$q" -f per_page=1 \
-                    --jq .total_count 2>/dev/null || true)
-              case "$n" in
-                ''|*message*|*[!0-9]*) n=""; sleep 15 ;;
-                *) break ;;
-              esac
+            err=""
+            # Six attempts with growing backoff, not four flat 15-second ones.
+            # The code search limit is 10 requests per minute and the window
+            # is a full minute, so a run landing shortly after another one has
+            # to be able to wait that window out rather than give up inside
+            # it. Two dispatches three minutes apart did exactly that on
+            # 2026-08-17: every query failed and the run reported an outage.
+            for attempt in 1 2 3 4 5 6; do
+              if n=$(gh api -X GET search/code -f q="$q" -f per_page=1 \
+                       --jq .total_count 2>/tmp/gh-search-err); then
+                case "$n" in
+                  ''|*[!0-9]*) err="unexpected response: ${n:-empty}" ;;
+                  *) err=""; break ;;
+                esac
+              else
+                # Keep the reason. The previous version sent it to /dev/null,
+                # which is why a rate limit, a permissions problem and an
+                # empty result all looked identical from the log.
+                err=$(tr -d '\n' < /tmp/gh-search-err | cut -c1-200)
+              fi
+              n=""
+              echo "  attempt ${attempt}/6 for '$q' failed: ${err:-no reason given}"
+              # No point sleeping after the last attempt. Written as an `if`
+              # rather than `[ ... ] && sleep`, because under `set -e` a
+              # false test as the loop body's last command kills the run.
+              if [ "$attempt" -lt 6 ]; then
+                sleep $((attempt * 15))
+              fi
             done
 
             if [ -z "$n" ]; then
-              echo "::warning::'$q' could not be counted - recording null"
+              echo "::warning::'$q' could not be counted (${err:-no reason given}) - recording null"
               failures=$((failures + 1))
               counts=$(echo "$counts" | jq --arg k "$id" '.[$k] = null')
             else


### PR DESCRIPTION
Dwa uruchomienia w odstępie trzech minut sprawiły, że **wszystkie** kwerendy padły — a workflow zachował się poprawnie: odmówił zapisania próbki i zgłosił awarię, zamiast dopisać wiersz zer. Sam pomiar jest sprawny.

Przyczyna: limit GitHub code search to 10 zapytań na minutę w oknie pełnej minuty, a budżet retry wynosił cztery płaskie oczekiwania po 15 s — za mało, żeby to okno przeczekać.

## Zmiana

- **Sześć prób z rosnącym backoffem** (15/30/45/60/75 s) zamiast czterech po 15 s.
- **Ostatnia próba już nie śpi na darmo.** Zapisane jako `if`, a nie `[ ... ] && sleep`, bo pod `set -e` fałszywy test jako ostatnie polecenie ciała pętli zabija bieg. Zweryfikowane symulacją: pętla przeżywa wszystkie sześć porażek.
- **Powód porażki jest zachowywany i wypisywany** przy każdej próbie oraz w ostrzeżeniu. Wcześniej szedł do `/dev/null` — dlatego limit zapytań, brak uprawnień i naprawdę pusty wynik wyglądały w logu identycznie, i dlatego zdiagnozowanie tego zajęło trzy biegi zamiast jednego.

## Stan faktyczny

Nie deklaruję jeszcze, że blast-radius działa end-to-end. Naprawione są trzy odrębne usterki (push na chroniony `main`, przełączenie na gałąź `status`, budżet retry), ale ścieżka publikacji nie przeszła jeszcze ani razu w całości — zweryfikuję ją osobnym biegiem po zmerge'owaniu i zaraportuję wynik.
