### PR TITLE
perf(seo): koniec ze zmiana adresu CSS przy kazdym commicie

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -181,7 +181,22 @@
     <link rel="apple-touch-icon" sizes="180x180" href="{{ '/assets/apple-touch-icon.png' | relative_url }}">
     <link rel="alternate" type="application/atom+xml" title="{{ site.title }}" href="{{ '/feed.xml' | relative_url }}">
 
-    <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+    {% comment %}
+      No ?v= cache-buster here on purpose, removed 2026-08-23.
+
+      It appended site.github.build_revision, which is the commit SHA, so every
+      commit produced a different stylesheet URL. Thirty commits in two days
+      meant thirty URLs for one unchanged file, and Googlebot re-fetched it each
+      time: Search Console reported 25% of the crawl budget going to CSS while
+      only 10% of requests were discovery. Thirty-six pages sat unindexed while
+      the crawler re-read normalize.css.
+
+      It was buying nothing. Checked against the live response rather than
+      assumed: GitHub Pages already serves this with Cache-Control max-age=600
+      and an ETag, so the worst case without a buster is a ten-minute-old
+      stylesheet, and the ETag usually prevents even that.
+    {% endcomment %}
+    <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
 
     <style>
       /* ==================================================================


### PR DESCRIPTION
**Statystyki indeksowania z Search Console, przeczytane dziś pierwszy raz:** 25% żądań Googlebota na tym serwisie to CSS, a **wykrywalność to zaledwie 10%** wszystkich żądań.

Dwie z pięćdziesięciu trzech stron niosą 78% wyświetleń, **36 stron nie jest zaindeksowanych wcale** — a robot spędza ćwierć budżetu na ponownym czytaniu `normalize.css`.

## Przyczyna to jedno wyrażenie Liquid

Adres arkusza doklejał `site.github.build_revision` — **SHA commita** — więc **każdy commit produkował inny URL dla pliku, który się nie zmienił**. Trzydzieści commitów w dwa dni to dla robota trzydzieści arkuszy stylów.

## I nie kupował nic

**Sprawdzone na żywej odpowiedzi, nie wyrozumowane:**

```
Cache-Control: max-age=600
ETag: "6a8ad228-2635"
```

GitHub Pages **już** obsługuje świeżość. Bez bustera najgorszy przypadek to arkusz sprzed dziesięciu minut, a `ETag` zwykle zapobiega nawet temu. Buster rozwiązywał problem, który CDN już rozwiązał — i kazał za to płacić budżetowi indeksowania.

## Czego to NIE naprawia

**Prawdziwym problemem jest pozycja.** Dwie strony niosące wyświetlenia siedzą na **36 i 54** — czwarta i szósta strona wyników — i żadna ilość budżetu indeksowania tego nie ruszy.

To uwalnia budżet, żeby robot **znalazł** strony, które już są napisane. Wypozycjonowanie ich to robota z HP i IIS.
