### PR TITLE
fix(ci): liczba na badge blast-radius czytana jako liczba, nie jako kod

### DIFF
--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -172,7 +172,12 @@ jobs:
           cp /tmp/blast-radius-samples.json blast-radius-samples.json
 
           if [ "$label" != "none" ]; then
-            formatted=$(printf "%'d" "$value" | tr ',' ' ')
+            # Grouped with sed rather than printf "%'d": the runner's locale
+            # is C, where that format simply does not group, which is why the
+            # first badge ever published read "24960 files". This is the
+            # headline number of the whole blast-radius argument - it has to
+            # read as a quantity, not as an identifier.
+            formatted=$(echo "$value" | sed -E ':a;s/([0-9])([0-9]{3})($|[^0-9])/ /;ta')
             cat > blast-radius.json <<JSON
           {"schemaVersion":1,"label":"$label in public code","message":"$formatted files","color":"critical"}
           JSON


### PR DESCRIPTION
Pierwszy badge, jaki ten workflow w ogóle opublikował, brzmiał `24960 files`. Grupowanie pochodziło z `printf "%'d"`, które w locale `C` używanym przez runnera po prostu nie grupuje — a nikt tego wcześniej nie widział, bo krok nigdy nie dobiegł do końca.

To jest nagłówkowa liczba całej narracji o skali problemu. `24 960` czyta się jak wielkość, `24960` jak identyfikator.

Grupowanie przez `sed`, niezależne od locale. Przetestowane: `24960 → 24 960`, `22080 → 22 080`, `999 → 999`, `1234567 → 1 234 567`.