### PR TITLE
feat(ci): odrzucaj workflow, ktory uruchamia skrypt przed instalacja jego zaleznosci

### DIFF
--- a/.github/check-workflows.py
+++ b/.github/check-workflows.py
@@ -7,10 +7,80 @@ cause. Two files sat like that for twelve runs each on 2026-08-17, each
 carrying a control character a scripted edit had written into a regex where
 an escape sequence was meant.
 """
+import ast
 import glob
+import os
+import re
 import sys
 
 import yaml
+
+# Third-party modules and the pip package that provides them. Only what this
+# repository actually imports; an unknown module is reported under its own name
+# rather than guessed at.
+PAKIET = {"yaml": "pyyaml"}
+
+
+def importy_zewnetrzne(sciezka):
+    """Top-level third-party imports of a Python file, as module names."""
+    try:
+        drzewo = ast.parse(open(sciezka, encoding="utf-8").read())
+    except Exception:
+        return set()
+    moduly = set()
+    for w in ast.walk(drzewo):
+        if isinstance(w, ast.Import):
+            moduly |= {a.name.split(".")[0] for a in w.names}
+        elif isinstance(w, ast.ImportFrom) and w.level == 0 and w.module:
+            moduly.add(w.module.split(".")[0])
+    katalog = os.path.dirname(sciezka) or "."
+    lokalne = {f[:-3] for f in os.listdir(katalog) if f.endswith(".py")}
+    return {m for m in moduly
+            if m not in sys.stdlib_module_names and m not in lokalne}
+
+
+def sprawdz_kolejnosc(job, nazwa, path):
+    """A python script must not run before its dependencies are installed.
+
+    tools/check-action.py was added on 2026-08-22 above the step that ran
+    `pip install pyyaml`, so every run of that job died on ModuleNotFoundError
+    before reaching the install. The first person to see the red check was an
+    outside contributor on their first pull request, on a change to a JSON file.
+
+    Each check in this file reads one file at a time. This one is the only one
+    that reads a job as a sequence, which is the shape that failure had: every
+    individual step was correct and the order was not.
+    """
+    zle = False
+    zainstalowane = set()
+    for krok in job.get("steps") or []:
+        if not isinstance(krok, dict):
+            continue
+        run = krok.get("run")
+        if not isinstance(run, str):
+            continue
+
+        for m in re.finditer(r"pip3?\s+install\s+([^\n|;&]+)", run):
+            for slowo in m.group(1).split():
+                if not slowo.startswith("-"):
+                    zainstalowane.add(slowo.lower())
+
+        for m in re.finditer(r"python3?\s+([\w./-]+\.py)", run):
+            skrypt = m.group(1)
+            if not os.path.exists(skrypt):
+                continue
+            for modul in importy_zewnetrzne(skrypt):
+                pakiet = PAKIET.get(modul, modul).lower()
+                if pakiet in zainstalowane or modul.lower() in zainstalowane:
+                    continue
+                krok_nazwa = krok.get("name") or run.strip().splitlines()[0]
+                print(f"::error file={path}::job `{nazwa}`, step "
+                      f"`{krok_nazwa}` runs {skrypt}, which imports "
+                      f"`{modul}` - but nothing installed `{pakiet}` earlier "
+                      f"in this job. It will die on ModuleNotFoundError.")
+                zle = True
+    return zle
+
 
 ALLOWED_CONTROL = {"\n", "\r"}
 
@@ -68,6 +138,8 @@ for path in sorted(glob.glob(".github/workflows/*.yml")):
         for name, job in (doc.get("jobs") or {}).items():
             if isinstance(job, dict):
                 check_permissions(job.get("permissions"), f"job `{name}`")
+                if sprawdz_kolejnosc(job, name, path):
+                    bad = True
 
 print("Workflow files: clean." if not bad else "Workflow files: problems above.")
 sys.exit(1 if bad else 0)


### PR DESCRIPTION
To jest **darmowa połowa tego, co robiłaby recenzja Copilota** — wycelowana w ten jeden błąd, który naprawdę by tu złapała.

`tools/check-action.py` został dodany 22 sierpnia **w kroku nad tym**, który uruchamiał `pip install pyyaml`. Każdy krok z osobna był poprawny; **kolejność nie**. Zadanie umierało na `ModuleNotFoundError`, zanim doszło do instalacji — a pierwszą osobą, która zobaczyła czerwone sprawdzenie, był kontrybutor z zewnątrz przy swoim pierwszym pull requeście, na zmianie w pliku JSON.

## Dlaczego żaden istniejący walidator tego nie widział

Każde inne sprawdzenie w tym pliku **czyta jeden plik naraz**. Ta wada nie była w pliku — była w **sekwencji**.

Ta reguła przechodzi kroki zadania po kolei, śledzi, co dotąd zainstalował pip, parsuje importy każdego skryptu z repozytorium, który zadanie uruchamia, i wywala się, gdy import zewnętrzny nie ma wcześniejszej instalacji.

Biblioteka standardowa i moduły leżące obok skryptu są wykluczone, więc nie strzela na `import json` ani na lokalny pomocnik. Tylko `yaml` jest zmapowany na nazwę pakietu; **cokolwiek nierozpoznanego raportuje pod własną nazwą modułu, zamiast zgadywać** — bo zła nazwa pakietu w komunikacie błędu wysyła czytelnika tam, gdzie nic nie ma.

## Przetestowane przez przywrócenie błędu

Z usuniętym krokiem instalacji **nazywa oba dotknięte kroki i kończy się kodem 1**; z przywróconym — czysto.

Walidator, któremu nigdy nie pokazano porażki, nie jest znany z tego, że cokolwiek sprawdza.

---

Sam Copilot zostaje poza pętlą: konto ma plan darmowy, gdzie recenzja PR-ów i agent kodujący nie są dostępne. **Sprawdzone, nie założone** — trzy próby dodania go jako recenzenta, wszystkie odrzucone.
