### PR TITLE
ci(lint): pin luaVersion to a 5.1 + 5.4 matrix instead of the action default

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -161,9 +161,33 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    strategy:
+      # Both versions always report. If 5.1 breaks, we want to see whether 5.4
+      # still passes - cancelling the sibling would hide half the answer.
+      fail-fast: false
+      matrix:
+        # Pinned deliberately, and to two versions on purpose (measured
+        # 2026-08-19, #191). leafo/gh-actions-lua@v13 moved its default
+        # luaVersion from 5.4 to 5.5, so this job silently started building
+        # Lua 5.5.0 from source; 5.5.0 shipped 2025-12-15 and is in no distro
+        # repository yet, meaning the example was being checked against an
+        # interpreter no reader can install.
+        #   5.4 - what docs/LINUX.md tells readers to apt/dnf/zypper install.
+        #   5.1 - the stricter parser, and the only thing that verifies the
+        #         "Lua 5.1+" claim in the header of lua-zerosmtp.lua. It is
+        #         what rejects goto/::labels::/`//`/bitwise ops creeping in.
+        # Both build from source in well under a minute and run in parallel,
+        # so wall-clock cost is ~0. Safe to rename the job: `lua` is not a
+        # required status check on main (verified 2026-08-19; the eleven
+        # required contexts are bash, csharp, go, java, kotlin,
+        # node-and-typescript, php, powershell, python, ruby, rust). Renaming
+        # a *required* job would block every future pull request permanently.
+        luaVersion: ['5.1', '5.4']
     steps:
       - uses: actions/checkout@v7
       - uses: leafo/gh-actions-lua@v13
+        with:
+          luaVersion: ${{ matrix.luaVersion }}
       - name: Syntax-check Lua script
         run: luac -p lua-zerosmtp.lua
 


### PR DESCRIPTION
Fixes #191.

`leafo/gh-actions-lua@v13` (merged in #184) moved its default `luaVersion` from
5.4 to 5.5. The `lua` job passed no `with:` block, so it silently followed and
started building Lua 5.5.0 from source. 5.5.0 shipped 2025-12-15 and is in no
distro repository, so the job was proving the example parses on an interpreter
no reader can install.

**Chosen: the matrix, not a bare 5.4 pin.**

| version | why it is in the matrix |
| --- | --- |
| `5.4` | what `docs/LINUX.md` line 50 tells readers to `apt`/`dnf`/`zypper` install |
| `5.1` | the stricter parser, and the only thing that verifies the `-- Lua 5.1+` claim in the header of `lua-zerosmtp.lua` |

Pinning 5.4 alone would have meant editing the file header down to `Lua 5.4+`,
because a compatibility claim nobody measures is the same class of defect as a
docs page pointing at an unpublished package. The matrix keeps the claim and
verifies it instead, for two parallel jobs of well under a minute each.

`fail-fast: false` so a failure on 5.1 still reports whether 5.4 passed —
cancelling the sibling would hide half the answer.

**Verified before pushing**

- `lua` is **not** a required status check on `main`. The eleven required
  contexts are `bash`, `csharp`, `go`, `java`, `kotlin`, `node-and-typescript`,
  `php`, `powershell`, `python`, `ruby`, `rust` (read from the branch
  protection API, 2026-08-19). The matrix renames the job to `lua (5.1)` /
  `lua (5.4)`; doing that to a *required* job would block every future pull
  request permanently.
- `leafo/gh-actions-lua@v13` still accepts the `5.1` and `5.4` shorthand
  aliases (upstream README, "Version aliases").
- `lua-zerosmtp.lua` contains no post-5.1 syntax — no `goto`, no `::labels::`,
  no `//`, no bitwise operators, no `<const>`/`<close>`, and the only string
  escapes in the file are `\n` and `\r`. The 5.1 leg is expected green, and the
  CI run on this PR is the actual measurement.
- `python .github/check-workflows.py` → `Workflow files: clean.`

Nothing else in `lint.yml` is touched.
