### PR TITLE
docs: audyt strony na zywo - kod byl nieczytelny, dwa twierdzenia przeterminowane

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ with anything that already speaks SMTP.
   environment variables, plus Ansible and Docker Compose recipes and setup
   guides for Windows Server, Linux, and printers by brand.
 - **Verifiably up** — the status badge above is a real check that runs against
-  `mx.msgwing.com` every 6 hours, not a static image.
+  `mx.msgwing.com` every 15 minutes, not a static image.
 
 Good for: contact forms · password resets · CI/CD and monitoring alerts ·
 scan-to-email · IoT and device notifications · homelabs.

--- a/docs/BLAST-RADIUS.md
+++ b/docs/BLAST-RADIUS.md
@@ -62,4 +62,4 @@ The figure and the data are free to cite, quote and republish under the reposito
 - [What the error will look like](ERROR-MESSAGES.md) when it starts failing
 - [Whether your hardware has an OAuth path](DEVICE-COMPATIBILITY.md), with a link to every vendor statement
 - [Every migration option](EXCHANGE-ONLINE-SMTP-AUTH.md), including the ones that are not this project
-- `npx zerosmtp-check` — check in two seconds whether your network even lets SMTP out, before assuming it is the credentials
+- `./check-connection.sh` (or `check-connection.ps1`) — check in two seconds whether your network even lets SMTP out, before assuming it is the credentials

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -19,29 +19,8 @@ spam:
 **This is why every example in this repository defaults to port `465`
 (implicit SSL/TLS) or `587` (STARTTLS), never port `25`.** If a script hangs
 until it times out rather than failing immediately, this is the first thing
-to check. Run the connectivity-only healthcheck (no credentials needed, no
-email sent):
-
-```bash
-npx zerosmtp-check
-```
-
-Nothing to install and nothing to clone. It resolves the host, connects on
-587 and 465, does the STARTTLS or implicit-TLS handshake, checks whether
-*this machine's* trust store accepts the certificate, and lists the `AUTH`
-mechanisms the server offers. No credentials are sent and no mail is
-delivered — the conversation stops after `EHLO`.
-
-It works against any SMTP host, which is the point when you are trying to
-establish whether the problem is the server or your network:
-
-```bash
-npx zerosmtp-check smtp.office365.com
-npx zerosmtp-check mail.example.com --port 25
-npx zerosmtp-check --json          # exit 0 = fine, 1 = a problem, 2 = DNS
-```
-
-If Node is not available, the repository has the same checks as scripts:
+to check. Run the connectivity-only check — no credentials needed, no email
+sent, and the conversation stops after `EHLO`:
 
 ```bash
 ./check-connection.sh
@@ -51,7 +30,17 @@ If Node is not available, the repository has the same checks as scripts:
 ./check-connection.ps1
 ```
 
-Or check manually:
+Both live in the [repository](https://github.com/msgwing/ZeroSMTP). They
+resolve the host, connect on 587 and 465, do the STARTTLS or implicit-TLS
+handshake, check whether *this machine's* trust store accepts the
+certificate, and list the `AUTH` mechanisms the server offers.
+
+They work against any SMTP host, which is the point when you are trying to
+establish whether the problem is the server or your network — pass the
+hostname as an argument.
+
+If you would rather not clone anything, the two one-liners below need nothing
+installed at all:
 
 ```bash
 # Bash/Linux/macOS — quick manual connectivity check

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -234,10 +234,39 @@
          exactly what this site is full of, and one unwrapped line turning the
          whole page into a horizontal scroller is the defect that would have
          disqualified this design under its own scoring. */
-      .markdown-body pre {
-        background:var(--code-bg); border:1px solid var(--line); border-radius:10px;
+      /* The theme wraps fenced code in div.highlight and paints that light,
+         which outranked the rule below and left light text on a light ground
+         at 1.09:1 - measured on the live site, not guessed. Both surfaces are
+         claimed here, and Rouge's token colours are re-pointed for a dark
+         ground: its defaults are navy and black, designed for the light one. */
+      .markdown-body pre,
+      .markdown-body div.highlight,
+      .markdown-body .highlight pre {
+        background:var(--code-bg); border-radius:10px;
         overflow-x:auto; max-width:100%;
       }
+      .markdown-body div.highlight { border:1px solid var(--line); }
+      .markdown-body .highlight pre { border:0; margin:0; }
+      .markdown-body pre code,
+      .markdown-body .highlight pre code { color:var(--code-ink); background:transparent; }
+
+      .markdown-body .highlight .c,  .markdown-body .highlight .c1,
+      .markdown-body .highlight .cm, .markdown-body .highlight .cp,
+      .markdown-body .highlight .cs { color:#A8B2C7; font-style:italic; }
+      .markdown-body .highlight .n,  .markdown-body .highlight .nx,
+      .markdown-body .highlight .o,  .markdown-body .highlight .p,
+      .markdown-body .highlight .w  { color:var(--code-ink); }
+      .markdown-body .highlight .nt, .markdown-body .highlight .nc,
+      .markdown-body .highlight .nf { color:#9BC4FF; }
+      .markdown-body .highlight .s,  .markdown-body .highlight .s1,
+      .markdown-body .highlight .s2, .markdown-body .highlight .sb,
+      .markdown-body .highlight .se { color:#FFD27D; }
+      .markdown-body .highlight .k,  .markdown-body .highlight .kd,
+      .markdown-body .highlight .kn, .markdown-body .highlight .kr { color:#FFA8D4; }
+      .markdown-body .highlight .m,  .markdown-body .highlight .mi,
+      .markdown-body .highlight .mf { color:#8FE9C4; }
+      .markdown-body .highlight .na, .markdown-body .highlight .nv { color:#FFD24A; }
+      .markdown-body .highlight .err { color:#FF9E96; background:transparent; }
       .markdown-body pre code { background:transparent; color:var(--code-ink); }
 
       /* ---------- masthead ---------- */

--- a/docs/index.md
+++ b/docs/index.md
@@ -121,7 +121,7 @@ Full quickstart, 15 language examples and setup guides are in the
 ---
 
 <p><small>
-Service status is checked automatically every 6 hours —
+Service status is checked automatically every 15 minutes —
 <a href="https://github.com/msgwing/ZeroSMTP/actions/workflows/service-healthcheck.yml">see the live check</a>.
 Questions or corrections: <a href="https://github.com/msgwing/ZeroSMTP/issues/new/choose">open an issue</a>.
 </small></p>


### PR DESCRIPTION
Audyt `https://docs.msgwing.com/` po zmianie layoutu — strona główna i dziewięć podstron.

## Co jest w porządku

Warto zapisać, bo zespół zdążył już przepisywać rzeczy, które nie były zepsute:

- **9/9 podstron**: HTTP 200, dokładnie jeden `<h1>`, opis meta, dok z rejestracją
- **sitemap: 40 URL-i** (liczone jako wystąpienia — plik jest w jednej linii, `grep -c` skłamie)
- **JSON-LD nadal emitowany** na FAQ i PRINTERS — redesign go nie urwał
- **zero martwych linków wewnętrznych**
- **zero zasobów z obcych hostów** — publiczna obietnica z FAQ dotrzymana
- layout trzyma się na podstronie z szerokimi tabelami przy 375 px: brak przewijania strony, dok 62 px nie zasłania treści

## Cztery rzeczy nie były w porządku

### 1. Bloki kodu miały kontrast 1,09:1

**Jasny tekst na jasnym tle — praktycznie niewidoczny.** Na stronie dokumentacji, której treść to w większości komunikaty błędów.

Redesign ustawił kolor kodu z nowej palety, ale motyw maluje `div.highlight` i **wygrał z regułą tła** — więc zmienił się wyłącznie tekst. Teraz zajęte są obie powierzchnie, a kolory tokenów Rouge przestawione pod ciemne tło: jego domyślne to granat i czerń, rysowane pod jasne.

**Najgorsza para: 7,56:1.** Zweryfikowane z regułami motywu odtworzonymi w pełnej wadze, a nie z usuniętym arkuszem — inaczej test nie dowodziłby niczego.

### 2. TROUBLESHOOTING kazał uruchomić `npx zerosmtp-check` — cztery razy

Paczka zwraca **404 z npm**, bo nigdy nie została opublikowana (repo nie ma `NPM_TOKEN`). To była jedyna strona, na której czytelnik jest już zablokowany. Działające skrypty leżały niżej na tej samej stronie i teraz prowadzą.

### 3. BLAST-RADIUS powtarzał to samo polecenie

### 4. Strona główna i README obiecywały sprawdzanie statusu „co 6 godzin"

Healthcheck chodzi **co 15 minut** od trzech dni. Zaniżanie własnego, jedynego mierzalnego twierdzenia to dziwny sposób na jego stawianie.
