### PR TITLE
fix(ci): npm w wersji wystarczajacej do trusted publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -41,6 +41,18 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
+      # npm's trusted publishing (OIDC) needs npm >= 11.5.1, and Node 22 ships
+      # npm 10.x. Without this the workflow would ask for a token even after
+      # a trusted publisher is configured, and the failure reads as "bad
+      # credentials" rather than "wrong npm version" - which is the expensive
+      # kind of error message. Harmless if we end up publishing with a token
+      # instead: a newer npm publishes the same package either way.
+      - name: npm new enough for trusted publishing
+        run: |
+          npm install -g npm@latest
+          npm --version
+          node --version
+
       # Publishing something that does not work is worse than not publishing.
       # These are the same checks the lint workflow runs, repeated here so
       # that a manual dispatch cannot skip them.


### PR DESCRIPTION
Znalezione przy sprawdzaniu, dlaczego instrukcja „Classic Token → Automation" nie działa: **npm nie ma już Classic Tokens.** Wydaje wyłącznie Granular Access Tokens — potwierdzone w ich dokumentacji, nie z pamięci.

Przy okazji ustalenie ważniejsze: **npm obsługuje trusted publishing przez OIDC, bez żadnego tokena.**

## Cztery z pięciu warunków już spełniamy

| warunek | stan |
|---|---|
| `id-token: write` | ✅ |
| runner hostowany przez GitHuba | ✅ `ubuntu-latest` |
| `registry-url` | ✅ |
| `repository.url` zgodny z repo | ✅ `git+https://github.com/msgwing/ZeroSMTP.git` |
| **npm ≥ 11.5.1** | ❌ **Node 22 dostarcza npm 10.x** |

## Dlaczego ta piąta jest podstępna

Próba publikacji przy skonfigurowanym trusted publisherze, ale starym npm, **poprosiłaby o token** — i zgłosiła to jako błąd poświadczeń, a nie jako nieaktualny npm. To najdroższy rodzaj komunikatu błędu: wskazuje na niewłaściwą przyczynę.

Krok jest nieszkodliwy, jeśli i tak pójdziemy tokenem — nowszy npm publikuje tę samą paczkę w obie strony. Dlatego wchodzi niezależnie od wybranej ścieżki.

## Czego nie zgaduję

Dokumentacja npm opisuje konfigurowanie trusted publishera **w ustawieniach paczki**, co sugeruje, że paczka musi istnieć. `zerosmtp-check` nigdy nie był publikowany. Czy da się to ustawić przed pierwszą publikacją — **nie wiem i nie będę tego twierdził**. To jedno spojrzenie w interfejs npm i rozstrzyga, którą ścieżką idziemy.
