### PR TITLE
chore: kolejka zatwierdzen do firmy, nie do wlasciciela

### DIFF
--- a/.github/workflows/ready-for-approval.yml
+++ b/.github/workflows/ready-for-approval.yml
@@ -108,7 +108,7 @@ jobs:
 
             const TYTUL = 'Przebiegi CI czekaja na zatwierdzenie';
             const open = (await github.rest.issues.listForRepo({
-              owner, repo, state: 'open', labels: 'do-akceptacji', per_page: 100,
+              owner, repo, state: 'open', labels: 'stan:zalegle', per_page: 100,
             })).data.filter(i => !i.pull_request && i.title === TYTUL);
 
             if (!runs.length) {
@@ -140,6 +140,8 @@ jobs:
               '**' + runs.length + ' przebieg(ow) CI czeka na zatwierdzenie.**' +
                 ' Najstarszy: **' + najstarszy + 'h**.',
               '',
+              'Do wykonania przez firme, nie przez wlasciciela.',
+              '',
               'Pull request od kogos, kto zglasza sie tu pierwszy raz, **nie moze',
               'uruchomic wymaganych sprawdzen**, dopoki ktos nie zatwierdzi jego',
               'workflow. Bez tego nie scali sie nigdy, niezaleznie od tego, jak',
@@ -168,7 +170,11 @@ jobs:
             } else {
               const issue = await github.rest.issues.create({
                 owner, repo, title: TYTUL, body,
-                labels: ['do-akceptacji'], assignees: [owner],
+                // Deliberately unassigned. The owner's instruction on
+                // 2026-08-23: the company accepts and acts, and nothing routes
+                // to them for approval. Assigning them is what makes GitHub
+                // send mail, so leaving it off is the whole mechanism.
+                labels: ['stan:zalegle'],
               });
               core.notice('Utworzono ' + issue.data.html_url);
             }


### PR DESCRIPTION
Polecenie właściciela z dzisiaj: **nie dostaje zadań do akceptacji, firma akceptuje i wykonuje**.

Strażnik zbudowany wczoraj **przypisywał mu** kolejkę oczekujących przebiegów — a przypisanie jest jedyną rzeczą, która sprawia, że GitHub wysyła maila. Teraz zgłoszenie niesie `stan:zalegle` i **żadnego przypisania**: istnieje jako praca dla zespołu i nikomu nie przerywa.

Samo zatwierdzenie dalej wymaga sesji z tokenem zdolnym wywołać endpoint `approve` — `GITHUB_TOKEN` nie może tego z założenia, bo workflow zatwierdzający własne przebiegi zniweczyłby całą kontrolę.

To jest więc kolejka, **którą firma odrabia**, a nie taka, która czyści się sama — i zgłoszenie mówi to w pierwszym zdaniu.
