### PR TITLE
docs: sprostowanie twierdzenia o DNS, ktoremu przeczy nasza wlasna strefa

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -241,8 +241,10 @@ exclude:
 # is no list of them anywhere to be found. Without it the seventeen error pages
 # are aimed at a December traffic spike we have no way to watch.
 #
-#   Google: search.google.com/search-console -> add property docs.msgwing.com
-#           -> HTML tag -> copy the content="..." value here
+#   Google: verified 2026-08-23 as a domain property (sc-domain:), so no tag is
+#           needed here and the slot stays empty on purpose. Left in place
+#           because a URL-prefix property would need one and the next person
+#           should not have to re-derive that.
 #   Bing:   bing.com/webmasters -> can import directly from Search Console
 verification:
   google: ""

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -8,11 +8,18 @@
       Search-engine site-ownership verification, driven from _config.yml so a
       token is pasted in one place rather than edited into this file.
 
-      None of these can use DNS TXT: docs.msgwing.com is a CNAME, required for
-      GitHub Pages, and a name carrying a CNAME can hold no other record type
-      (RFC 1034). Yandex's resolver enforces that and never looks for the TXT
-      at all, unlike Google's and Cloudflare's public resolvers, which serve it
-      anyway. So the HTML tag is the only route for all three.
+      On DNS, corrected 2026-08-23 after checking our own zone rather than
+      repeating what this comment used to say. It claimed a name carrying a
+      CNAME can hold no other record type (RFC 1034) and that DNS verification
+      was therefore impossible here. Our own zone disproves it: docs.msgwing.com
+      is a CNAME to msgwing.github.io *and* serves a TXT, which is how Yandex
+      was verified in the first place. What is true is narrower - Yandex's own
+      resolver enforced the rule and would not read the TXT, so their
+      verification had to move to a meta tag. Google reads it fine.
+
+      The tag stays regardless. It is the one method that works the same on
+      every engine and does not depend on a DNS provider's tolerance for a
+      record combination the RFC frowns on.
 
       Why it matters more than a checkbox: Search Console is the only honest
       answer to "what are people actually searching for". Search queries are


### PR DESCRIPTION
Komentarz twierdzil, ze nazwa z CNAME nie moze niesc innego typu rekordu i ze weryfikacja DNS jest tu przez to niemozliwa. **Nasza wlasna strefa temu przeczy**: `docs.msgwing.com` jest CNAME-em na `msgwing.github.io` **i serwuje TXT** — tak wlasnie zweryfikowano Yandex, zanim przeszedl na tag meta.

Prawdziwe jest wezsze twierdzenie: **resolver Yandexa** egzekwuje te regule i tego TXT nie odczyta. Google odczytuje bez problemu, a wlasciwosc w Search Console zostala zweryfikowana **jako domenowa, bez zadnego tagu** — wiec to miejsce w konfiguracji zostaje puste **celowo**, a nie przez przeoczenie.

Komentarz glaszacy regule, ktorej przeczy DNS tego samego repozytorium, to sposob, w jaki nastepna osoba podejmuje zla decyzje z pelnym przekonaniem.