### PR TITLE
fix(ci): niepoprawne uprawnienie zabijalo raport postepow

### DIFF
--- a/.github/check-workflows.py
+++ b/.github/check-workflows.py
@@ -14,6 +14,17 @@ import yaml
 
 ALLOWED_CONTROL = {"\n", "\r"}
 
+# The complete set GITHUB_TOKEN accepts. Anything else makes GitHub reject the
+# whole workflow at startup, with the same silent, logless failure a syntax
+# error produces - `administration: read` did exactly that on 2026-08-17,
+# added while trying to reach the traffic API, which the Actions token cannot
+# read under any permission.
+VALID_PERMISSIONS = {
+    "actions", "attestations", "checks", "contents", "deployments",
+    "discussions", "id-token", "issues", "models", "packages", "pages",
+    "pull-requests", "repository-projects", "security-events", "statuses",
+}
+
 bad = False
 for path in sorted(glob.glob(".github/workflows/*.yml")):
     raw = open(path, encoding="utf-8", newline="").read()
@@ -31,10 +42,32 @@ for path in sorted(glob.glob(".github/workflows/*.yml")):
         bad = True
 
     try:
-        yaml.safe_load(raw)
+        doc = yaml.safe_load(raw)
     except Exception as exc:
         print(f"::error file={path}::does not parse as YAML: {exc}")
         bad = True
+        continue
+
+    # Valid YAML is not the same as a valid workflow. An unknown key under
+    # `permissions:` makes GitHub reject the file at startup with the same
+    # silent, logless failure - `administration: read` did exactly that on
+    # 2026-08-17 while trying to reach the traffic API, which the Actions
+    # token cannot read at all.
+    def check_permissions(perms, where):
+        global bad
+        if not isinstance(perms, dict):
+            return
+        unknown = sorted(set(perms) - VALID_PERMISSIONS)
+        if unknown:
+            print(f"::error file={path}::unknown permission(s) {unknown} "
+                  f"in {where} — GitHub rejects the whole workflow")
+            bad = True
+
+    if isinstance(doc, dict):
+        check_permissions(doc.get("permissions"), "top-level permissions")
+        for name, job in (doc.get("jobs") or {}).items():
+            if isinstance(job, dict):
+                check_permissions(job.get("permissions"), f"job `{name}`")
 
 print("Workflow files: clean." if not bad else "Workflow files: problems above.")
 sys.exit(1 if bad else 0)

--- a/.github/workflows/progress-report.yml
+++ b/.github/workflows/progress-report.yml
@@ -23,15 +23,14 @@ on:
     - cron: '0 6 */3 * *'   # every three days, 06:00 UTC
   workflow_dispatch:
 
-# `administration: read` is what the traffic endpoints map to. Without it the
-# first run reported "Resource not accessible by integration" and the report
-# went out with its headline numbers missing - which is the one thing this
-# report cannot be, since GitHub keeps traffic for only 14 days and nobody
-# else is writing it down.
+# No `administration:` here, however much the traffic endpoints want it: it is
+# not a valid GITHUB_TOKEN permission, and adding it made GitHub reject the
+# whole workflow at startup - a failure with no job and no log. The traffic
+# API is simply out of reach for the Actions token; the report says so in
+# words rather than pretending the numbers are zero.
 permissions:
   contents: read
   issues: write
-  administration: read
 
 jobs:
   report:
@@ -108,7 +107,7 @@ jobs:
               L.push(`| Unikalni odwiedzający (14 dni) | **${num(views.uniques)}** |`);
               L.push(`| Odsłony (14 dni) | ${num(views.count)} |`);
             } else {
-              L.push('| Ruch | ⚠️ **niedostępny — API odmówiło dostępu** |');
+              L.push('| Ruch | — _wymaga tokena osobistego, patrz niżej_ |');
             }
             L.push(`| Gwiazdki | **${meta.stargazers_count}** |`);
             L.push(`| Forki | ${meta.forks_count} |`);
@@ -165,6 +164,18 @@ jobs:
             } else {
               L.push('**Nic nie czeka na Twoją decyzję.** Zmiany w tym repozytorium zatwierdza rada;');
               L.push('do Ciebie trafia wyłącznie publikacja u obcych i tworzenie poświadczeń.');
+            }
+            L.push('');
+            if (!views) {
+              L.push('');
+              L.push('> **Liczby odwiedzin są poza zasięgiem tego raportu.** Endpointy ruchu');
+              L.push('> wymagają tokena osobistego, a token Actions ich nie ma i mieć nie może.');
+              L.push('> Do odczytania ręcznie w dowolnej chwili:');
+              L.push('>');
+              L.push('> ```bash');
+              L.push('> gh api repos/' + owner + '/' + repo + '/traffic/views');
+              L.push('> gh api repos/' + owner + '/' + repo + '/traffic/popular/referrers');
+              L.push('> ```');
             }
             L.push('');
             L.push('_Raport generowany automatycznie co trzy dni. Nie wymaga odpowiedzi — zamknij go._');


### PR DESCRIPTION
`administration: read` **nie jest uprawnieniem `GITHUB_TOKEN`**. Dodanie go sprawiło, że GitHub odrzucał cały workflow przy starcie — ta sama cicha porażka co przy znakach sterujących, bez joba i bez logu. Raport, który miał naprawić brak liczb odwiedzin, przestał się uruchamiać w ogóle.

Endpointy ruchu są poza zasięgiem tokena Actions **przy dowolnym uprawnieniu**. Raport mówi to teraz wprost i podaje dwa polecenia `gh api` do odczytania ręcznie — zamiast wypisywać zero albo przepraszającą kreskę, która czyta się jak spokojne dwa tygodnie.

`check-workflows.py` waliduje teraz również **nazwy uprawnień**, na poziomie workflow i joba, wobec udokumentowanego zbioru. Test negatywny potwierdza, że łapie dokładnie ten błąd: ponowne wstawienie `administration: read` wywala check.