### PR TITLE
docs: narzedzie na stronie, przez ktora wchodzi caly serwis

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,23 @@ tool and [the alternatives page](ALTERNATIVES.md) says which one is right.
 
 ## Start here
 
+**If you have an error in front of you right now, skip the table:**
+
+```bash
+npx zerosmtp-check --explain "535 5.7.139 Authentication unsuccessful"
+```
+
+Paste whatever *your* client printed. A Postfix SASL line, a Python traceback,
+`1102` off a Kyocera panel, or `curl: (67) Login denied` — which shows none of
+the server's answer at all. Seventeen error strings are covered, and each one
+says whether the cause can still be turned back on before the end of December
+2026, because three of the four still can.
+
+If mail is **hanging** rather than being refused, run it with no arguments: it
+checks ports 25, 587 and 465 from the machine that is actually failing, which
+is the only place the answer means anything. Nothing to install, no credentials,
+no mail sent.
+
 | If you… | Go to |
 | --- | --- |
 | Got an authentication error from `smtp.office365.com` | [Exchange Online SMTP AUTH migration](EXCHANGE-ONLINE-SMTP-AUTH.md) |


### PR DESCRIPTION
**Sprawdzone, nie założone** — i wynik gorszy, niż się spodziewałem:

| Na stronie głównej docs | |
|---|---|
| wzmianek o `zerosmtp-check` | **0** |
| wzmianek o `npx` | **0** |
| linków do 17 stron pod konkretne błędy | **0** |

To **punkt wejścia całego serwisu** i nie wiedział nic o dwóch dniach pracy.

Ta sama wada co sieroty i README dziś rano, w trzecim miejscu: **rzecz zostaje zbudowana i nie pojawia się tam, gdzie ludzie lądują.**

## Nad tabelą, nie jako jej siedemnasty wiersz

Tabela odpowiada na pytanie *„której strony potrzebuję"* — słuszne, gdy ktoś **czyta**. Ktoś w trakcie awarii, z błędem na ekranie, ma inne pytanie, i dla niego **jedna komenda bije wybór z szesnastu opcji**. Zwłaszcza że tekst, na który patrzy, zwykle nie jest tym, co wysłał serwer — a tego żadna strona nie powie mu przez dobrą organizację.

Przypadek **zawieszania** nazwany osobno, bo to najczęstsza pierwsza awaria i **w ogóle nie jest problemem uwierzytelniania**: sieć odrzuca port, a żadna ilość czytania o `5.7.139` tego nie powie.
