### PR TITLE
docs: nowa akcja tam, gdzie ludzie czytaja, i sprostowanie mojego twierdzenia

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,25 @@ contact form, or side project, ZeroSMTP costs nothing to try first.
 
 ## GitHub Actions
 
-Using ZeroSMTP from a workflow (CI failure alerts, deploy notifications,
-scheduled reports)? [`msgwing/send-email-action`](https://github.com/msgwing/send-email-action)
-on the [GitHub Marketplace](https://github.com/marketplace/actions/zerosmtp-send-email)
-wraps the setup below into one step:
+Two actions, and they do opposite things.
+
+**[`msgwing/ZeroSMTP`](https://github.com/marketplace/actions/zerosmtp-check) — check that mail *can* be sent.**
+Runs the connectivity check from the runner and fails the job when the mail
+server's certificate is inside a window you choose. Nobody watches a mail
+certificate; it expires on a Sunday and the first report is a user saying
+scanning stopped working. No credentials and no mail sent.
+
+```yaml
+- uses: msgwing/ZeroSMTP@v1.7.0
+  with:
+    host: smtp.office365.com
+    cert-expiry-days: '14'
+```
+
+**[`msgwing/send-email-action`](https://github.com/msgwing/send-email-action) — actually send one.**
+For CI failure alerts, deploy notifications and scheduled reports.
+On the [GitHub Marketplace](https://github.com/marketplace/actions/zerosmtp-send-email),
+it wraps the setup below into one step:
 
 ```yaml
 - uses: msgwing/send-email-action@v1

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -107,3 +107,27 @@ dozens of notifications in minutes. The same
 (5/minute, 50/hour, 200/day): configure alert flapping/throttling in your
 monitoring tool so a single incident doesn't burn through the daily limit
 before a human sees it.
+
+## Certificate expiry, from CI
+
+Every check above watches whether the relay is answering. None of them watches
+the thing that takes mail down without any warning at all: the certificate on
+your own mail server expiring.
+
+It is worth a separate line because of how it fails. Nothing degrades, nothing
+retries, no alert threshold is crossed. It works on Saturday and on Sunday it
+does not, and the first report is somebody saying scanning stopped working.
+
+```yaml
+- uses: msgwing/ZeroSMTP@v1.7.0
+  with:
+    host: smtp.office365.com
+    cert-expiry-days: '14'
+```
+
+Put it on a schedule and the build goes red two weeks before the certificate
+does. `fail-on-error: false` reports without failing, which is what you want if
+the host is somebody else's and a red build would page the wrong person.
+
+No credentials are used and no mail is sent - the conversation stops after
+`EHLO`, the same as [`npx zerosmtp-check`](https://www.npmjs.com/package/zerosmtp-check).


### PR DESCRIPTION
Wystawka **ZeroSMTP Check** w Marketplace ożyła dzisiaj. Ani README, ani żadna z dziewiętnastu stron dokumentacji o niej nie wspominała — czyli **ta sama porażka co rano**: narzędzie wyszło, a strony, które ludzie faktycznie czytają, milczały.

## Prostuję własne twierdzenie

Powiedziałem, że Marketplace to jedyna powierzchnia GitHuba, na której tego projektu nie ma. **To była nieprawda i jedno zapytanie by to sprawdziło** — `msgwing/send-email-action` wisi pod `marketplace/actions/zerosmtp-send-email` od początku sierpnia. Twierdzenie padło z pamięci o tym, co zbudowaliśmy, a nie ze sprawdzenia.

To, co sprawdzenie **naprawdę** pokazuje, jest ciekawsze od samego twierdzenia: tamta wystawka ma **zero gwiazdek i nie ruszyła się od 2026-08-02**. Obecność w Marketplace już była i nie dała nic mierzalnego — więc po drugiej wystawce też nie należy samej z siebie wiele oczekiwać. To półka, nie kampania.

## Co wchodzi

README wymienia teraz **obie i mówi, która jest która**, bo robią rzeczy przeciwne, a jedna linijka o „naszej akcji GitHuba" zostawiłaby czytelnika ze zgadywaniem: jedna sprawdza, że pocztę **da się** wysłać, druga ją **wysyła**.

`MONITORING.md` dostaje wygaśnięcie certyfikatu jako osobną sekcję. Każde sprawdzenie na tej stronie pilnuje, czy przekaźnik odpowiada. **Żadne nie pilnowało awarii, która przychodzi bez ostrzeżenia** — nic się nie degraduje, żaden próg nie zostaje przekroczony, w sobotę działa, a w niedzielę nie.
