### PR TITLE
fix(ci): naprawa dwoch workflow, ktorych GitHub nie mogl sparsowac

### DIFF
--- a/.github/check-workflows.py
+++ b/.github/check-workflows.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Reject workflow files GitHub would refuse to parse.
+
+A workflow with a syntax error fails at startup: no job, no log, and a run
+named after the file path instead of the workflow. Nothing points at the
+cause. Two files sat like that for twelve runs each on 2026-08-17, each
+carrying a control character a scripted edit had written into a regex where
+an escape sequence was meant.
+"""
+import glob
+import sys
+
+import yaml
+
+ALLOWED_CONTROL = {"\n", "\r"}
+
+bad = False
+for path in sorted(glob.glob(".github/workflows/*.yml")):
+    raw = open(path, encoding="utf-8", newline="").read()
+
+    control = sorted({hex(ord(c)) for c in raw
+                      if ord(c) < 32 and c not in ALLOWED_CONTROL and c != "\t"})
+    if control:
+        print(f"::error file={path}::control characters {control} — GitHub "
+              f"rejects the whole file, and the run reports no reason")
+        bad = True
+
+    if "\t" in raw:
+        print(f"::error file={path}::literal tab — write \t in a regex "
+              f"rather than embedding a real tab")
+        bad = True
+
+    try:
+        yaml.safe_load(raw)
+    except Exception as exc:
+        print(f"::error file={path}::does not parse as YAML: {exc}")
+        bad = True
+
+print("Workflow files: clean." if not bad else "Workflow files: problems above.")
+sys.exit(1 if bad else 0)

--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -177,7 +177,7 @@ jobs:
             # first badge ever published read "24960 files". This is the
             # headline number of the whole blast-radius argument - it has to
             # read as a quantity, not as an identifier.
-            formatted=$(echo "$value" | sed -E ':a;s/([0-9])([0-9]{3})($|[^0-9])/ /;ta')
+            formatted=$(echo "$value" | sed -E ':a;s/([0-9])([0-9]{3})($|[^0-9])/\1 \2\3/;ta')
             cat > blast-radius.json <<JSON
           {"schemaVersion":1,"label":"$label in public code","message":"$formatted files","color":"critical"}
           JSON

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -71,6 +71,16 @@ jobs:
         run: python tools/build-error-pages.py --check
       - name: Blast radius page matches data/blast-radius.json
         run: python tools/build-blast-radius.py --check
+      # A workflow file GitHub cannot parse fails at startup with no job and
+      # no log, so it stays invisible until somebody notices a run named after
+      # a file path instead of a workflow. Two files sat like that for twelve
+      # runs each on 2026-08-17, carrying a 0x01 and a 0x08 that a scripted
+      # edit had written where a regex meant backslash-1 and backslash-b.
+      # Cheap to check, expensive to miss.
+      - name: Workflow files parse, and carry no control characters
+        run: |
+          pip install --quiet pyyaml
+          python .github/check-workflows.py
 
   bash:
     needs: changes

--- a/.github/workflows/listings-radar.yml
+++ b/.github/workflows/listings-radar.yml
@@ -149,7 +149,7 @@ jobs:
               // README happens to contain the word "email", which is true of
               // most repos and says nothing. A directory looks like a
               // directory: dozens of entry-shaped lines.
-              const entries = (readme.match(/^[ 	]*[-*] \[[^\]]+\]\(https?:\/\//gm) || []).length;
+              const entries = (readme.match(/^[ \t]*[-*] \[[^\]]+\]\(https?:\/\//gm) || []).length;
               if (entries < 40) {
                 core.info(`${r.full_name}: only ${entries} list entries - not a directory.`);
                 rejected++;
@@ -162,7 +162,7 @@ jobs:
               // the wrong list, and submitting anyway is how a maintainer
               // learns to ignore you.
               const heading = readme.match(
-                /^#{1,4}[ 	]+.*(e-?mail|smtp|mail|transactional).*$/im);
+                /^#{1,4}[ \t]+.*\b(e-?mail|smtp|mail|transactional)\b.*$/im);
               if (!heading) {
                 core.info(`${r.full_name}: ${entries} entries but no mail section.`);
                 rejected++;


### PR DESCRIPTION
`blast-radius.yml` i `listings-radar.yml` **padały przy każdym biegu od ostatniej edycji — po dwanaście razy każdy** — i żadna porażka nie mówiła dlaczego.

## Dlaczego to było niewidoczne

Workflow, którego GitHub nie potrafi sparsować, **pada przy starcie: bez joba, bez logu, a bieg nazywa się ścieżką pliku zamiast nazwą workflow**. Dlatego lista Actions wyglądała na zepsutą, a nie było w co kliknąć.

## Przyczyna — mój błąd

Oba pliki zawierały **znaki sterujące**. Skryptowa edycja wpisała `0x01`, `0x02`, `0x03` do `blast-radius.yml` tam, gdzie podstawienie `sed` miało mieć `\1 \2 \3`, oraz `0x08` i dosłowne tabulatory do `listings-radar.yml` tam, gdzie regex miał mieć `\b` i `\t`. Zwykłe stringi Pythona zamieniły sekwencje ucieczki na bajty, które nazywają. Same wyrażenia były poprawne — plik nie.

## Strażnik

`.github/check-workflows.py` chodzi teraz w jobie `device-table`, który **nie jest filtrowany po ścieżkach**, więc wykonuje się przy każdym PR. Odrzuca znaki sterujące, dosłowne tabulatory i wszystko, co nie parsuje się jako YAML.

Złapał dokładnie ten sam błąd **w trakcie własnego dopisywania** — pierwsza wersja tego kroku wstawiła znaki sterujące do `lint.yml`. To jest najlepszy argument za jego istnieniem, jaki mogę podać.

Wszystkie 18 plików workflow zwalidowane lokalnie: **czyste**.
