### PR TITLE
chore: lokalne wytyczne agentow poza repozytorium

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,11 @@ Packages/
 .gradle/
 build/
 free-for-dev/
+
+# Local-only: the working agent guidelines. Root CLAUDE.md carries the four
+# Karpathy principles (upstream, MIT) plus a section reconciling them with this
+# company's standing orders - and that section names the private team roles and
+# a production detail. HANDBOOK.md's red line says neither goes in a public
+# file. The upstream copies it is built from are versioned in the private team
+# repo at .claude/agents/karpathy/.
+/CLAUDE.md


### PR DESCRIPTION
Właściciel ustawił firmę na wytyczne Karpathy'ego. Claude Code czyta je z `CLAUDE.md` w korzeniu, więc plik istnieje lokalnie.

Nie powinien tu trafić. Same cztery zasady są publiczne i na MIT, ale nasza kopia niesie sekcję godzącą je z tym, jak ta firma już pracuje — a ta sekcja wymienia z nazwy role wewnętrzne, które siedzą w prywatnym repozytorium właśnie dlatego, że część tych plików mapuje słabe punkty projektu, i powtarza szczegół produkcyjny, który nasza własna polityka bezpieczeństwa trzyma poza plikami publicznymi.

Kto chce same zasady:
```
curl https://raw.githubusercontent.com/multica-ai/andrej-karpathy-skills/main/CLAUDE.md
```