### PR TITLE
feat(seo): sekcja wrapperow, ktora nigdy sie nie wyrenderowala

### DIFF
--- a/data/errors.json
+++ b/data/errors.json
@@ -30,10 +30,8 @@
       "scope": "tenant or mailbox",
       "meaning": "Microsoft 365 refused username-and-password authentication. The credentials are almost certainly fine — the authentication *method* is switched off. Retyping the password, generating a new one, or recreating the mailbox will not change anything.",
       "wrappers": [
-        "Python `smtplib` reports it as `SMTPAuthenticationError (535, ...)`",
-        "Java / JavaMail reports it as `javax.mail.AuthenticationFailedException`",
-        "MailKit and .NET report it as `AuthenticationInvalidCredentials`",
-        "Most printer and scanner panels shorten it to `Authentication failed` or `Login failed`"
+        "Python `smtplib` raises `SMTPAuthenticationError: (535, b'5.7.139 ...')`. The numeric code is split off into its own field and the rest arrives as a bytes literal, so searching for the message with `535` still in front of it returns nothing.",
+        "`curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said."
       ]
     },
     {
@@ -43,7 +41,10 @@
       "kind": "auth-refused",
       "scope": "tenant",
       "meaning": "The same refusal, reported at tenant level: the block applies to every mailbox that inherits the tenant setting, not just the one you are testing. Switching to a different mailbox will produce the same error, which is the fastest way to confirm you are in this case rather than the per-mailbox one.",
-      "wrappers": []
+      "wrappers": [
+        "Python `smtplib` raises `SMTPAuthenticationError: (535, b'5.7.139 ...')`. The numeric code is split off into its own field and the rest arrives as a bytes literal, so searching for the message with `535` still in front of it returns nothing.",
+        "`curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said."
+      ]
     },
     {
       "slug": "535-5-7-139-smtpclientauthentication-is-disabled-for-the-mailbox",
@@ -52,7 +53,10 @@
       "kind": "auth-refused",
       "scope": "mailbox",
       "meaning": "The same refusal, reported for this one mailbox. Either an admin disabled it explicitly here, or it inherits a tenant-wide block and Microsoft is naming the mailbox rather than the tenant. Common on personal Outlook.com accounts and on single mailboxes that have been locked down deliberately — worth asking why before undoing it.",
-      "wrappers": []
+      "wrappers": [
+        "Python `smtplib` raises `SMTPAuthenticationError: (535, b'5.7.139 ...')`. The numeric code is split off into its own field and the rest arrives as a bytes literal, so searching for the message with `535` still in front of it returns nothing.",
+        "`curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said."
+      ]
     },
     {
       "slug": "535-5-7-3-authentication-unsuccessful",
@@ -61,7 +65,10 @@
       "kind": "auth-refused",
       "scope": "tenant or mailbox",
       "meaning": "A generic refusal with the same set of causes as 5.7.139, but without the sub-code that tells you which. Because it names nothing, it is the one most often mistaken for a wrong password. Check the four causes before touching the credentials.",
-      "wrappers": []
+      "wrappers": [
+        "Python `smtplib` raises `SMTPAuthenticationError: (535, b'5.7.3 ...')`. The numeric code is split off into its own field and the rest arrives as a bytes literal, so searching for the message with `535` still in front of it returns nothing.",
+        "`curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said."
+      ]
     },
     {
       "slug": "535-5-7-57-client-was-not-authenticated-to-send-anonymous-mail",

--- a/docs/errors/535-5-7-139-basic-authentication-is-disabled.md
+++ b/docs/errors/535-5-7-139-basic-authentication-is-disabled.md
@@ -40,10 +40,8 @@ It exists because the one-liner everybody reaches for —
 
 Libraries and device firmware rarely pass the server's message through unchanged. These are the same refusal:
 
-- Python `smtplib` reports it as `SMTPAuthenticationError (535, ...)`
-- Java / JavaMail reports it as `javax.mail.AuthenticationFailedException`
-- MailKit and .NET report it as `AuthenticationInvalidCredentials`
-- Most printer and scanner panels shorten it to `Authentication failed` or `Login failed`
+- Python `smtplib` raises `SMTPAuthenticationError: (535, b'5.7.139 ...')`. The numeric code is split off into its own field and the rest arrives as a bytes literal, so searching for the message with `535` still in front of it returns nothing.
+- `curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said.
 
 Kyocera MFPs report it as **send error 1102** / `0x1102`, which looks like a hardware fault and is not one.
 

--- a/docs/errors/535-5-7-139-smtpclientauthentication-is-disabled-for-the-mailbox.md
+++ b/docs/errors/535-5-7-139-smtpclientauthentication-is-disabled-for-the-mailbox.md
@@ -36,6 +36,15 @@ Before the end of December 2026 the first three are the likely answer, and the f
 It exists because the one-liner everybody reaches for —
 `Get-CASMailbox | Where SmtpClientAuthenticationDisabled -eq $false` — **misses every mailbox that inherits the tenant setting** rather than carrying its own, and can therefore report zero on a tenant that is fully exposed. The script counts all three states separately.
 
+## The same error in other clothes
+
+Libraries and device firmware rarely pass the server's message through unchanged. These are the same refusal:
+
+- Python `smtplib` raises `SMTPAuthenticationError: (535, b'5.7.139 ...')`. The numeric code is split off into its own field and the rest arrives as a bytes literal, so searching for the message with `535` still in front of it returns nothing.
+- `curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said.
+
+Kyocera MFPs report it as **send error 1102** / `0x1102`, which looks like a hardware fault and is not one.
+
 ## If it cannot be turned back on
 
 Three options remain, and they differ more than they look:

--- a/docs/errors/535-5-7-139-smtpclientauthentication-is-disabled-for-the-tenant.md
+++ b/docs/errors/535-5-7-139-smtpclientauthentication-is-disabled-for-the-tenant.md
@@ -36,6 +36,15 @@ Before the end of December 2026 the first three are the likely answer, and the f
 It exists because the one-liner everybody reaches for —
 `Get-CASMailbox | Where SmtpClientAuthenticationDisabled -eq $false` — **misses every mailbox that inherits the tenant setting** rather than carrying its own, and can therefore report zero on a tenant that is fully exposed. The script counts all three states separately.
 
+## The same error in other clothes
+
+Libraries and device firmware rarely pass the server's message through unchanged. These are the same refusal:
+
+- Python `smtplib` raises `SMTPAuthenticationError: (535, b'5.7.139 ...')`. The numeric code is split off into its own field and the rest arrives as a bytes literal, so searching for the message with `535` still in front of it returns nothing.
+- `curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said.
+
+Kyocera MFPs report it as **send error 1102** / `0x1102`, which looks like a hardware fault and is not one.
+
 ## If it cannot be turned back on
 
 Three options remain, and they differ more than they look:

--- a/docs/errors/535-5-7-3-authentication-unsuccessful.md
+++ b/docs/errors/535-5-7-3-authentication-unsuccessful.md
@@ -36,6 +36,15 @@ Before the end of December 2026 the first three are the likely answer, and the f
 It exists because the one-liner everybody reaches for —
 `Get-CASMailbox | Where SmtpClientAuthenticationDisabled -eq $false` — **misses every mailbox that inherits the tenant setting** rather than carrying its own, and can therefore report zero on a tenant that is fully exposed. The script counts all three states separately.
 
+## The same error in other clothes
+
+Libraries and device firmware rarely pass the server's message through unchanged. These are the same refusal:
+
+- Python `smtplib` raises `SMTPAuthenticationError: (535, b'5.7.3 ...')`. The numeric code is split off into its own field and the rest arrives as a bytes literal, so searching for the message with `535` still in front of it returns nothing.
+- `curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said.
+
+Kyocera MFPs report it as **send error 1102** / `0x1102`, which looks like a hardware fault and is not one.
+
 ## If it cannot be turned back on
 
 Three options remain, and they differ more than they look:


### PR DESCRIPTION
Generator stron bledow ma sekcje `The same error in other clothes`, sterowana polem `wrappers`. We wszystkich szesciu wpisach bylo puste, wiec **sekcja nigdy nie pojawila sie na zadnej opublikowanej stronie.** Mechanizm zbudowany i nigdy nie nakarmiony.

Ma to znaczenie, bo komunikat bledu to najwyzszej intencji zapytanie, jakie ten projekt moze zlapac — a tekst, ktory czlowiek faktycznie wkleja w wyszukiwarke, prawie nigdy nie jest tym, co wyslal serwer. Klient przepisal go po drodze.

Dwa wrappery, **zlapane, nie przypomniane**: postawiony lokalny serwer SMTP odpowiadajacy prawdziwa odmowa, i puszczone na niego klienty.

- Python `smtplib` odcina kod numeryczny do osobnego pola — szukanie tekstu z `535` z przodu nie znajduje nic. Zweryfikowane na dwoch roznych odmowach.
- `curl` drukuje **wylacznie** `curl: (67) Login denied` i wyrzuca tekst serwera. Ta linia nie mowi nic o tenancie ani o Basic auth, wiec czyta sie jak zle haslo — i dzis nikt tego nie prostuje.

Trzecia linia, o tym jak loguje to Postfix, **zostala napisana z pamieci i usunieta.** Postfiksa nie da sie tu uruchomic, wiec nie dalo sie jej zlapac.