### PR TITLE
feat(report): ruch przez wlasny token, zeby firma przestala pracowac na slepo

### DIFF
--- a/.github/workflows/progress-report.yml
+++ b/.github/workflows/progress-report.yml
@@ -39,6 +39,13 @@ jobs:
       - uses: actions/github-script@v9
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Read-only, used for nothing but the three traffic endpoints. It is
+          # deliberately NOT set as this step's github-token: doing that would
+          # make every write in here act as the owner, and GitHub does not
+          # notify the actor who performed an action - the report would stop
+          # mailing the one person it is written for. Absent is a supported
+          # state and the report says so rather than failing.
+          TRAFFIC_TOKEN: ${{ secrets.TRAFFIC_TOKEN }}
         with:
           script: |
             const owner = context.repo.owner, repo = context.repo.repo;
@@ -49,10 +56,27 @@ jobs:
 
             // --- traffic ---------------------------------------------------
             let views = null, referrers = [], paths = [];
+            const trafficToken = process.env.TRAFFIC_TOKEN;
             try {
-              views = (await github.rest.repos.getViews({ owner, repo })).data;
-              referrers = (await github.rest.repos.getTopReferrers({ owner, repo })).data;
-              paths = (await github.rest.repos.getTopPaths({ owner, repo })).data;
+              if (!trafficToken) throw new Error('brak sekretu TRAFFIC_TOKEN');
+              // Plain fetch rather than the octokit in `github`, because that
+              // one is bound to GITHUB_TOKEN and must stay that way - see the
+              // note on the env block above.
+              const traffic = async (path) => {
+                const r = await fetch(
+                  `https://api.github.com/repos/${owner}/${repo}/${path}`, {
+                    headers: {
+                      authorization: `Bearer ${trafficToken}`,
+                      accept: 'application/vnd.github+json',
+                      'user-agent': 'zerosmtp-progress-report',
+                    },
+                  });
+                if (!r.ok) throw new Error(`${path}: HTTP ${r.status}`);
+                return r.json();
+              };
+              views = await traffic('traffic/views');
+              referrers = await traffic('traffic/popular/referrers');
+              paths = await traffic('traffic/popular/paths');
             } catch (e) {
               // Loud, not quiet. A report that silently drops the numbers it
               // exists to carry looks like a calm week.
@@ -266,7 +290,9 @@ jobs:
             if (!views) {
               L.push('');
               L.push('> **Liczby odwiedzin są poza zasięgiem tego raportu.** Endpointy ruchu');
-              L.push('> wymagają tokena osobistego, a token Actions ich nie ma i mieć nie może.');
+              L.push('> wymagają osobnego tokena, a sekret `TRAFFIC_TOKEN` nie jest ustawiony');
+              L.push('> albo nie ma uprawnienia **Administration: Read-only**. Bez niego firma');
+              L.push('> buduje strony na ślepo: nie widzi, które przynoszą ludzi.');
               L.push('> Do odczytania ręcznie w dowolnej chwili:');
               L.push('>');
               L.push('> ```bash');


### PR DESCRIPTION
Raport od zawsze mówił, że endpointy ruchu są **poza zasięgiem**. Są poza zasięgiem **tokena Actions** — i to się z czasem skróciło do „niemożliwe", przez co nikt się tym nie zajął przez tygodnie.

**Zweryfikowane w dokumentacji GitHuba, nie z pamięci:** trzy endpointy ruchu wymagają tokena drobnoziarnistego z uprawnieniem **„Administration" → Read-only**. To token, który człowiek tworzy raz.

## Dlaczego osobnym torem, a nie podmianą

Czyta go zwykły `fetch` z własnym poświadczeniem, a **nie** przez ustawienie go jako `github-token` tego kroku. Ta druga droga jest oczywistym skrótem i **zepsułaby raport**: każdy zapis w kroku działałby wtedy jako właściciel, a GitHub nie powiadamia aktora, który sam wykonał akcję — raport po cichu przestałby mailować jedyną osobę, dla której jest pisany.

To czerwona linia nr 7 i uszanowanie jej nie kosztuje tu nic.

## Brak sekretu zostaje stanem obsługiwanym

Bez niego raport drukuje to, co drukował dotąd — tyle że mówi teraz, **którego sekretu brakuje i ile to kosztuje**.

I to jest właściwy powód, dla którego to ma znaczenie: dziś stanęło **14 stron błędów**, zaindeksowanych URL-i jest **48**, a między jednym ręcznym sprawdzeniem a drugim **nikt nie wie, które z nich przynoszą choć jednego człowieka**.

Program zasięgowy bez pętli zwrotnej to zgadywanie powtarzane wedle harmonogramu.
