### PR TITLE
docs: panel statusu nie moze odsylac do nieopublikowanej paczki

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -844,11 +844,20 @@
       var RUNS = 'https://api.github.com/repos/msgwing/ZeroSMTP/actions/workflows/'
                + 'service-healthcheck.yml/runs?per_page=1&status=completed';
 
+      // Deliberately not `npx zerosmtp-check`: that package is not published
+      // to npm - publish-npm.yml needs an NPM_TOKEN secret the repository
+      // does not have, and has never run. Telling a reader to run a command
+      // that 404s is worse than telling them nothing. These two need no
+      // install and are already in the troubleshooting guide.
       function selfTest() {
         return '<p class="muted">To test from your own network rather than ours &mdash; '
-             + 'which is the result that actually decides whether your device can '
-             + 'send &mdash; run <code>npx zerosmtp-check</code>. It opens both ports '
-             + 'and completes the TLS handshake, and sends nothing.</p>';
+             + 'which is the result that actually decides whether your device can send '
+             + '&mdash; open a terminal:</p>'
+             + '<ul>'
+             + '<li>Windows: <code>Test-NetConnection mx.msgwing.com -Port 587</code></li>'
+             + '<li>Linux or macOS: <code>openssl s_client -starttls smtp -connect mx.msgwing.com:587</code></li>'
+             + '</ul>'
+             + '<p class="muted">Both open the connection and send no mail.</p>';
       }
 
       el.addEventListener('click', function(e){


### PR DESCRIPTION
Panel guzika stanu proponował `npx zerosmtp-check` jako sposób na test z własnej sieci. **Ta paczka zwraca 404 z rejestru npm.**

Znalezione przy pierwszym przebiegu nowego `security-director`:

- `publish-npm.yml` wymaga sekretu `NPM_TOKEN`
- repozytorium ma **zero sekretów**
- workflow **nigdy się nie uruchomił** — lista biegów jest pusta
- `https://registry.npmjs.org/zerosmtp-check` → **404**

Odesłanie czytelnika pod polecenie, które padnie, jest gorsze niż nieodesłanie go nigdzie — a na stronie, której cały argument brzmi „verifiably up", to najdroższe możliwe miejsce na pomyłkę. Błąd był mój, wszedł wczoraj w #159.

## Zamiast tego

Dwa jednolinijkowce bez instalacji, obecne już w przewodniku troubleshootingu:

- Windows: `Test-NetConnection mx.msgwing.com -Port 587`
- Linux/macOS: `openssl s_client -starttls smtp -connect mx.msgwing.com:587`

Oba otwierają połączenie i nie wysyłają poczty.

## Decyzja dla Ciebie

Opublikowanie CLI jest warte zachodu — `npx zerosmtp-check` to jedyny artefakt tego projektu, który ktoś uruchamia i podaje dalej. Wymaga jednak automation tokena z npmjs.com wstawionego jako sekret `NPM_TOKEN`. **Poświadczeń nie tworzę i nie wprowadzam** — to musi zrobić człowiek.
