### PR TITLE
chore: powiedz Copilotowi, czego nie ma czytac

### DIFF
--- a/.copilotignore
+++ b/.copilotignore
@@ -1,0 +1,29 @@
+# Files Copilot must not read as context.
+#
+# Every path here is already named in .gitignore, so listing it again reveals
+# nothing that was not public. What it adds is that these do not leave the
+# machine: they are local-only precisely because they are the material this
+# project decided not to publish, and a code assistant reading the working
+# directory does not know that.
+#
+# Account-level content exclusion is off on this plan (copilotignore_enabled:
+# false, checked 2026-08-23), so today this file is a statement of intent
+# rather than an enforced rule. It costs nothing and starts working the moment
+# the setting does.
+
+# Strategy documents. Roughly 34 KB of what the company is going to do and
+# when, which is the one thing a competitor could act on directly.
+STRATEGIA-*.md
+
+# The agent roster. security-director.md and pentester.md map this project's
+# own weak points - that is why the team repository is private and not a
+# stylistic preference.
+.claude/
+
+# Working guidelines, which name the internal roles.
+/CLAUDE.md
+
+# Credentials. .env.example is the public template and stays readable.
+.env
+.env.*
+!.env.example


### PR DESCRIPTION
**Sprawdzone, nie założone:** konto ma `free_limited_copilot`, `restricted_telemetry: false`, `copilotignore_enabled: false`.

W tym katalogu roboczym — a **poza publicznym repozytorium** — leży:

| Co | Ile |
|---|---|
| `STRATEGIA-*.md` | 4 pliki, ~34 KB |
| `CLAUDE.md` | 7,5 KB |
| `.claude/agents/` | **25 plików ról** |

Dwie z tych ról — `security-director` i `pentester` — **mapują słabe punkty tego projektu**. To jest podana przyczyna, dla której repozytorium zespołu jest prywatne, a nie preferencja stylistyczna. Asystent kodu czytający katalog roboczy nie ma jak tego wiedzieć.

Każda wymieniona ścieżka **jest już w `.gitignore`**, więc te nazwy były jawne wcześniej i wypisanie ich ponownie nie odsłania niczego nowego.

Wykluczanie treści nie działa na tym planie, więc **ten plik nic dziś nie zmienia**. Jest, bo koszt wynosi zero, a alternatywą jest pamiętanie, żeby go napisać w dniu, w którym ustawienie stanie się dostępne — czyli rzecz, której się nie pamięta.

Przełączniki udostępniania danych na poziomie konta to część, która **działa już teraz** — i te należą do właściciela, bo to jego konto, a nie ustawienie repozytorium.
