### PR TITLE
docs: say where the site-level description actually surfaces

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -16,10 +16,15 @@
 
 title: ZeroSMTP
 tagline: Free SMTP relay that still accepts basic username/password auth
-# Fallback description for every page that has no `description:` of its own
-# below, and the site description in the JSON-LD. It is an offer, so it
-# carries both limits: the 200/day cap and the from-address. See the
-# index.md scope for the other one. 159 chars, under the ~160 SERP budget.
+# Where this actually surfaces, checked against the live site 2026-08-19:
+# the <subtitle> of feed.xml, and the meta description of any page that has
+# no `description:` of its own - which today is none of the 40, all of them
+# have one either from a scope below or from generated front matter. It is
+# NOT the JSON-LD description; jekyll-seo-tag uses the page's there.
+#
+# It is still an offer, so it carries both limits - the 200/day cap and the
+# from-address - because the next page added here inherits it by default.
+# See the index.md scope for the other offer. 159 chars, under ~160.
 description: >-
   Free SMTP relay for printers, scanners and legacy apps that cannot do
   OAuth 2.0. Plain username/password auth, 200 messages a day from an


### PR DESCRIPTION
Follow-up to #200, comment only - the description string is byte-identical.

#200's comment claimed the site-level `description:` is "the fallback for every page that has no `description:` of its own, and the site description in the JSON-LD". Checked against the deployed site rather than reasoned about, both halves were wrong:

- **No page serves it.** All 40 URLs in the sitemap were fetched and their `<meta name="description">` compared: zero match the site default. Every page has its own, from a scope in this file or from generated front matter.
- **It is not the JSON-LD description.** jekyll-seo-tag puts the *page's* description in the `WebSite` node; the homepage's JSON-LD carries the index.md string.
- **It is the `<subtitle>` of `feed.xml`**, which is a real reader-facing surface and was not mentioned at all.

The string stays as shipped and keeps both limits, because the next page added to this site inherits it by default and a default that omits the cap is one merge away from being live. Only the comment changes.

*A fix that was reasoned about is not a fix that works* - the handbook's first paid-for lesson, applied to a comment this time.