### PR TITLE
feat(seo): IIS SMTP relay dostaje wlasna strone, za jedynym sygnalem jaki mamy

### DIFF
--- a/docs/IIS-SMTP-RELAY.md
+++ b/docs/IIS-SMTP-RELAY.md
@@ -1,0 +1,101 @@
+---
+title: "IIS SMTP relay and Microsoft 365"
+description: "The IIS SMTP Server feature relaying to Microsoft 365: what breaks when Basic auth ends in December 2026, and what to do about it."
+---
+
+# IIS SMTP relay and the Microsoft 365 Basic auth shutdown
+
+The IIS **SMTP Server** feature is the local relay a great deal of Windows
+software still points at. An application drops mail on `localhost:25`, the SMTP
+virtual server forwards it to a smart host, and nobody has thought about it for
+a decade.
+
+If that smart host is `smtp.office365.com` with a username and password, it
+stops working at the end of December 2026.
+
+## Why this page exists separately
+
+Microsoft has not supported this component since 2008. It ships with Windows
+Server, it works, and the usual advice — "reconfigure the application" — is
+useless when the application is a vendor binary whose only mail setting is
+*deliver to local SMTP server*. That case is common and it deserves a straight
+answer rather than a recommendation to rewrite software you do not own.
+
+## What actually breaks
+
+Nothing about the IIS side. The virtual server keeps accepting mail on port 25
+from localhost exactly as before.
+
+The failure is at the smart host: Microsoft 365 refuses the username and
+password, the message sits in the **Queue** folder, and IIS retries on its own
+schedule without telling anybody. There is no alert. The first symptom is
+usually somebody noticing that a report stopped arriving weeks ago.
+
+Confirm it is authentication rather than the network:
+
+```powershell
+npx zerosmtp-check smtp.office365.com
+```
+
+If the ports are reachable and TLS is fine, the refusal is the credentials
+being rejected, not a firewall. Paste what the queue or the event log recorded:
+
+```powershell
+npx zerosmtp-check --explain "535 5.7.139 Authentication unsuccessful"
+```
+
+## Your three options
+
+**Re-enable SMTP AUTH on the tenant.** Works until the end of December 2026 and
+not after. Legitimate as breathing room; a trap as a plan. The
+[migration guide](EXCHANGE-ONLINE-SMTP-AUTH.md) covers what happens to it.
+
+**Point the smart host somewhere that still accepts a password.** The
+application keeps delivering to `localhost:25` and never learns anything
+changed. Mail goes out from a generated `@msgwing.com` address rather than your
+own domain, which rules this out for customer-facing mail and makes it a
+reasonable fit for machine-generated notifications — see the
+[FAQ](FAQ.md#will-emails-be-sent-from-my-own-domain-eg-youyourdomaincom) before
+deciding.
+
+**Replace the relay.** A modern MTA on the same box does the same job with
+modern authentication. More work, and the right answer if the mail matters.
+
+## Configuring the smart host
+
+The console is IIS 6.0 Manager, which is a separate feature from the IIS
+Manager you are used to. Microsoft's own instructions for installing and
+configuring the feature are
+[here](https://learn.microsoft.com/en-us/iis/application-frameworks/install-and-configure-php-on-iis/configure-smtp-e-mail-in-iis-7-and-above).
+
+The three settings that matter, on the SMTP virtual server's **Properties**:
+
+| Where | What |
+| --- | --- |
+| `Delivery → Outbound Security` | Basic authentication, with the relay username and password, **TLS encryption enabled** |
+| `Delivery → Outbound connections` | Port `587` |
+| `Delivery → Advanced → Smart host` | `mx.msgwing.com` |
+
+Leave the virtual server's own access control alone: it should still accept
+only from `127.0.0.1`, because a relay that accepts from anywhere is an open
+relay and will be found.
+
+## Check the queue before you call it fixed
+
+The queue is a directory, and it is the honest test:
+
+```powershell
+Get-ChildItem C:\inetpub\mailroot\Queue
+Get-ChildItem C:\inetpub\mailroot\Badmail
+```
+
+An empty `Queue` means mail is leaving. Files accumulating in `Badmail` mean it
+is being rejected and IIS has given up on it — that directory is where the
+December 2026 failure will pile up silently, and it is worth a scheduled check
+regardless of which option you take.
+
+## Related
+
+- [Windows Server: every way to send mail](WINDOWS-SERVER.md)
+- [Every SMTP AUTH error and what it means](ERROR-MESSAGES.md)
+- [What breaks in December 2026](AFFECTED-SYSTEMS.md)

--- a/docs/WINDOWS-SERVER.md
+++ b/docs/WINDOWS-SERVER.md
@@ -110,6 +110,11 @@ ever handles the specific notification traffic it's meant for.
 
 ## Legacy: the classic IIS SMTP relay (not recommended for new setups)
 
+> Its own page now: **[IIS SMTP relay and Microsoft 365](IIS-SMTP-RELAY.md)**
+> — the queue and Badmail directories where this fails silently, the three
+> settings that matter, and the three options when the application cannot
+> be reconfigured. The short version is below.
+
 If you're maintaining an old application that only supports "deliver to
 local SMTP server" and can't be reconfigured to connect directly, the
 [Microsoft doc linked above](https://learn.microsoft.com/en-us/iis/application-frameworks/install-and-configure-php-on-iis/configure-smtp-e-mail-in-iis-7-and-above)

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,6 +68,7 @@ no mail sent.
 | Need to know **what else** in your environment will break | [What breaks: affected systems](AFFECTED-SYSTEMS.md) |
 | Have a printer or MFP to reconfigure | [Printer scan-to-email setup by brand](PRINTERS.md) |
 | Manage Windows Server / IIS / Exchange | [Windows Server guide](WINDOWS-SERVER.md) |
+| Have an app that can only "deliver to local SMTP server" | [IIS SMTP relay and Microsoft 365](IIS-SMTP-RELAY.md) |
 | Manage Linux servers | [Linux](LINUX.md) · [system-wide relay](SYSTEM-MTA.md) |
 | Want to look up one device or product | [OAuth compatibility list](DEVICE-COMPATIBILITY.md) |
 | Have a printer whose vendor says no OAuth firmware is coming | [Devices that will never get OAuth firmware](NO-OAUTH-FIRMWARE.md) |


### PR DESCRIPTION
Search Console dał dziś pierwsze dane: **8 kliknięć w trzy tygodnie** i jedna strona ruszająca się sama — **`WINDOWS-SERVER.html`, wyświetlenia +107%**.

**Dwie z pięćdziesięciu trzech stron tego serwisu dotykają Windows** — i jedna z nich to ta, którą Google podbija.

Ta strona chowa **cztery różne intencje wyszukiwania** w jednym dokumencie: aplikacja wskazana wprost na przekaźnik, PowerShell z Harmonogramem zadań, Send Connector Exchange'a i przekaźnik IIS SMTP. Stanowisko tego projektu — zapisane w `tools/build-error-pages.py` i udowodnione siedemnastoma stronami błędów — brzmi: **strona opisująca wiele rzeczy przegrywa każdą z nich ze stroną opisującą jedną**.

## Dlaczego IIS pierwszy

Największa spuścizna i **najcieńsze potraktowanie**: trzynaście linii na komponent, którego Microsoft nie wspiera od 2008 roku i do którego wciąż dostarcza masa oprogramowania na Windows.

Zwykła rada — „przekonfiguruj aplikację" — jest bezużyteczna, gdy aplikacja to binarka dostawcy, której jedynym ustawieniem poczty jest *dostarcz do lokalnego serwera SMTP*. Ten przypadek zasługuje na prostą odpowiedź, a nie na sugestię przepisania oprogramowania, którego się nie posiada.

## Strona zaczyna od tego, JAK to się psuje

Bo to jest część, której nikt nie widzi: **IIS dalej przyjmuje pocztę na localhoście dokładnie jak wcześniej**, smart host ją odrzuca, a wiadomości piętrzą się w `Queue` i `Badmail` **bez żadnego alertu**. Pierwszym objawem jest zwykle to, że ktoś zauważa, że jakiś raport przestał przychodzić tygodnie temu.

Oba katalogi są nazwane, bo ich sprawdzenie to uczciwy test — i warto go zaplanować niezależnie od wybranej opcji.

Trzy opcje podane z kosztem każdej, łącznie z tym, że poczta przez ten przekaźnik wychodzi **z wygenerowanego adresu, nie z domeny klienta** — co wyklucza ją dla poczty do klientów, i jest powiedziane **przed** tabelą konfiguracji, a nie po niej.

Podlinkowana z sekcji, z której została wydzielona, i z tabeli triage na stronie głównej — żeby nie powtórzyć tegotygodniowego błędu z jedenastoma sierotami.
