### PR TITLE
fix(docs): rail konwersji przykleja sie na cala strone, nie na 32 piksele

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -316,6 +316,15 @@
       .layout { display:grid; grid-template-columns:minmax(0,1fr); gap:0 clamp(24px,3vw,40px); align-items:start; }
       @media (min-width:1040px) {
         .layout.has-rail { grid-template-columns:minmax(0,1fr) var(--rail); }
+        /* `.layout` sets align-items:start so the main column does not stretch.
+           That also shrank this grid item to the height of the card inside it,
+           which left `position:sticky` with nowhere to travel: measured on the
+           live page, the rail was 545px tall around a 513px card - 32px of
+           movement on a 4,847px page. It stuck for 32 pixels and then scrolled
+           away, which reads as sticky being broken rather than absent.
+           Stretching only this item gives it the full row height back; measured
+           again afterwards, 4,088px of travel and the card holds at top:18px. */
+        .rail { align-self:stretch; }
       }
       .rail { min-width:0; }
       .railinner { position:sticky; top:18px; }


### PR DESCRIPTION
Zgłoszone przez właściciela: karta ma jechać w dół razem ze stroną. **Była już `position:sticky`** i była od premiery projektu — dlatego nikt nie zajrzał drugi raz.

## Zmierzone na żywej stronie, nie wydedukowane

`.layout` ustawia `align-items:start`, żeby główna kolumna się nie rozciągała. To **równocześnie skurczyło element siatki z railem do wysokości karty w środku**:

| | przed | po |
|---|---|---|
| wysokość `.rail` | 545 px | 4601 px |
| wysokość karty | 513 px | 513 px |
| **zapas do przesuwania** | **32 px** | **4088 px** |

Strona ma 4847 px. Karta **przyklejała się na 32 piksele** i odjeżdżała razem z resztą — co wygląda dokładnie jak `sticky`, które w ogóle nie działa. Dlatego sama obecność tej właściwości w CSS nie była dowodem, że działa.

## Jedna linijka

Rozciągnięcie **tylko tego jednego elementu siatki** przywraca mu pełną wysokość wiersza, nie ruszając wyrównania głównej kolumny. Zamknięte w tej samej regule szerokości, w której rail w ogóle istnieje.

Zweryfikowane tak samo, jak zdiagnozowane: **po przewinięciu o 2000 px karta stoi 18 px poniżej górnej krawędzi okna** — czyli tam, gdzie `top:18px` prosił od początku.

Poniżej 1040 px rail jest `position:static`, a tę robotę przejmuje dok na dole strony — tam nic się nie zmienia.
