### PR TITLE
fix(ci): pyyaml instalowany przed krokami, ktore go importuja

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -65,6 +65,13 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: '3.13'
+      # Installed once, before anything that needs it. It used to live inside
+      # the last step in this job, which worked until a step that also imports
+      # yaml was added above it - and then the first person to hit
+      # ModuleNotFoundError was an outside contributor on their first pull
+      # request, on a change that had nothing to do with it.
+      - name: Python dependencies for the checks below
+        run: pip install --quiet pyyaml
       - name: Device table and pages match data/devices.json
         run: python tools/build-device-table.py --check
       - name: Error pages match data/errors.json
@@ -82,9 +89,7 @@ jobs:
       # edit had written where a regex meant backslash-1 and backslash-b.
       # Cheap to check, expensive to miss.
       - name: Workflow files parse, and carry no control characters
-        run: |
-          pip install --quiet pyyaml
-          python .github/check-workflows.py
+        run: python .github/check-workflows.py
 
   bash:
     needs: changes


### PR DESCRIPTION
`tools/check-action.py` dodany wczoraj importuje `yaml`. Instalacja `pyyaml` siedziała **wewnątrz ostatniego kroku tego samego zadania** — więc każdy przebieg `device-table` od tamtej pory umiera na `ModuleNotFoundError`, zanim do niej dojdzie.

**Pierwszą osobą, która na to trafiła, był kontrybutor z zewnątrz** — przy swoim pierwszym pull requeście, na zmianie w pliku JSON, która nie ma z tym nic wspólnego. Zobaczył czerwone wymagane sprawdzenie z moim błędem w środku.

Instalacja jest teraz osobnym krokiem, zaraz po `setup-python`, więc dodanie kroku wymagającego zależności nie może po cichu zależeć od kolejności kroków pod nim.

Warto nazwać kształt tego błędu, a nie tylko go naprawić: **wsadzenie instalacji do kroku, który akurat jej potrzebował, działało dokładnie tak długo, jak długo był to jedyny taki krok.** Było poprawne, gdy powstawało, i stało się błędne, gdy coś dodano wyżej — a nic tego nie pilnowało. To ta sama porażka co nieaktualny komentarz, tyle że w pliku workflow.
