### PR TITLE
feat: npx zerosmtp-check dziala, wraca tam skad go zdjeto

### DIFF
--- a/.pr-body.md
+++ b/.pr-body.md
@@ -1,0 +1,10 @@
+"# Cel
+
+Zwiększenie konwersji odwiedzających repo na gwiazdki i rejestracje na msgwing.com.
+
+## Zmiany
+
+- Dodano plakietkę gwiazdek w nagłówku README
+- Wzmocniono CTA rejestracji w Quickstart (30 sekund, bez karty)
+- Dodano prośbę o gwiazdkę zaraz po quickstartcie
+- Dodano sekcję \"Support ZeroSMTP\" przed tabelą porównawczą - wyjaśnia, że gwiazdka to najskuteczniejsza forma wsparcia"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- `zerosmtp-check` is on npm. `npx zerosmtp-check` runs the connection test
+  with no install and no clone, published from CI with provenance, so the
+  tarball can be traced back to the workflow run and commit that built it.
+
+### Fixed
+- The status panel on docs.msgwing.com and the generated `BLAST-RADIUS.md`
+  both offer `npx zerosmtp-check` again. Both had been carrying a comment
+  saying the package 404s, which stopped being true the moment it was
+  published; a stale reason in a source file is how a correct decision gets
+  reversed by somebody who reads it a month later.
+
 ## [1.6.0] - 2026-08-17
 
 The relay's status is now visible where readers actually are, and the

--- a/docs/BLAST-RADIUS.md
+++ b/docs/BLAST-RADIUS.md
@@ -62,4 +62,4 @@ The figure and the data are free to cite, quote and republish under the reposito
 - [What the error will look like](ERROR-MESSAGES.md) when it starts failing
 - [Whether your hardware has an OAuth path](DEVICE-COMPATIBILITY.md), with a link to every vendor statement
 - [Every migration option](EXCHANGE-ONLINE-SMTP-AUTH.md), including the ones that are not this project
-- `./check-connection.sh`, or `check-connection.ps1` on Windows — check in two seconds whether your network even lets SMTP out, before assuming it is the credentials
+- `npx zerosmtp-check` — no install; checks in two seconds whether your network even lets SMTP out, before you assume it is the credentials. `./check-connection.sh` and `check-connection.ps1` in the repository do the same without Node.

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -946,20 +946,21 @@
       var RUNS = 'https://api.github.com/repos/msgwing/ZeroSMTP/actions/workflows/'
                + 'service-healthcheck.yml/runs?per_page=1&status=completed';
 
-      // Deliberately not `npx zerosmtp-check`: that package is not published
-      // to npm - publish-npm.yml needs an NPM_TOKEN secret the repository
-      // does not have, and has never run. Telling a reader to run a command
-      // that 404s is worse than telling them nothing. These two need no
-      // install and are already in the troubleshooting guide.
+      // `npx zerosmtp-check` is published as of 2026-08-22 and the registry
+      // returns 200, so it leads here now: it is the one line a reader can
+      // paste and pass on, which the two below are not. They stay because
+      // they need no Node at all, and a printer technician on a locked-down
+      // Windows box has neither npm nor the rights to get it.
       function selfTest() {
         return '<p class="muted">To test from your own network rather than ours &mdash; '
              + 'which is the result that actually decides whether your device can send '
              + '&mdash; open a terminal:</p>'
              + '<ul>'
+             + '<li>Anywhere with Node: <code>npx zerosmtp-check</code></li>'
              + '<li>Windows: <code>Test-NetConnection mx.msgwing.com -Port 587</code></li>'
              + '<li>Linux or macOS: <code>openssl s_client -starttls smtp -connect mx.msgwing.com:587</code></li>'
              + '</ul>'
-             + '<p class="muted">Both open the connection and send no mail.</p>';
+             + '<p class="muted">All three open the connection and send no mail.</p>';
       }
 
       el.addEventListener('click', function(e){

--- a/tools/build-blast-radius.py
+++ b/tools/build-blast-radius.py
@@ -171,14 +171,16 @@ def buduj(dane):
         "with a link to every vendor statement",
         "- [Every migration option](EXCHANGE-ONLINE-SMTP-AUTH.md), including "
         "the ones that are not this project",
-        # Deliberately not `npx zerosmtp-check`: that package returns 404
-        # from npm and has never been published, because the repository
-        # has no NPM_TOKEN. Corrected twice on the generated page before
-        # anybody noticed the page is generated and this script was
-        # putting it straight back.
-        "- `./check-connection.sh`, or `check-connection.ps1` on Windows — "
-        "check in two seconds whether your network even lets SMTP out, "
-        "before assuming it is the credentials",
+        # `npx zerosmtp-check` is back as of 2026-08-22: the package is
+        # published (1.0.0, with provenance) and the registry returns 200.
+        # It was pulled from this list while the package 404'd, and the
+        # correction was made twice on the generated page before anybody
+        # noticed the page is generated and this script was putting it
+        # straight back. If it ever 404s again, fix it here, not there.
+        "- `npx zerosmtp-check` — no install; checks in two seconds whether "
+        "your network even lets SMTP out, before you assume it is the "
+        "credentials. `./check-connection.sh` and `check-connection.ps1` in "
+        "the repository do the same without Node.",
         "",
     ]
 


### PR DESCRIPTION
`zerosmtp-check@1.0.0` jest na npm — 3 pliki, 16 KB, MIT, **z provenance attestation**, rejestr zwraca 200. Opublikowane z `publish-npm.yml`, który do dziś nie uruchomił się ani razu.

Nie uruchamiał się, bo potrzebował `NPM_TOKEN`. **Ten sekret istnieje od 2026-08-19 19:10** — właściciel go utworzył, skomentował #173 „wykonałem według instrukcji" i w tej samej minucie issue zamknął. Zamknięcie usunęło jedyną powierzchnię, która mogłaby komukolwiek o tym powiedzieć, więc poświadczenie leżało nieużyte trzy dni, paczka dalej zwracała 404, a dokumentacja dalej ją omijała.

Dwa pliki źródłowe niosły komentarz wyjaśniający, że paczka 404-uje — i dlatego polecenie zostało z nich zdjęte. Ten powód wygasł w momencie publikacji. Nieaktualne uzasadnienie zostawione na miejscu jest gorsze niż brak komentarza: czyta się jak aktualne, i następna osoba cofnie na jego podstawie słuszną decyzję.

Wygenerowana strona została **przegenerowana, nie edytowana** — to trzeci wiersz DOCTRINE §8 — a generator puszczony ponownie potwierdza, że diff to ta jedna zmiana, a nie narastająca.

`check-connection.sh` i `check-connection.ps1` zostają w obu miejscach. `npx` wymaga Node, a serwisant drukarek na zamkniętym Windowsie nie ma ani npm, ani praw, żeby go zainstalować.
