### PR TITLE
docs: narzedzie na stronach, na ktore ludzie juz trafiaja

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ rather than trust it.
 > That's Microsoft switching off Basic auth for SMTP AUTH — [start
 > here](docs/ERROR-MESSAGES.md). Three of the four causes are still reversible
 > until the end of December 2026.
+>
+> ```bash
+> npx zerosmtp-check --explain "535 5.7.139 Authentication unsuccessful"
+> ```
+>
+> Paste whatever *your* client printed — a Postfix SASL line, a Python
+> traceback, `1102` off a Kyocera panel, or the `curl: (67) Login denied` that
+> hides the server's answer entirely. They are the same refusal wearing
+> different clothes, and it says which case you are in and whether it can still
+> be switched back on. No install, nothing sent.
 
 ---
 

--- a/docs/ERROR-MESSAGES.md
+++ b/docs/ERROR-MESSAGES.md
@@ -7,6 +7,18 @@ authentication for SMTP is refused.
 **None of them mean your password is wrong.** They mean the authentication
 *method* is switched off, which is a different problem with a different fix.
 
+Or skip the reading and paste it:
+
+```bash
+npx zerosmtp-check --explain "535 5.7.139 Authentication unsuccessful"
+```
+
+Whatever your own client printed works — a Postfix SASL line, a Python
+traceback, `1102` off a Kyocera panel, or `curl: (67) Login denied`, which
+shows none of the server's answer at all. It says which of the four cases you
+are in and whether it can still be switched back on. Nothing installed,
+nothing sent.
+
 ## Why the same error has four different causes
 
 Basic auth for SMTP AUTH gets refused in four situations, and the client-side

--- a/docs/PRINTERS.md
+++ b/docs/PRINTERS.md
@@ -84,6 +84,14 @@ What the panel shows, and what it actually means:
 | What you see | What it means |
 | --- | --- |
 | Kyocera **send error 1102** / `0x1102` | Kyocera's code for an SMTP authentication failure — same root cause when pointing at Microsoft 365. |
+
+A panel code is the hardest version of this to act on, because it looks like the machine is failing and says nothing about a mail server. If you have a laptop on the same network:
+
+```bash
+npx zerosmtp-check --explain 1102
+```
+
+It names the cause, says whether an administrator can still switch it back on, and — the part that matters on a service call — says the device does not need replacing.
 | `Authentication failed` / `Login failed` on the panel | Vendor wording for a refused username/password. Your credentials are fine; the method is switched off. |
 | `535` with any wording | The server refused Basic auth for SMTP AUTH. |
 | Connection times out, no auth error at all | Not authentication — the network is blocking outbound SMTP. See [TROUBLESHOOTING.md](TROUBLESHOOTING.md). |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -23,6 +23,18 @@ to check. Run the connectivity-only check — no credentials needed, no email
 sent, and the conversation stops after `EHLO`:
 
 ```bash
+npx zerosmtp-check
+```
+
+Nothing to install and nothing to clone. It tests 25, 587 and 465 from the
+machine that is actually failing, which is the only place the answer means
+anything. Port 25 is included because it is the one this table is mostly
+about — it is checked for reachability, not as a route to send by, and the
+output says so.
+
+Already have the repository checked out, or working on a box with no Node?
+
+```bash
 ./check-connection.sh
 ```
 

--- a/docs/errors/535-5-7-139-basic-authentication-is-disabled.md
+++ b/docs/errors/535-5-7-139-basic-authentication-is-disabled.md
@@ -14,6 +14,16 @@ description: "What 535 5.7.139 Authentication unsuccessful, basic authentication
 
 Microsoft 365 refused username-and-password authentication. The credentials are almost certainly fine — the authentication *method* is switched off. Retyping the password, generating a new one, or recreating the mailbox will not change anything.
 
+## Check it from the machine that is failing
+
+```bash
+npx zerosmtp-check --explain "535 5.7.139 Authentication unsuccessful, basic authentication is disabled"
+```
+
+No install and nothing sent. It reads the refusal your own client printed - which is rarely what the server said, because libraries and device panels rewrite it - and says which of these cases you are in.
+
+If the send is hanging rather than being refused, the cause is usually the network and not the credentials. `npx zerosmtp-check` with no arguments checks ports 25, 587 and 465 from where you are standing.
+
 **This does not mean your password is wrong.** Nothing about the credentials changed; the method used to present them was switched off.
 
 ## Which of the four causes is yours

--- a/docs/errors/535-5-7-139-smtpclientauthentication-is-disabled-for-the-mailbox.md
+++ b/docs/errors/535-5-7-139-smtpclientauthentication-is-disabled-for-the-mailbox.md
@@ -14,6 +14,16 @@ description: "What 535 5.7.139 SmtpClientAuthentication is disabled for the Mail
 
 The same refusal, reported for this one mailbox. Either an admin disabled it explicitly here, or it inherits a tenant-wide block and Microsoft is naming the mailbox rather than the tenant. Common on personal Outlook.com accounts and on single mailboxes that have been locked down deliberately — worth asking why before undoing it.
 
+## Check it from the machine that is failing
+
+```bash
+npx zerosmtp-check --explain "535 5.7.139 SmtpClientAuthentication is disabled for the Mailbox"
+```
+
+No install and nothing sent. It reads the refusal your own client printed - which is rarely what the server said, because libraries and device panels rewrite it - and says which of these cases you are in.
+
+If the send is hanging rather than being refused, the cause is usually the network and not the credentials. `npx zerosmtp-check` with no arguments checks ports 25, 587 and 465 from where you are standing.
+
 **This does not mean your password is wrong.** Nothing about the credentials changed; the method used to present them was switched off.
 
 ## Which of the four causes is yours

--- a/docs/errors/535-5-7-139-smtpclientauthentication-is-disabled-for-the-tenant.md
+++ b/docs/errors/535-5-7-139-smtpclientauthentication-is-disabled-for-the-tenant.md
@@ -14,6 +14,16 @@ description: "What 535 5.7.139 SmtpClientAuthentication is disabled for the Tena
 
 The same refusal, reported at tenant level: the block applies to every mailbox that inherits the tenant setting, not just the one you are testing. Switching to a different mailbox will produce the same error, which is the fastest way to confirm you are in this case rather than the per-mailbox one.
 
+## Check it from the machine that is failing
+
+```bash
+npx zerosmtp-check --explain "535 5.7.139 SmtpClientAuthentication is disabled for the Tenant"
+```
+
+No install and nothing sent. It reads the refusal your own client printed - which is rarely what the server said, because libraries and device panels rewrite it - and says which of these cases you are in.
+
+If the send is hanging rather than being refused, the cause is usually the network and not the credentials. `npx zerosmtp-check` with no arguments checks ports 25, 587 and 465 from where you are standing.
+
 **This does not mean your password is wrong.** Nothing about the credentials changed; the method used to present them was switched off.
 
 ## Which of the four causes is yours

--- a/docs/errors/535-5-7-3-authentication-unsuccessful.md
+++ b/docs/errors/535-5-7-3-authentication-unsuccessful.md
@@ -14,6 +14,16 @@ description: "What 535 5.7.3 Authentication unsuccessful means, whether it can s
 
 A generic refusal with the same set of causes as 5.7.139, but without the sub-code that tells you which. Because it names nothing, it is the one most often mistaken for a wrong password. Check the four causes before touching the credentials.
 
+## Check it from the machine that is failing
+
+```bash
+npx zerosmtp-check --explain "535 5.7.3 Authentication unsuccessful"
+```
+
+No install and nothing sent. It reads the refusal your own client printed - which is rarely what the server said, because libraries and device panels rewrite it - and says which of these cases you are in.
+
+If the send is hanging rather than being refused, the cause is usually the network and not the credentials. `npx zerosmtp-check` with no arguments checks ports 25, 587 and 465 from where you are standing.
+
 **This does not mean your password is wrong.** Nothing about the credentials changed; the method used to present them was switched off.
 
 ## Which of the four causes is yours

--- a/docs/errors/535-5-7-57-client-was-not-authenticated-to-send-anonymous-mail.md
+++ b/docs/errors/535-5-7-57-client-was-not-authenticated-to-send-anonymous-mail.md
@@ -14,6 +14,16 @@ description: "What 535 5.7.57 SMTP; Client was not authenticated to send anonymo
 
 A different problem from the ones above: the client sent no credentials at all, or sent them after `MAIL FROM` instead of before. Usually a device or script configured for anonymous internal relay that is now pointed at an endpoint requiring authentication. Check whether the SMTP settings have an authentication checkbox that is switched off, before assuming Basic auth is the issue.
 
+## Check it from the machine that is failing
+
+```bash
+npx zerosmtp-check --explain "535 5.7.57 SMTP; Client was not authenticated to send anonymous mail"
+```
+
+No install and nothing sent. It reads the refusal your own client printed - which is rarely what the server said, because libraries and device panels rewrite it - and says which of these cases you are in.
+
+If the send is hanging rather than being refused, the cause is usually the network and not the credentials. `npx zerosmtp-check` with no arguments checks ports 25, 587 and 465 from where you are standing.
+
 ## Check this before assuming it is the Basic auth shutdown
 
 This one is worth ruling out cheaply, because the fix is usually local:

--- a/docs/errors/550-5-7-60-client-does-not-have-permissions-to-send-as-this-sender.md
+++ b/docs/errors/550-5-7-60-client-does-not-have-permissions-to-send-as-this-sender.md
@@ -14,6 +14,16 @@ description: "What 550 5.7.60 SMTP; Client does not have permissions to send as 
 
 Authentication succeeded. This is not the Basic auth shutdown. The `From` address in the message does not belong to the mailbox that authenticated, and Microsoft 365 will not let one send as the other without an explicit Send As permission. Common after pointing a device at a shared or service mailbox while leaving the old From address in its settings.
 
+## Check it from the machine that is failing
+
+```bash
+npx zerosmtp-check --explain "550 5.7.60 SMTP; Client does not have permissions to send as this sender"
+```
+
+No install and nothing sent. It reads the refusal your own client printed - which is rarely what the server said, because libraries and device panels rewrite it - and says which of these cases you are in.
+
+If the send is hanging rather than being refused, the cause is usually the network and not the credentials. `npx zerosmtp-check` with no arguments checks ports 25, 587 and 465 from where you are standing.
+
 ## This is not the Basic auth shutdown
 
 Authentication worked. Do not change the authentication settings — the problem is the `From` address.

--- a/tools/build-error-pages.py
+++ b/tools/build-error-pages.py
@@ -82,6 +82,26 @@ def zbuduj(wpis, aktualizacja):
         "",
         wpis["meaning"],
         "",
+        # The reader arrived here from a search box with the error already in
+        # their clipboard, and the tool that answers it in one line was not
+        # mentioned on any of these pages at all. That is a page telling
+        # somebody about a problem while withholding the thing that solves it.
+        # It goes above every other section for the same reason: they are
+        # mid-incident and reading in order.
+        "## Check it from the machine that is failing",
+        "",
+        "```bash",
+        f'npx zerosmtp-check --explain "{wpis["code"]} {wpis["message"]}"',
+        "```",
+        "",
+        "No install and nothing sent. It reads the refusal your own client "
+        "printed - which is rarely what the server said, because libraries and "
+        "device panels rewrite it - and says which of these cases you are in.",
+        "",
+        "If the send is hanging rather than being refused, the cause is usually "
+        "the network and not the credentials. `npx zerosmtp-check` with no "
+        "arguments checks ports 25, 587 and 465 from where you are standing.",
+        "",
     ]
 
     if wpis["kind"] == "auth-refused":


### PR DESCRIPTION
**Zmierzone przed napisaniem czegokolwiek:** zero z sześciu stron błędów wspominało `zerosmtp-check`, README główne — zero, jedna z dziewiętnastu stron dokumentacji. A narzędzie odpowiada dokładnie na pytanie, o którym te strony są.

Czyli: ktoś szuka komunikatu błędu, trafia na stronę napisaną pod ten komunikat, czyta kilkaset słów i **nigdy się nie dowiaduje, że jest jednolinijkowiec, który powiedziałby mu to w dwie sekundy.** To nie jest luka marketingowa. To strona opisująca problem i zatajająca rzecz, która go rozwiązuje.

| Powierzchnia | Przed | Po |
|---|---|---|
| strony błędów | **0/6** | **6/6** |
| README | **0** | 1 — w cytacie o `535 5.7.139` |
| strony docs | 1/19 | 4/19 |

Strony błędów są generowane, więc blok wszedł **do generatora** — dostało go sześć naraz i dostanie każda dodana później. O to chodzi w poprawianiu tego u źródła.

**README:** cytat o `535 5.7.139` już siedział w momencie najwyższej intencji na najczęściej oglądanej stronie — 46 z 55 unikalnych odwiedzających ląduje w korzeniu repo — i wskazywał stronę dokumentacji. Teraz podaje też komendę.

**TROUBLESHOOTING.md** to homepage paczki npm, i dokładnie w miejscu, gdzie mówi *„uruchom sprawdzenie łączności"*, podawał `./check-connection.sh` — czyli wymagał najpierw sklonowania repozytorium. To było **poprawne, gdy paczka zwracała 404**. Nie jest od piątku. `npx` idzie pierwszy, skrypt zostaje dla maszyn bez Node — a to realny przypadek na zamkniętym Windowsie.

**PRINTERS.md** dostaje ścieżkę `1102`, bo kod z panelu jest najtrudniejszą wersją tego problemu: wygląda jak awaria sprzętu i nie mówi nic o serwerze pocztowym. Odpowiedź, której serwisant potrzebuje na wizycie, brzmi **„urządzenia nie trzeba wymieniać"** — i teraz strona to mówi.

Nie dodane do pozostałych piętnastu stron. Powtarzanie tego wszędzie to wypełniacz, a czytelnik, który widzi ten sam blok na każdej stronie, przestaje czytać wszystkie.
