### PR TITLE
docs: state both limits in the two og:descriptions that are offers

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -16,10 +16,14 @@
 
 title: ZeroSMTP
 tagline: Free SMTP relay that still accepts basic username/password auth
+# Fallback description for every page that has no `description:` of its own
+# below, and the site description in the JSON-LD. It is an offer, so it
+# carries both limits: the 200/day cap and the from-address. See the
+# index.md scope for the other one. 159 chars, under the ~160 SERP budget.
 description: >-
-  Free SMTP relay for printers, scanners and legacy apps affected by the
-  Microsoft 365 SMTP AUTH Basic authentication shutdown. Plain
-  username/password auth, no OAuth required.
+  Free SMTP relay for printers, scanners and legacy apps that cannot do
+  OAuth 2.0. Plain username/password auth, 200 messages a day from an
+  @msgwing.com address.
 
 url: https://docs.msgwing.com
 baseurl: ""
@@ -65,10 +69,15 @@ defaults:
       path: "index.md"
     values:
       title: "Free SMTP relay that still accepts basic auth"
+      # The homepage is where the offer is made, so both limits are in the
+      # description itself, not only in the body. "no credit card" was
+      # removed rather than supplemented: in free-tier idiom it means "no
+      # paid gate", and next to an unstated cap the reader finishes the
+      # sentence as "unlimited". 157 chars, under the ~160 SERP budget.
       description: >-
         Free SMTP relay for printers, scanners and legacy apps hit by the
-        Microsoft 365 SMTP AUTH Basic authentication shutdown. No OAuth, no
-        credit card, no mail server to run.
+        Microsoft 365 SMTP AUTH shutdown. 200 messages a day from a generated
+        @msgwing.com address.
       widget: countdown
   - scope:
       path: "EXCHANGE-ONLINE-SMTP-AUTH.md"


### PR DESCRIPTION
Closes #189 (the `og:description` half; the `banner.png` half belongs to `color-systems` and stays out of this PR).

## What was wrong

Red line 4: *the limits are never omitted to improve a conversion rate.* `trust-safety` narrowed the change board's original finding, and its narrowing is the accurate one: it is **two** `description:` blocks, not nineteen.

Of the 19 blocks in `docs/_config.yml`, 17 describe an article — *"Fix scan-to-email after Microsoft 365 disables Basic auth. Per-brand SMTP settings for Ricoh, Canon…"* is not an offer, and the handbook's rule ("wherever the offer is made") does not reach it. Two are offers:

- the **site-level default** (lines 19-22) — the fallback `og:description` for every page that has no scoped one, and the site description in the JSON-LD;
- **`index.md`** (lines 68-70) — the homepage, where the offer is actually made.

Neither stated the 200/day cap or the from-address.

`"no credit card"` was the specific liability, so it is **removed rather than supplemented**. In free-tier idiom it means *no paid gate*; sitting beside an unstated cap it lets the reader finish the sentence as *unlimited*. It is the phrase that made the old social card's "Zero limits" read as consistent with the rest of the site.

## The wording, and the budget

`docs/_config.yml` documents a ~160 character budget for descriptions before search engines truncate. A description that states a limit but gets cut before reaching it would be worse than one that does not try, so both were counted after YAML folding, not before.

**Site-level default — 159 chars**

> Free SMTP relay for printers, scanners and legacy apps that cannot do OAuth 2.0. Plain username/password auth, 200 messages a day from an @msgwing.com address.

*(was 174 — already over budget, and its tail carried no limit)*

**`index.md` — 157 chars**

> Free SMTP relay for printers, scanners and legacy apps hit by the Microsoft 365 SMTP AUTH shutdown. 200 messages a day from a generated @msgwing.com address.

*(was 169)*

The two lead differently on purpose — the homepage leads with the event people search for, the article fallback leads with the device framing — so 21 pages do not inherit a near-duplicate of the homepage's meta description.

### Departures from the draft in the issue

The issue proposed `200/day` for `index.md` (155 chars). Changed to `200 messages a day` (157): `200/day` does not say 200 of *what*, and a limit the reader has to guess the unit of is not a stated limit. The nine characters were paid for by dropping `randomly` from `randomly generated` — *"a generated @msgwing.com address"* already tells the reader they do not choose it.

### What was dropped, and why

**"No paid tier lifts it."** It does not fit 160 characters alongside everything else. It qualifies the cap rather than being a limit in its own right, and the two limits themselves — the number and the from-address — are both present. It stays in the page bodies (`docs/index.md:39`, `docs/index.md:95`) and the FAQ.

The from-address limit was kept in both, at the cost of other wording, because it is the one that decides whether the tool fits the reader at all.

## Verified

- Both strings parsed back out of the YAML after folding and measured there: 159 and 157.
- Repository grepped for `credit card` outside `free-for-dev/` (vendored upstream, not ours): `docs/_config.yml:71` was the only occurrence, and it is gone.
- The live `<meta name="description">` will be re-checked against `docs.msgwing.com` after Pages rebuilds, and the result posted on #189. A fix reported before it deploys is a failure this project has already paid for three times.
