### PR TITLE
feat(seo): strona dla drukarki domowej - polowa ruchu, ktorej nikt nie obsluguje

### DIFF
--- a/docs/PRINTERS.md
+++ b/docs/PRINTERS.md
@@ -155,6 +155,10 @@ them in the printer's own credential store, not a shared document.
 
 ---
 
+> **Home printer, and not sure what any of this means?** [Scan to email from a home printer](SCAN-TO-EMAIL-HOME.md) explains what an
+> SMTP server is and why Gmail and Hotmail stopped working, without assuming
+> you administer a mail system.
+
 ## Where the settings live, by brand
 
 Menu wording shifts between firmware versions, but locations are stable

--- a/docs/SCAN-TO-EMAIL-HOME.md
+++ b/docs/SCAN-TO-EMAIL-HOME.md
@@ -1,0 +1,113 @@
+---
+title: "Scan to email from a home printer"
+description: "What an SMTP server is, why Gmail and Hotmail stopped working with printers, and how to get scan-to-email working again for free."
+---
+
+# Scan to email from a home printer
+
+Your printer can scan a page and email it to you. To do that it needs a **mail
+server** to hand the message to — printers cannot send email by themselves, the
+same way a letter needs a post office.
+
+That setting is called **SMTP**, and this page is about what to put in it when
+the obvious answer stopped working.
+
+## What is an SMTP server?
+
+It is a computer that accepts your message and delivers it. Your printer
+connects to it, proves who it is with a username and password, hands over the
+scan, and disconnects. Three things go in the printer's settings:
+
+| Setting | What it is |
+| --- | --- |
+| Server (or *SMTP server*, *outgoing server*) | the address to connect to |
+| Port | which door to use — almost always `587` or `465` |
+| Username and password | proof you are allowed to send |
+
+That is the whole idea. Everything else on this page is about which server to
+use.
+
+## Why Gmail and Hotmail stopped working
+
+For years people typed their own Gmail or Hotmail address and password into the
+printer, and it worked.
+
+It does not any more. Google and Microsoft both stopped accepting a plain
+password from devices, because a password typed into a printer is a password
+sitting in a printer. They now want a sign-in method almost no printer can do.
+
+If your printer says **"SMTP server requires authentication"**, **"login
+failed"**, or simply stops sending after years of working, this is usually why.
+Nothing is broken and retyping the password will not help.
+
+Some Gmail accounts can still use an **app password**, which is a separate
+password just for the printer. If you have two-step verification switched on,
+that is worth trying first — it costs nothing and keeps everything in one place.
+
+## If that does not work, use a relay
+
+A relay is a mail server whose whole job is to accept mail from devices like
+yours. ZeroSMTP is one, it is free, and it does not ask for a card:
+
+| Setting | Value |
+| --- | --- |
+| Server | `mx.msgwing.com` |
+| Port | `587` — or `465` if your printer only offers SSL |
+| Authentication | On |
+| Username / password | from [registration](https://msgwing.com) |
+| From address | the one you are given |
+
+[**Get a free account →**](https://msgwing.com)
+
+**Two things to know before you start**, because they matter more at home than
+anywhere else:
+
+Scans arrive **from a generated `@msgwing.com` address**, not from your own.
+For scanning a document to yourself, to family, or to an accountant, that is
+usually fine — the attachment is what matters. If it has to look like it came
+from your own address, this is the wrong tool and
+[the alternatives page](ALTERNATIVES.md) says which one is right.
+
+The limit is **200 messages a day** and no paid tier lifts it. A household will
+never reach that. A small office scanning invoices all day might.
+
+## Where the setting lives on your printer
+
+Almost every printer hides this behind its **web interface**: find the
+printer's IP address on its own screen (usually under `Network` or `Wi-Fi`
+settings), then type that number into a browser on a computer on the same
+network.
+
+| Brand | Where to look |
+| --- | --- |
+| HP | `Scan` or `Networking` → `Outgoing Email Profiles` — [full HP guide](HP-PRINTER-SMTP.md) |
+| Canon | Remote UI → `Settings/Registration` → `TX Settings` → `E-Mail Settings` |
+| Epson | Web Config → `Network` → `Email Server` → `Basic` |
+| Brother | Web Based Management → `Network` → `Protocol` → `SMTP` |
+| Others | [every brand, with menu paths](PRINTERS.md) |
+
+## It still does not send
+
+Check whether the printer can reach a mail server at all. From a computer on
+the same network:
+
+```bash
+npx zerosmtp-check
+```
+
+It tests the connection and reports what it found. No installation and no mail
+is sent. If it cannot connect either, the problem is the network rather than
+the printer — some internet providers block these ports on home connections,
+and [troubleshooting](TROUBLESHOOTING.md) covers what to do about it.
+
+If the printer shows an error code or message instead, paste it:
+
+```bash
+npx zerosmtp-check --explain "535 5.7.139 Authentication unsuccessful"
+```
+
+## Related
+
+- [HP printer: "SMTP server requires authentication"](HP-PRINTER-SMTP.md)
+- [Scan-to-email setup for every brand](PRINTERS.md)
+- [What the error messages mean](ERROR-MESSAGES.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,6 +68,7 @@ no mail sent.
 | Need to know **what else** in your environment will break | [What breaks: affected systems](AFFECTED-SYSTEMS.md) |
 | Have a printer or MFP to reconfigure | [Printer scan-to-email setup by brand](PRINTERS.md) |
 | Have an HP printer saying **"SMTP server requires authentication"** | [What that means and how to fix it](HP-PRINTER-SMTP.md) |
+| Just want a **home printer** to email a scan, and Gmail or Hotmail stopped working | [Scan to email from a home printer](SCAN-TO-EMAIL-HOME.md) |
 | Manage Windows Server / IIS / Exchange | [Windows Server guide](WINDOWS-SERVER.md) |
 | Have an app that can only "deliver to local SMTP server" | [IIS SMTP relay and Microsoft 365](IIS-SMTP-RELAY.md) |
 | Manage Linux servers | [Linux](LINUX.md) · [system-wide relay](SYSTEM-MTA.md) |


### PR DESCRIPTION
Właściciel poprosił, żeby użytkownicy domowi weszli do strategii. **Dane mówią, że już w niej są** — a nic na tym serwisie nie było napisane dla nich.

## Dowód

Trzynaście zapytań czyta się jak osoba w domu, nie administrator: `what is smtp server for hp printer`, `hotmail smtp server for hp printer`, `gmail smtp printer`, `scan to email printer`. **17 wyświetleń** — a każda strona tutaj zakłada, że czytelnik zarządza systemem pocztowym.

Geografia mówi to samo głośniej:

| Rynek | Wyświetlenia | Pozycja | Kliknięcia |
|---|---|---|---|
| Filipiny | 76 | 52,9 | **0** |
| Tajlandia | 38 | 42,7 | **0** |
| Malezja | 27 | 47,5 | **0** |
| Turcja | 27 | 50,0 | **0** |
| Wietnam | 25 | 50,1 | **0** |
| Indonezja | 22 | 58,9 | **0** |
| Arabia Saudyjska | 21 | 32,5 | **0** |
| **Razem** | **327** | | **0** |

**Prawie połowa wszystkich wyświetleń, ani jednego kliknięcia.**

`What is an SMTP server` to człowiek, który **nie wie, co to SMTP**. Wysłanie go na stronę o konektorach Exchange Online to to samo, co nie wysłanie go nigdzie.

## Jak ta strona jest napisana

Zaczyna od **drukarki**, nie od protokołu. Tłumaczy, czemu Gmail i Hotmail przestały przyjmować hasło. I **najpierw wymienia hasła aplikacji** — co kosztuje nas klienta i jest właściwą odpowiedzią dla kogoś, kto ma już działające konto Google.

Limity stoją **nad** tabelą ustawień, nie pod nią. W domu wspólny adres nadawcy zwykle nie ma znaczenia, bo człowiek skanuje dokument do siebie; tam, gdzie ma znaczenie, powinien się o tym dowiedzieć **przed** wpisaniem hasła do drukarki, a nie po.

Dwieście dziennie podane tak samo: **gospodarstwo domowe nigdy tego nie osiągnie, biuro skanujące faktury cały dzień może.** Lepiej powiedziane tutaj niż odkryte we wtorek.
