### PR TITLE
feat(seo): miejsca na weryfikacje Google i Bing, i powod dla ktorego to wazne

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -230,3 +230,21 @@ defaults:
 
 exclude:
   - assets/*.py
+
+# Search-engine webmaster verification. Paste the token each console gives you;
+# an empty value emits no tag at all, so a half-configured entry cannot ship a
+# broken one.
+#
+# Google Search Console is the one that matters most and is the one missing:
+# it reports the actual queries that brought somebody to this site, which is
+# the only legitimate source for that - search queries are not public and there
+# is no list of them anywhere to be found. Without it the seventeen error pages
+# are aimed at a December traffic spike we have no way to watch.
+#
+#   Google: search.google.com/search-console -> add property docs.msgwing.com
+#           -> HTML tag -> copy the content="..." value here
+#   Bing:   bing.com/webmasters -> can import directly from Search Console
+verification:
+  google: ""
+  bing: ""
+  yandex: "54561a99b7e3ae2b"

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -5,13 +5,31 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     {% comment %}
-      Yandex Webmaster site-ownership verification. Not doable via DNS TXT
-      here: docs.msgwing.com is a CNAME (required for GitHub Pages), and a
-      name with a CNAME can't carry any other record type (RFC 1034) - the
-      Yandex resolver enforces this and never even looks for the TXT record,
-      unlike Google/Cloudflare's public resolvers which serve it anyway.
+      Search-engine site-ownership verification, driven from _config.yml so a
+      token is pasted in one place rather than edited into this file.
+
+      None of these can use DNS TXT: docs.msgwing.com is a CNAME, required for
+      GitHub Pages, and a name carrying a CNAME can hold no other record type
+      (RFC 1034). Yandex's resolver enforces that and never looks for the TXT
+      at all, unlike Google's and Cloudflare's public resolvers, which serve it
+      anyway. So the HTML tag is the only route for all three.
+
+      Why it matters more than a checkbox: Search Console is the only honest
+      answer to "what are people actually searching for". Search queries are
+      not public and no list of them exists to buy or harvest - the only place
+      the real ones appear is in the console of the site they landed on. It is
+      also the one feedback loop we can have on the December 2026 bet, which is
+      seventeen error pages aimed at queries we currently cannot see.
     {% endcomment %}
-    <meta name="yandex-verification" content="54561a99b7e3ae2b" />
+    {% if site.verification.google %}
+    <meta name="google-site-verification" content="{{ site.verification.google }}" />
+    {% endif %}
+    {% if site.verification.bing %}
+    <meta name="msvalidate.01" content="{{ site.verification.bing }}" />
+    {% endif %}
+    {% if site.verification.yandex %}
+    <meta name="yandex-verification" content="{{ site.verification.yandex }}" />
+    {% endif %}
 
     {% seo %}
 


### PR DESCRIPTION
Właściciel zapytał, czy da się znaleźć świeże zapytania ludzi w Google i napisać do nich maila.

**Przesłanka nie działa: zapytania wyszukiwarek nie są publiczne.** Nikt nie widzi, kto czego szukał, nie istnieje zbiór takich danych do pozyskania — i to jest fakt o tym, jak działa wyszukiwarka, a nie reguła o tym, co wolno.

## Ale pod spodem jest rzecz realna i jej nie mamy

**Search Console pokazuje prawdziwe zapytania**, po których ktoś trafił na tę stronę. To jedyne legalne źródło tej informacji, bo to jedyne miejsce, w którym prawdziwe zapytania w ogóle się pojawiają — w konsoli serwisu, na który ktoś wszedł.

**Sprawdzone, nie założone:**

| Narzędzie | Stan |
|---|---|
| Yandex Webmaster | podpięte |
| **Google Search Console** | **BRAK** |
| **Bing Webmaster** | **BRAK** |

Siedemnaście stron błędów stanęło w tym tygodniu, wycelowanych w grudniowy skok, i **nie mamy jak zobaczyć, czy którakolwiek na cokolwiek rankuje**.

## Co się zmienia

Weryfikacja przenosi się z tagu na sztywno do `_config.yml` — token wkleja się w **jednym miejscu**, a pusta wartość **nie emituje tagu wcale**, więc półskonfigurowany wpis nie może wysłać zepsutego.

Żadna z trzech nie może użyć DNS TXT: `docs.msgwing.com` to CNAME wymagany przez GitHub Pages, a nazwa z CNAME nie może nieść innego typu rekordu (RFC 1034).
