### PR TITLE
fix(ci): raport postepow zamyka poprzedni sam

### DIFF
--- a/.github/workflows/progress-report.yml
+++ b/.github/workflows/progress-report.yml
@@ -178,12 +178,35 @@ jobs:
               L.push('> ```');
             }
             L.push('');
-            L.push('_Raport generowany automatycznie co trzy dni. Nie wymaga odpowiedzi — zamknij go._');
+            L.push('_Raport generowany automatycznie co trzy dni. Nie wymaga odpowiedzi — poprzedni zamyka się sam._');
 
             const issue = await github.rest.issues.create({
               owner, repo,
               title: `Raport postępów — ${day}`,
               body: L.join('\n'),
               assignees: [owner],
+              labels: ['raport'],
             });
             core.notice(`Raport: ${issue.data.html_url}`);
+
+            // A report is a snapshot and the next one supersedes it. Left for a
+            // person to close, three accumulated in six days and the owner had
+            // to ask why fourteen issues were open. Nobody should have to
+            // notice that: a bot that opens an issue on a schedule and never
+            // closes one fills the queue until the queue stops being read -
+            // which is the same lesson the outreach queue already taught.
+            const older = (await github.rest.issues.listForRepo({
+              owner, repo, state: 'open', labels: 'raport', per_page: 100,
+            })).data.filter(i => !i.pull_request && i.number !== issue.data.number);
+
+            for (const o of older) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: o.number,
+                body: `Zastąpiony przez #${issue.data.number}.`,
+              });
+              await github.rest.issues.update({
+                owner, repo, issue_number: o.number,
+                state: 'closed', state_reason: 'completed',
+              });
+              core.info(`Zamknięto poprzedni raport #${o.number}.`);
+            }


### PR DESCRIPTION
Otwierał zgłoszenie co trzy dni, prosił człowieka o zamknięcie i **nikt tego nie robił**. Trzy uzbierały się w sześć dni, a właściciel musiał zapytać, dlaczego jest czternaście otwartych zgłoszeń.

To jest dokładnie ta rzecz, której właściciel nigdy nie powinien zauważać.

## Naprawa

Raport jest **migawką**, a następny go unieważnia. Workflow etykietuje teraz swój wynik jako `raport` i przy każdym biegu komentuje oraz zamyka wszystkie wcześniejsze. Nic nie ginie — zamknięcie wskazuje zgłoszenie, które je zastąpiło.

Stopka przestała prosić czytelnika o zamknięcie, bo **to była instrukcja, która nie zadziałała**.

## Ta sama lekcja, zapisana już wcześniej

Kolejka outreachowa nauczyła nas, że **kolejka zapełniająca się szybciej, niż jest opróżniana, przestaje być czytana** — a wtedy ta jedna sprawa w niej, która miała znaczenie, też nie zostaje przeczytana.

Dokładnie to działo się w skrzynce właściciela: #189 leżało obok #173, jedynej rzeczy realnie odblokowującej kanał, i rozcieńczało ją. Rada ds. zmian orzekła już wcześniej, że ta eskalacja była błędem — zgłoszenie zostało z tej kolejki wyjęte.

## Stan kolejki właściciela po sprzątaniu

Z trzech na dwa, i oba są prawdziwe: **#173** (`NPM_TOKEN`) i **#190** (wgranie karty repozytorium). Obie to poświadczenia albo ustawienia konta — czyli rzeczy, których zespół nie może zrobić za właściciela.
