### PR TITLE
fix(docs): dwa twierdzenia poprawione w generatorze, nie na stronie

### DIFF
--- a/docs/BLAST-RADIUS.md
+++ b/docs/BLAST-RADIUS.md
@@ -10,7 +10,7 @@ description: "A weekly count of public files on GitHub that still point at Micro
 
 At least **24,960 public files on GitHub** still contain a Microsoft 365 SMTP hostname. Every one of them is a place where somebody wrote down a setting that stops working when Basic authentication is switched off by default at the end of December 2026.
 
-Measured 2026-08-16. Re-measured every week — the series is below, and it is the more interesting half: a single number says the problem is large, a series says whether anyone is fixing it.
+Measured 2026-08-16. The measurement runs every Monday, and the series below has 1 sample so far: a single number says the problem is large, a series says whether anyone is fixing it.
 
 ## Current count
 
@@ -62,4 +62,4 @@ The figure and the data are free to cite, quote and republish under the reposito
 - [What the error will look like](ERROR-MESSAGES.md) when it starts failing
 - [Whether your hardware has an OAuth path](DEVICE-COMPATIBILITY.md), with a link to every vendor statement
 - [Every migration option](EXCHANGE-ONLINE-SMTP-AUTH.md), including the ones that are not this project
-- `npx zerosmtp-check` — check in two seconds whether your network even lets SMTP out, before assuming it is the credentials
+- `./check-connection.sh`, or `check-connection.ps1` on Windows — check in two seconds whether your network even lets SMTP out, before assuming it is the credentials

--- a/tools/build-blast-radius.py
+++ b/tools/build-blast-radius.py
@@ -65,9 +65,14 @@ def buduj(dane):
         "authentication is switched off by default at the end of December "
         "2026.",
         "",
-        f"Measured {ostatnia['date']}. Re-measured every week — the series is "
-        "below, and it is the more interesting half: a single number says the "
-        "problem is large, a series says whether anyone is fixing it.",
+        # The count of samples, not a promise about cadence. The page said
+        # "re-measured every week" while the series held a single point,
+        # and the first reader to check that would have been right to stop
+        # believing the rest of it. The schedule is stated as a schedule.
+        f"Measured {ostatnia['date']}. The measurement runs every Monday, and "
+        f"{'the series below has ' + str(len(probki)) + ' sample' + ('' if len(probki) == 1 else 's') + ' so far' if len(probki) < 4 else 'the series below is the more interesting half'}: "
+        "a single number says the problem is large, a series says whether "
+        "anyone is fixing it.",
         "",
         "## Current count",
         "",
@@ -166,8 +171,14 @@ def buduj(dane):
         "with a link to every vendor statement",
         "- [Every migration option](EXCHANGE-ONLINE-SMTP-AUTH.md), including "
         "the ones that are not this project",
-        "- `npx zerosmtp-check` — check in two seconds whether your network "
-        "even lets SMTP out, before assuming it is the credentials",
+        # Deliberately not `npx zerosmtp-check`: that package returns 404
+        # from npm and has never been published, because the repository
+        # has no NPM_TOKEN. Corrected twice on the generated page before
+        # anybody noticed the page is generated and this script was
+        # putting it straight back.
+        "- `./check-connection.sh`, or `check-connection.ps1` on Windows — "
+        "check in two seconds whether your network even lets SMTP out, "
+        "before assuming it is the credentials",
         "",
     ]
 


### PR DESCRIPTION
Obie te rzeczy były już raz poprawione — **na wygenerowanej stronie**. Następne uruchomienie generatora wstawiło je z powrotem.

Reguła `content-engineer` mówi wprost: nigdy nie edytuj strony generowanej, zmień generator. To jest cena zignorowania jej.

## `npx zerosmtp-check` — po raz trzeci

Paczka zwraca **404 z npm** i nigdy nie została opublikowana, bo repozytorium nie ma `NPM_TOKEN`. Usunięta z README, z panelu statusu i ze strony troubleshootingu — **przetrwała tutaj**, bo ten plik odtwarza stronę z szablonu. Zastąpiona dwoma skryptami, które istnieją.

## „Re-measured every week" było obietnicą, nie faktem

Seria ma **jedną opublikowaną próbkę**. Zgłosił to `trust-safety`, rozstrzygając, czy tę liczbę wolno oferować jako badge do osadzania u innych — i ma rację, że twierdzenie musi się bronić, **zanim** liczba trafi na cudzą stronę. Pierwszy czytelnik, który to sprawdzi, będzie miał prawo przestać wierzyć reszcie strony.

Zdanie podaje teraz harmonogram jako harmonogram i liczy próbki, które faktycznie ma:

> Measured 2026-08-16. The measurement runs every Monday, and **the series below has 1 sample so far**: a single number says the problem is large, a series says whether anyone is fixing it.

Pozostanie prawdziwe przy drugiej próbce i przy czterdziestej.
