### PR TITLE
fix(cli): deduplikacja mechanizmow AUTH, import bez otwierania gniazd

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -403,6 +403,24 @@ jobs:
           set -e
           echo "$out"
           [ "$code" = "1" ] || { echo "::error::expected exit 1, got $code"; exit 1; }
+      # Reported by the owner running this against two Polish mail hosts:
+      # poczta.interia.pl advertises AUTH PLAIN LOGIN three times over and the
+      # tool printed it back verbatim, which reads like a finding and is not
+      # one. Tested by import rather than over the network, so it stays offline
+      # and deterministic - and the import itself is the second assertion,
+      # because before the main flow was guarded this opened sockets.
+      - name: AUTH mechanisms are de-duplicated, and importing has no side effects
+        run: |
+          node --input-type=module -e "
+          import { authMechanisms } from './packages/zerosmtp-check/index.js';
+          const CRLF = String.fromCharCode(13, 10);
+          const dup = authMechanisms('250-AUTH PLAIN LOGIN PLAIN LOGIN' + CRLF + '250 OK');
+          if (dup.join(',') !== 'PLAIN,LOGIN') { console.error('not de-duplicated: ' + dup); process.exit(1); }
+          if (!dup.duplicated) { console.error('duplication was not flagged'); process.exit(1); }
+          const clean = authMechanisms('250-AUTH LOGIN PLAIN' + CRLF + '250 OK');
+          if (clean.duplicated) { console.error('false positive on a clean list'); process.exit(1); }
+          console.log('ok: ' + dup.join(' ') + ' / ' + clean.join(' '));
+          "
       - name: Package metadata is publishable, and ships errors.js
         run: |
           npm pack --dry-run 2>&1 | tee /tmp/pack.txt

--- a/packages/zerosmtp-check/README.md
+++ b/packages/zerosmtp-check/README.md
@@ -74,10 +74,14 @@ delivered.
 block, so it answers "is this the network or is it me" before anything else
 does.
 
-It is checked for reachability, **not** as a way to send. On this relay - and
-on most - port 25 offers no AUTH at all, so a device pointed at it will
-connect, look perfectly healthy, and then fail to log in. The report says so on
-the line where it would otherwise just say ok.
+Whether you can *send* over 25 depends on the server, and the check does not
+guess: it reports the AUTH mechanisms the server actually advertised. This
+relay offers none there, so the report says so and points at 587 and 465
+instead. Plenty of other servers do offer AUTH on 25 and the report will say
+that too.
+
+That distinction matters because a port that connects and looks perfectly
+healthy but offers no way to log in is exactly how an afternoon disappears.
 
 
 ```

--- a/packages/zerosmtp-check/index.js
+++ b/packages/zerosmtp-check/index.js
@@ -14,14 +14,18 @@
 import net from 'node:net';
 import tls from 'node:tls';
 import dns from 'node:dns/promises';
+import { pathToFileURL } from 'node:url';
 import { ERRORS, DEVICE_CODES } from './errors.js';
 
 const DEFAULT_HOST = 'mx.msgwing.com';
 // 25 first, because it is the one most likely to be blocked and therefore
-// the fastest answer to "is it the network or is it me". It is checked
-// for reachability, not as a route to send by: on this relay - and on
-// most - 25 offers no AUTH at all, which the report says out loud so
-// that nobody reads "ok" and points a printer at it.
+// the fastest answer to "is it the network or is it me".
+//
+// Whether 25 can be sent by depends entirely on the server, and the first
+// wording here generalised without measuring: this relay offers no AUTH on
+// 25, but mx.hsomail.pl and poczta.interia.pl both do. So the report claims
+// nothing - it says "no AUTH offered" only when that is what the server
+// actually said, and only then points at 587 and 465 instead.
 const DEFAULT_PORTS = [25, 587, 465];
 const TIMEOUT_MS = 10_000;
 
@@ -193,10 +197,29 @@ function describeCert(secure) {
   };
 }
 
-function authMechanisms(ehlo) {
+export function authMechanisms(ehlo) {
+  // Only the `250-AUTH MECH MECH` form. The `250-AUTH=` line some servers also
+  // send is a workaround for very old Outlook clients and repeats the same
+  // mechanisms, so counting it would double everything.
   const line = ehlo.split(/\r?\n/).find(l => /^250[ -]AUTH /i.test(l));
   if (!line) return [];
-  return line.replace(/^250[ -]AUTH /i, '').trim().split(/\s+/);
+  const raw = line.replace(/^250[ -]AUTH /i, '').trim().split(/\s+/).filter(Boolean);
+
+  // Servers do repeat themselves here. poczta.interia.pl advertises
+  // `AUTH PLAIN LOGIN PLAIN LOGIN PLAIN LOGIN` - three copies of the same two
+  // mechanisms, which is a duplicated SASL configuration rather than three
+  // different ways in. Printed verbatim it reads like a finding. The set is
+  // what the reader needs; that it was repeated is worth a line to a mail
+  // admin and nothing to anybody else, so it travels separately.
+  const seen = new Set();
+  const unique = raw.filter(m => {
+    const k = m.toUpperCase();
+    if (seen.has(k)) return false;
+    seen.add(k);
+    return true;
+  });
+  unique.duplicated = unique.length !== raw.length;
+  return unique;
 }
 
 // --- the check itself ---------------------------------------------------------
@@ -204,7 +227,7 @@ function authMechanisms(ehlo) {
 async function checkPort(host, port, opts) {
   const result = {
     port, tcp: false, tls: false, starttls: null,
-    cert: null, auth: [], error: null,
+    cert: null, auth: [], authDuplicated: false, error: null,
   };
 
   let socket;
@@ -252,6 +275,7 @@ async function checkPort(host, port, opts) {
     send(secure, 'EHLO zerosmtp-check');
     const ehlo = await readReply(secure, opts.timeout);
     result.auth = authMechanisms(ehlo);
+    result.authDuplicated = Boolean(result.auth.duplicated);
 
     send(secure, 'QUIT');
     secure.destroy();
@@ -451,6 +475,10 @@ function report(host, addresses, results) {
       if (r.auth.some(m => /^(LOGIN|PLAIN)$/i.test(m))) {
         out.push('           accepts a username and password');
       }
+      if (r.authDuplicated) {
+        out.push('           (the server listed these more than once - a '
+          + 'duplicated SASL config, harmless to you)');
+      }
     } else if (r.tls) {
       // Reachable and encrypted is not the same as usable. Port 25 commonly
       // gets here: it is the server-to-server port and offers no AUTH, so a
@@ -484,58 +512,68 @@ function report(host, addresses, results) {
 
 // --- main ------------------------------------------------------------------------
 
-const opts = parseArgs(process.argv.slice(2));
+// Everything below runs only when this file is the program. Without the
+// guard, `import { authMechanisms }` opens sockets to the relay as a side
+// effect of being imported - which is how the parser ended up untestable
+// without a network, and how a duplicated AUTH list shipped unnoticed.
+const isMain = process.argv[1]
+  && import.meta.url === pathToFileURL(process.argv[1]).href;
 
-if (opts.help) { console.log(HELP); process.exit(0); }
-if (opts.error) { console.error(`${opts.error}\n\n${HELP}`); process.exit(1); }
+if (isMain) {
+  const opts = parseArgs(process.argv.slice(2));
 
-if (opts.explain !== undefined) {
-  let text = opts.explain.replace(/\s*--json\s*/g, ' ').trim();
+  if (opts.help) { console.log(HELP); process.exit(0); }
+  if (opts.error) { console.error(`${opts.error}\n\n${HELP}`); process.exit(1); }
 
-  // No text after the flag and something is piped in: read the log. That is
-  // the shape the problem actually arrives in for anyone with shell access -
-  // the error is sitting in a file, not on their clipboard.
-  if (!text && !process.stdin.isTTY) {
-    const chunks = [];
-    for await (const chunk of process.stdin) chunks.push(chunk);
-    text = Buffer.concat(chunks).toString('utf8').trim();
+  if (opts.explain !== undefined) {
+    let text = opts.explain.replace(/\s*--json\s*/g, ' ').trim();
+
+    // No text after the flag and something is piped in: read the log. That is
+    // the shape the problem actually arrives in for anyone with shell access -
+    // the error is sitting in a file, not on their clipboard.
+    if (!text && !process.stdin.isTTY) {
+      const chunks = [];
+      for await (const chunk of process.stdin) chunks.push(chunk);
+      text = Buffer.concat(chunks).toString('utf8').trim();
+    }
+
+    if (opts.json) {
+      const payload = explainJson(text);
+      console.log(JSON.stringify(payload, null, 2));
+      process.exit(payload.matched ? 0 : 1);
+    }
+
+    const answer = explain(text);
+    console.log(answer);
+    // Exit 1 when nothing matched, so a script can tell the two apart.
+    process.exit(/^No match for that one\.|^Nothing to explain\./.test(answer) ? 1 : 0);
   }
+
+
+  let addresses = [];
+  try {
+    addresses = (await dns.lookup(opts.host, { all: true })).map(a => a.address);
+  } catch (err) {
+    const msg = `Could not resolve ${opts.host}: ${err.code || err.message}`;
+    if (opts.json) console.log(JSON.stringify({ host: opts.host, dns: false, error: msg }, null, 2));
+    else console.error(msg);
+    process.exit(2);
+  }
+
+  const results = [];
+  for (const port of opts.ports) {
+    results.push(await checkPort(opts.host, port, opts));
+  }
+
+  const ok = results.every(r => r.tcp && r.tls && (!r.cert || r.cert.authorized) && !r.error);
 
   if (opts.json) {
-    const payload = explainJson(text);
-    console.log(JSON.stringify(payload, null, 2));
-    process.exit(payload.matched ? 0 : 1);
+    console.log(JSON.stringify(
+      { host: opts.host, addresses, ports: results, ok }, null, 2));
+  } else {
+    console.log(report(opts.host, addresses, results));
   }
 
-  const answer = explain(text);
-  console.log(answer);
-  // Exit 1 when nothing matched, so a script can tell the two apart.
-  process.exit(/^No match for that one\.|^Nothing to explain\./.test(answer) ? 1 : 0);
+  process.exit(ok ? 0 : 1);
+
 }
-
-
-let addresses = [];
-try {
-  addresses = (await dns.lookup(opts.host, { all: true })).map(a => a.address);
-} catch (err) {
-  const msg = `Could not resolve ${opts.host}: ${err.code || err.message}`;
-  if (opts.json) console.log(JSON.stringify({ host: opts.host, dns: false, error: msg }, null, 2));
-  else console.error(msg);
-  process.exit(2);
-}
-
-const results = [];
-for (const port of opts.ports) {
-  results.push(await checkPort(opts.host, port, opts));
-}
-
-const ok = results.every(r => r.tcp && r.tls && (!r.cert || r.cert.authorized) && !r.error);
-
-if (opts.json) {
-  console.log(JSON.stringify(
-    { host: opts.host, addresses, ports: results, ok }, null, 2));
-} else {
-  console.log(report(opts.host, addresses, results));
-}
-
-process.exit(ok ? 0 : 1);

--- a/packages/zerosmtp-check/package.json
+++ b/packages/zerosmtp-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zerosmtp-check",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Check whether outbound SMTP works from this machine, and say what an SMTP error actually means. TCP, STARTTLS/implicit TLS, certificates and AUTH against any host, plus --explain for the refusal your log, library or printer panel printed. No credentials, no mail sent, no dependencies.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Zgłoszone przez właściciela, który uruchomił narzędzie na dwóch polskich hostach pocztowych. `poczta.interia.pl` zwróciło:

```
AUTH PLAIN LOGIN PLAIN LOGIN PLAIN LOGIN
```

**Sprawdzone na serwerze, nie zgadnięte:** on naprawdę tak się ogłasza. Narzędzie raportowało wiernie. Mimo to czyta się to jak znalezisko, a diagnostyk, którego wynik wygląda alarmująco, gdy nic się nie dzieje, kosztuje czytelnika tyle samo czasu co diagnostyk, który się myli. Mechanizmy są dwa; powtórzenie to zdublowana konfiguracja SASL i ma własną linijkę.

**Ten sam przebieg wyprostował moje twierdzenie.** Tekst o porcie 25 mówił, że ten przekaźnik — *„i większość"* — nie oferuje tam AUTH. Nigdy tego nie zmierzyłem. **Oba hosty właściciela oferują AUTH na 25.** Uogólnienie zniknęło z komentarza w kodzie i z README. Raport mówi „no AUTH offered" wyłącznie wtedy, gdy tak powiedział serwer — i to akurat działało poprawnie.

Próba otestowania parsera obnażyła drugi problem: eksport oznaczał, że `import { authMechanisms }` **uruchamiał całe CLI i otwierał gniazda** do przekaźnika, bo główny przepływ leżał na najwyższym poziomie. Jest teraz za strażnikiem `isMain`.

I to jest powód, dla którego ten błąd mógł w ogóle przejść niezauważony: **jedyny kawałek czystej obróbki tekstu w tym narzędziu nie dawał się przetestować bez sieci.**

CI sprawdza teraz oba, offline: lista ze zdublowaniami wraca odchudzona i oznaczona, czysta zostaje nietknięta, a samo dojście importu do końca jest asercją, że nic się przy imporcie nie dzieje.
