### PR TITLE
docs: regeneracja BLAST-RADIUS.md - main przestaje byc czerwony

### DIFF
--- a/docs/BLAST-RADIUS.md
+++ b/docs/BLAST-RADIUS.md
@@ -62,4 +62,4 @@ The figure and the data are free to cite, quote and republish under the reposito
 - [What the error will look like](ERROR-MESSAGES.md) when it starts failing
 - [Whether your hardware has an OAuth path](DEVICE-COMPATIBILITY.md), with a link to every vendor statement
 - [Every migration option](EXCHANGE-ONLINE-SMTP-AUTH.md), including the ones that are not this project
-- `./check-connection.sh` (or `check-connection.ps1`) — check in two seconds whether your network even lets SMTP out, before assuming it is the credentials
+- `npx zerosmtp-check` — check in two seconds whether your network even lets SMTP out, before assuming it is the credentials


### PR DESCRIPTION
Job `device-table` padał przy **każdym pushu na `main`**, odkąd zmienił się format liczby: zacommitowana strona i `data/blast-radius.json` różniły się o jedną linię. Check miał rację, strona była nieaktualna.

Znalazła to rada ds. zmian przy okazji przeglądu PR-ów zależności — poza swoim zakresem, więc zgłosiła zamiast naprawiać.

Job zostaje bez bramki `needs: changes`: wyłapał realną rozbieżność, a nie fałszywy alarm. Wygenerowana strona, która po cichu odjeżdża od swoich danych, to dokładnie ta awaria, której ten job ma zapobiegać. Czego potrzebuje, to żeby ktoś patrzył, gdy czerwienieje — **lint, który stale świeci na czerwono, uczy zespół, żeby przestał go czytać.**