### PR TITLE
fix(action): opis mial 141 znakow, formularz odrzuca od 125

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -73,6 +73,8 @@ jobs:
         run: python tools/build-blast-radius.py --check
       - name: CLI error data matches data/errors.json
         run: python tools/build-cli-errors.py --check
+      - name: action.yml is publishable to the Marketplace
+        run: python tools/check-action.py
       # A workflow file GitHub cannot parse fails at startup with no job and
       # no log, so it stays invisible until somebody notices a run named after
       # a file path instead of a workflow. Two files sat like that for twelve

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'ZeroSMTP Check'
-description: 'Check outbound SMTP from this runner - ports, TLS, AUTH and how soon the certificate expires - before a deploy finds out it cannot send mail.'
+description: 'Check outbound SMTP from a runner: ports, TLS, AUTH, and fail the job when the mail certificate is near expiry.'
 author: 'msgwing'
 
 branding:

--- a/tools/check-action.py
+++ b/tools/check-action.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Validate action.yml against what GitHub Marketplace actually enforces.
+
+Written after a publish attempt was rejected. The documentation page on
+publishing lists the requirements that stop you having a listing at all -
+public repository, one action.yml at the root, a unique name - and says nothing
+about the description length. That one is only enforced by the release form,
+which means the first time anybody sees it is when a person is standing in
+front of the publish button with the release already drafted.
+
+So it is checked here instead, where it costs nothing to find out.
+
+    python tools/check-action.py
+"""
+
+import pathlib
+import sys
+
+import yaml
+
+KORZEN = pathlib.Path(__file__).resolve().parent.parent
+PLIK = KORZEN / "action.yml"
+
+# Measured from the release form's own validator on 2026-08-22: "Description
+# must be less than 125 characters." Strictly less than, so 124 is the ceiling.
+MAX_OPISU = 125
+
+# Marketplace accepts only these for branding. Anything else fails the form.
+KOLORY = {"white", "yellow", "blue", "green", "orange", "red", "purple", "gray-dark"}
+
+
+def main() -> int:
+    if not PLIK.exists():
+        print("action.yml is missing from the repository root - without it there "
+              "is no Marketplace listing at all", file=sys.stderr)
+        return 1
+
+    dane = yaml.safe_load(PLIK.read_text(encoding="utf-8"))
+    bledy = []
+
+    for pole in ("name", "description", "runs"):
+        if not dane.get(pole):
+            bledy.append(f"{pole}: missing")
+
+    opis = dane.get("description", "")
+    if len(opis) >= MAX_OPISU:
+        bledy.append(
+            f"description: {len(opis)} characters, and the release form rejects "
+            f"anything from {MAX_OPISU} up. Trim it here rather than finding out "
+            f"at the publish button.")
+
+    marka = dane.get("branding") or {}
+    if not marka.get("icon"):
+        bledy.append("branding.icon: missing - the listing has no icon without it")
+    kolor = marka.get("color")
+    if kolor and kolor not in KOLORY:
+        bledy.append(f"branding.color: {kolor!r} is not one of {sorted(KOLORY)}")
+
+    if bledy:
+        for b in bledy:
+            print(f"::error file=action.yml::{b}", file=sys.stderr)
+        return 1
+
+    print(f"action.yml is publishable - description {len(opis)}/{MAX_OPISU - 1} "
+          f"characters, branding {marka.get('icon')}/{kolor}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Właściciel doszedł do przycisku publikacji i formularz odmówił: **„Description must be less than 125 characters."** Mój miał 141.

**Tego limitu nie ma na stronie dokumentacji o publikowaniu w Marketplace**, którą przeczytałem uważnie przed napisaniem `action.yml`. Ta strona wymienia to, co uniemożliwia posiadanie wystawki w ogóle — publiczne repo, jeden `action.yml` w korzeniu, unikalna nazwa — i nie mówi nic o długości.

Reguła jest egzekwowana **wyłącznie przez formularz wydania**, więc pierwsza osoba, która ją napotyka, to ta stojąca przy przycisku z już przygotowanym wydaniem. Dokładnie tak się stało, i był to właściciel, a nie ja.

**Przeczytanie dokumentacji tu nie wystarczyło i powinienem był założyć, że nie wystarczy.** Ograniczenie widoczne tylko w interfejsie dalej jest ograniczeniem, a sposobem na znalezienie go wcześnie jest walidowanie wobec niego, a nie ufanie, że strona dokumentacji jest kompletna.

`tools/check-action.py` pilnuje teraz limitu opisu, wymaga `name`, `description`, `runs` i ikony, oraz odrzuca kolor spoza ośmiu akceptowanych. Chodzi w tym samym zadaniu lint co pozostałe generatory.

**Przetestowany przez podanie mu dokładnie tego opisu, który został odrzucony**, i potwierdzenie, że zwraca błąd — walidator, któremu nigdy nie pokazano porażki, nie jest znany z tego, że cokolwiek sprawdza.
