### PR TITLE
feat: formularz komunikatow bledow - generator stron nie mial wsadu

### DIFF
--- a/.github/ISSUE_TEMPLATE/error-string.yml
+++ b/.github/ISSUE_TEMPLATE/error-string.yml
@@ -1,0 +1,41 @@
+name: An SMTP error we do not have a page for
+description: Paste the exact refusal your server, client or device panel printed
+title: "[error] "
+labels: ["docs"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Somebody pasting an error into a search box is broken at that moment and is
+        looking for exactly one thing. Each distinct string gets its own page here,
+        generated from `data/errors.json`.
+
+        **Paste it exactly, including the parts that look like noise.** The wrapping
+        your client added is the point: `curl` throws away the server's text entirely
+        and prints only `curl: (67) Login denied`, which is why people mistake it for
+        a wrong password. That difference is what makes the string findable.
+  - type: textarea
+    id: raw
+    attributes:
+      label: The error, exactly as it appeared
+      description: Copy and paste. Do not tidy it up or translate it.
+      render: text
+    validations:
+      required: true
+  - type: input
+    id: source
+    attributes:
+      label: What printed it
+      placeholder: Postfix log, Python smtplib, a Kyocera panel, PowerShell, Veeam...
+    validations:
+      required: true
+  - type: input
+    id: server
+    attributes:
+      label: Which server were you talking to?
+      placeholder: smtp.office365.com, smtp-mail.outlook.com, something else
+  - type: textarea
+    id: fixed
+    attributes:
+      label: Did anything fix it?
+      description: Even "nothing did" is useful - it tells us the cause is no longer reversible.


### PR DESCRIPTION
`data/errors.json` napedza jedna wygenerowana strone na jeden komunikat bledu — a komunikat bledu to najwyzszej intencji zapytanie, jakie ten projekt moze zlapac. Plik ma **szesc wpisow**. Szesc stron. Nic w tym repozytorium nie zbieralo siodmego.

Zgloszenia urzadzen maja formularz od dawna i `devices.json` ma pietnascie wierszy. Komunikaty bledow nie mialy formularza i maja szesc. To caly argument.

Formularz prosi o tekst **doslownie**, i mowi dlaczego: opakowanie dodane przez klienta jest ta uzyteczna czescia. `curl` wyrzuca tekst serwera i drukuje samo `curl: (67) Login denied` — dlatego bierze sie to za zle haslo. Zmierzone w tym tygodniu na lokalnym serwerze, nie przypomniane.

---

**Dwie rzeczy prawie zepsute po drodze.** API profilu spolecznosci zwraca `issue_template: false`, co odnosi sie do pojedynczego `ISSUE_TEMPLATE.md` i nie mowi nic o katalogu — cztery szablony **juz istnialy**. Odczytanie tego pola jako "brak szablonow" nadpisalo `config.yml` wersja krotsza i gorsza oraz dolozylo drugi formularz urzadzen obok istniejacego. Oba cofniete, zanim cokolwiek trafilo do commita.