### PR TITLE
feat(cli): port 25 tez sprawdzany, z wyjasnieniem czemu nie sluzy do wysylki

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -349,6 +349,13 @@ jobs:
           code=$?
           set -e
           [ "$code" = "2" ] || { echo "::error::expected exit 2, got $code"; exit 1; }
+      - name: Port 25 is checked but never offered as a way to send
+        run: |
+          out=$(node packages/zerosmtp-check/index.js --port 25 --json) || true
+          echo "$out"
+          # If 25 ever starts advertising AUTH the wording below stops being
+          # true, and this is the step that will say so.
+          echo "$out" | jq -e '.ports[0].auth | length == 0' > /dev/null             || { echo "::error::port 25 now offers AUTH - the report text needs rewriting"; exit 1; }
       - name: Real check against mx.msgwing.com produces valid JSON
         # Exit 0 (all good) and exit 1 (a port unreachable) are both correct
         # behaviour and depend on the relay, so the assertion is on the
@@ -362,7 +369,7 @@ jobs:
           echo "$out"
           [ "$code" = "0" ] || [ "$code" = "1" ] \
             || { echo "::error::unexpected exit $code"; exit 1; }
-          echo "$out" | jq -e '.host and (.addresses | length > 0) and (.ports | length == 2) and has("ok")' > /dev/null
+          echo "$out" | jq -e '.host and (.addresses | length > 0) and (.ports | length == 3) and has("ok")' > /dev/null
       # --explain is the half of this tool that gives an answer rather than a
       # measurement, so it is the half that can be confidently wrong. Each
       # case below is one of the three people it exists for.

--- a/packages/zerosmtp-check/README.md
+++ b/packages/zerosmtp-check/README.md
@@ -53,7 +53,7 @@ This tells the cases apart in about two seconds.
 
 ## What it checks
 
-For each port (587 and 465 by default):
+For each port (25, 587 and 465 by default):
 
 - DNS resolution
 - TCP connect, with a real timeout rather than hanging
@@ -68,6 +68,17 @@ The conversation stops after `EHLO`. Nothing is authenticated and nothing is
 delivered.
 
 ## Usage
+### Why port 25 is in there
+
+25 is checked first because it is the one your provider is most likely to
+block, so it answers "is this the network or is it me" before anything else
+does.
+
+It is checked for reachability, **not** as a way to send. On this relay - and
+on most - port 25 offers no AUTH at all, so a device pointed at it will
+connect, look perfectly healthy, and then fail to log in. The report says so on
+the line where it would otherwise just say ok.
+
 
 ```
 npx zerosmtp-check [host] [options]

--- a/packages/zerosmtp-check/index.js
+++ b/packages/zerosmtp-check/index.js
@@ -17,7 +17,12 @@ import dns from 'node:dns/promises';
 import { ERRORS, DEVICE_CODES } from './errors.js';
 
 const DEFAULT_HOST = 'mx.msgwing.com';
-const DEFAULT_PORTS = [587, 465];
+// 25 first, because it is the one most likely to be blocked and therefore
+// the fastest answer to "is it the network or is it me". It is checked
+// for reachability, not as a route to send by: on this relay - and on
+// most - 25 offers no AUTH at all, which the report says out loud so
+// that nobody reads "ok" and points a printer at it.
+const DEFAULT_PORTS = [25, 587, 465];
 const TIMEOUT_MS = 10_000;
 
 const HELP = `
@@ -445,6 +450,16 @@ function report(host, addresses, results) {
       out.push(`           AUTH ${r.auth.join(' ')}`);
       if (r.auth.some(m => /^(LOGIN|PLAIN)$/i.test(m))) {
         out.push('           accepts a username and password');
+      }
+    } else if (r.tls) {
+      // Reachable and encrypted is not the same as usable. Port 25 commonly
+      // gets here: it is the server-to-server port and offers no AUTH, so a
+      // device configured to use it will connect, look healthy, and then fail
+      // to log in. Saying "ok" and stopping would cause that.
+      out.push('           no AUTH offered - this port will not take a '
+        + 'username and password');
+      if (r.port === 25) {
+        out.push('           use 587 (STARTTLS) or 465 (implicit TLS) to send');
       }
     }
     if (r.error) out.push(`  ->       ${r.error}`);

--- a/packages/zerosmtp-check/package.json
+++ b/packages/zerosmtp-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zerosmtp-check",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Check whether outbound SMTP works from this machine, and say what an SMTP error actually means. TCP, STARTTLS/implicit TLS, certificates and AUTH against any host, plus --explain for the refusal your log, library or printer panel printed. No credentials, no mail sent, no dependencies.",
   "type": "module",
   "bin": {
@@ -34,7 +34,8 @@
     "535-5-7-139",
     "printer",
     "troubleshooting",
-    "oauth2"
+    "oauth2",
+    "port-25"
   ],
   "homepage": "https://docs.msgwing.com/TROUBLESHOOTING.html",
   "repository": {


### PR DESCRIPTION
Na polecenie właściciela. Port 25 jest teraz sprawdzany domyślnie i **idzie pierwszy**, bo to jego dostawca chmury najczęściej blokuje — czyli odpowiada na pytanie *„czy to sieć, czy ja"* szybciej niż pozostałe dwa.

**Zmierzone przed dodaniem, nie po:** `mx.msgwing.com` słucha na 25, więc nie zamienia to każdego uruchomienia w porażkę. Przyjmuje STARTTLS i pokazuje ten sam ważny certyfikat.

Czego natomiast **nie robi**, to nie oferuje `AUTH`. 587 i 465 ogłaszają `PLAIN` i `LOGIN`; 25 nie ogłasza nic, bo to port serwer-serwer.

To rozróżnienie musiało pojechać razem z portem. Wiersz mówiący samo *„port 25 ok"* to zaproszenie do skonfigurowania drukarki na 25 — która potem połączy się, będzie wyglądać zdrowo i nie zaloguje się. **Narzędzie spowodowałoby dokładnie to zamieszanie, które ma likwidować.**

Port, który dochodzi do TLS i nie oferuje AUTH, mówi to teraz wprost, a dla 25 dodatkowo wskazuje 587 i 465 jako porty do wysyłki.

CI sprawdza, że portów jest trzy, i **osobno** — że 25 nadal nie ogłasza AUTH. Jeśli to się kiedyś zmieni, treść raportu staje się nieprawdziwa, i ten krok o tym powie, zamiast żeby ktoś odkrył to z wątku pomocy technicznej.
