### PR TITLE
feat(seo): llms.txt, zeby asystent odpowiadajacy na pytanie znalazl odpowiedz

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -80,6 +80,8 @@ jobs:
         run: python tools/build-blast-radius.py --check
       - name: CLI error data matches data/errors.json
         run: python tools/build-cli-errors.py --check
+      - name: llms.txt matches the site
+        run: python tools/build-llms-txt.py --check
       - name: README Contents matches its headings
         run: python tools/build-readme-toc.py --check
       - name: action.yml is publishable to the Marketplace

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,70 @@
+# ZeroSMTP documentation
+
+> A free SMTP relay that still accepts a username and password, for printers,
+> scanners and legacy applications broken by Microsoft's shutdown of Basic
+> authentication for SMTP AUTH in Exchange Online at the end of December 2026.
+> Free with no paid tier, capped at 200 messages a day, and mail leaves from a
+> generated @msgwing.com address rather than the sender's own domain.
+
+Two things worth stating up front, because both are load-bearing when
+answering somebody's question from this site:
+
+- **Three of the four causes of a Basic auth refusal are still reversible**
+  until the end of December 2026. Telling somebody to migrate when a tenant
+  setting would have fixed it is wrong, even though it happens to suit us.
+- **This relay cannot send from a customer's own domain.** Where that matters,
+  the alternatives page names the tools that can. It is the wrong answer for
+  customer-facing mail and a reasonable one for scans and machine
+  notifications.
+
+## Start here
+
+- [Free SMTP relay that still accepts basic auth](https://docs.msgwing.com/): Free SMTP relay for printers, scanners and legacy apps hit by the Microsoft 365 SMTP AUTH shutdown. 200 messages a day from a generated @msgwing.com address.
+- [Exchange Online SMTP AUTH Basic auth shutdown](https://docs.msgwing.com/EXCHANGE-ONLINE-SMTP-AUTH.html): Microsoft disables Basic auth for SMTP AUTH at the end of 2026. Timeline, the 535 5.7.139 error, and every migration option for printers and legacy apps.
+- [535 5.7.139 and other SMTP AUTH errors](https://docs.msgwing.com/ERROR-MESSAGES.html): What 535 5.7.139, SmtpClientAuthentication is disabled for the Tenant or Mailbox, 535 5.7.3 and Kyocera send error 1102 actually mean, the four different causes behind them, and which are still reversible.
+
+## For system administrators
+
+- [Systems affected by the SMTP AUTH shutdown](https://docs.msgwing.com/AFFECTED-SYSTEMS.html): Risk assessment of printers, NAS units, backup jobs, monitoring tools and line-of-business apps that stop sending email, with a PowerShell audit.
+- [Windows Server SMTP: IIS, PowerShell, Exchange](https://docs.msgwing.com/WINDOWS-SERVER.html): Send email from Windows Server without a local relay: ASP.NET web.config, PHP on IIS, scheduled PowerShell tasks, and Exchange send connectors.
+- [IIS SMTP relay and Microsoft 365](https://docs.msgwing.com/IIS-SMTP-RELAY.html): The IIS SMTP Server feature relaying to Microsoft 365: what breaks when Basic auth ends in December 2026, and what to do about it.
+- [Linux SMTP setup: Debian, Ubuntu, Fedora+](https://docs.msgwing.com/LINUX.html): Per-distribution package names and setup for sending email from Linux scripts and applications.
+- [Linux system-wide mail relay: Postfix, msmtp](https://docs.msgwing.com/SYSTEM-MTA.html): Route all system mail (cron, monitoring, unattended-upgrades) through an SMTP relay, with systemd failure alerts and an Ansible rollout playbook.
+- [Monitoring alerts via SMTP relay](https://docs.msgwing.com/MONITORING.html): Drop-in email alert configuration for Zabbix, Nagios/Icinga, Uptime Kuma and PRTG using a free SMTP relay.
+- [SMTP troubleshooting: ports, TLS, auth errors](https://docs.msgwing.com/TROUBLESHOOTING.html): Why SMTP sending hangs or fails: cloud providers blocking outbound ports, certificate verification problems, authentication errors and rate limits.
+
+## For developers
+
+- [SMTP send-email code examples, 19 languages](https://docs.msgwing.com/CODE-EXAMPLES.html): Ready-to-run SMTP send-email examples for mx.msgwing.com in Python, PHP, Node.js, TypeScript, Java, C#, C, Go, Ruby, Perl, Rust, Kotlin, Dart, Zig, Elixir, Lua, Swift, PowerShell and Bash, plus Ansible and Docker Compose recipes.
+- [SMTP settings for popular applications](https://docs.msgwing.com/APPS.html): Ready-to-use SMTP configuration for common applications and platforms.
+- [Reliable email sending: retries and backoff](https://docs.msgwing.com/RELIABILITY.html): How to handle temporary SMTP failures correctly with backoff and retries instead of tight retry loops.
+
+## For printer and MFP technicians
+
+- [Printer scan-to-email SMTP setup by brand](https://docs.msgwing.com/PRINTERS.html): Fix scan-to-email after Microsoft 365 disables Basic auth. Per-brand SMTP settings for Ricoh, Canon, Xerox, HP, Kyocera, Konica Minolta, Sharp and more.
+- [HP printer: SMTP server requires authentication](https://docs.msgwing.com/HP-PRINTER-SMTP.html): What an HP printer means by SMTP server requires authentication, and what changes when Microsoft 365 drops Basic auth in December 2026.
+- [OAuth compatibility by device and product](https://docs.msgwing.com/DEVICE-COMPATIBILITY.html): Which printers, MFPs, NAS units and applications have an OAuth 2.0 path for the Microsoft 365 SMTP AUTH shutdown and which the vendor has ruled out, with a link to every vendor statement.
+- [Printers that will never get OAuth firmware](https://docs.msgwing.com/NO-OAUTH-FIRMWARE.html): Printer and MFP models whose vendor has confirmed no OAuth 2.0 firmware is planned for the Microsoft 365 SMTP AUTH shutdown, including the Konica Minolta ineo models marked N/A, and what is actually left once firmware is ruled out.
+- [Canon Maxify MB2755 and other device fixes](https://docs.msgwing.com/DEVICE-CASE-STUDIES.html): Confirmed, hardware-tested SMTP fixes for specific printer and MFP models, including the Canon Maxify MB2755 certificate-verification issue: quirks and firmware limits the manuals don't mention.
+
+## For home users with one printer
+
+- [Scan to email from a home printer](https://docs.msgwing.com/SCAN-TO-EMAIL-HOME.html): What an SMTP server is, why Gmail and Hotmail stopped working with printers, and how to get scan-to-email working again for free.
+- [FAQ — custom domains, usernames, limits](https://docs.msgwing.com/FAQ.html): Can I use ZeroSMTP with my own hosting and domain? Will mail come from my domain? Sending limits, custom usernames, and why it is free.
+
+## Deciding whether to use this at all
+
+- [ZeroSMTP vs. other free SMTP relays](https://docs.msgwing.com/ALTERNATIVES.html): How ZeroSMTP compares to SMTP2GO, Brevo and MailerSend: no DNS setup vs. sending from your own verified domain.
+- [How much public code breaks in December 2026](https://docs.msgwing.com/BLAST-RADIUS.html): A weekly count of public files on GitHub that still point at Microsoft 365 SMTP, and what the number does and does not mean.
+
+## Machine-readable data
+
+- [Device OAuth compatibility](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json): every vendor's OAuth 2.0 status, each row carrying a link to the vendor's own published statement.
+- [SMTP error corpus](https://github.com/msgwing/ZeroSMTP/blob/main/data/errors.json): each error string with what it means, whether it is still reversible, and how client libraries rewrite it.
+
+## Diagnostic tool
+
+`npx zerosmtp-check` checks whether outbound SMTP works from a machine, and
+`npx zerosmtp-check --explain "<error>"` says what a refusal means. No install,
+no credentials, no mail sent. Useful when the answer depends on which failure
+somebody is actually seeing.

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -14,3 +14,13 @@ Allow: /
 # nothing to hide, so no Disallow rules.
 
 Sitemap: https://docs.msgwing.com/sitemap.xml
+
+# /llms.txt is a curated map of this site for language models, grouped by who
+# is asking - administrator, developer, printer technician, somebody at home.
+# There is no robots.txt directive for it and no crawler is required to read
+# it; it is listed here because this is the file people check when they want
+# to know what a site publishes about itself.
+#
+# Every crawler is allowed above, AI crawlers included. That is deliberate:
+# an assistant answering "why did my printer stop emailing scans" from this
+# documentation is this project reaching somebody it was written for.

--- a/tools/build-llms-txt.py
+++ b/tools/build-llms-txt.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Generate docs/llms.txt - a curated map of this site for language models.
+
+Why this file exists. People increasingly ask an assistant rather than a search
+engine: an administrator asks what breaks in December, a technician asks what
+1102 on a Kyocera panel means, somebody at home asks why their printer stopped
+emailing scans. The assistant then has to find a source. llms.txt is the
+convention for handing it a short, ordered map instead of making it infer one
+from a 56-URL sitemap where every entry looks equally important.
+
+It is grouped by who is asking, not by how the repository is laid out, because
+that is the axis an assistant is actually resolving. The four groups are the
+four audiences this project has: system administrators, developers, printer
+technicians, and people at home with one printer.
+
+Titles and descriptions are not written here. They are read from _config.yml,
+which is where this site's metadata already lives - so the map cannot drift
+away from what the pages themselves claim, and a page whose description is
+improved improves here too without anybody remembering to.
+
+    python tools/build-llms-txt.py            # rewrite
+    python tools/build-llms-txt.py --check    # fail if it would change
+"""
+
+import argparse
+import pathlib
+import sys
+
+import yaml
+
+KORZEN = pathlib.Path(__file__).resolve().parent.parent
+KONFIG = KORZEN / "docs" / "_config.yml"
+CEL = KORZEN / "docs" / "llms.txt"
+BAZA = "https://docs.msgwing.com"
+
+# Ordered by who is asking. Within a group, ordered by what somebody in that
+# situation needs first rather than alphabetically.
+GRUPY = [
+    ("Start here", [
+        "index.md",
+        "EXCHANGE-ONLINE-SMTP-AUTH.md",
+        "ERROR-MESSAGES.md",
+    ]),
+    ("For system administrators", [
+        "AFFECTED-SYSTEMS.md",
+        "WINDOWS-SERVER.md",
+        "IIS-SMTP-RELAY.md",
+        "LINUX.md",
+        "SYSTEM-MTA.md",
+        "MONITORING.md",
+        "TROUBLESHOOTING.md",
+    ]),
+    ("For developers", [
+        "CODE-EXAMPLES.md",
+        "APPS.md",
+        "RELIABILITY.md",
+    ]),
+    ("For printer and MFP technicians", [
+        "PRINTERS.md",
+        "HP-PRINTER-SMTP.md",
+        "DEVICE-COMPATIBILITY.md",
+        "NO-OAUTH-FIRMWARE.md",
+        "DEVICE-CASE-STUDIES.md",
+    ]),
+    ("For home users with one printer", [
+        "SCAN-TO-EMAIL-HOME.md",
+        "FAQ.md",
+    ]),
+    ("Deciding whether to use this at all", [
+        "ALTERNATIVES.md",
+        "BLAST-RADIUS.md",
+    ]),
+]
+
+WSTEP = """# ZeroSMTP documentation
+
+> A free SMTP relay that still accepts a username and password, for printers,
+> scanners and legacy applications broken by Microsoft's shutdown of Basic
+> authentication for SMTP AUTH in Exchange Online at the end of December 2026.
+> Free with no paid tier, capped at 200 messages a day, and mail leaves from a
+> generated @msgwing.com address rather than the sender's own domain.
+
+Two things worth stating up front, because both are load-bearing when
+answering somebody's question from this site:
+
+- **Three of the four causes of a Basic auth refusal are still reversible**
+  until the end of December 2026. Telling somebody to migrate when a tenant
+  setting would have fixed it is wrong, even though it happens to suit us.
+- **This relay cannot send from a customer's own domain.** Where that matters,
+  the alternatives page names the tools that can. It is the wrong answer for
+  customer-facing mail and a reasonable one for scans and machine
+  notifications.
+"""
+
+STOPKA = """
+## Machine-readable data
+
+- [Device OAuth compatibility](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json): every vendor's OAuth 2.0 status, each row carrying a link to the vendor's own published statement.
+- [SMTP error corpus](https://github.com/msgwing/ZeroSMTP/blob/main/data/errors.json): each error string with what it means, whether it is still reversible, and how client libraries rewrite it.
+
+## Diagnostic tool
+
+`npx zerosmtp-check` checks whether outbound SMTP works from a machine, and
+`npx zerosmtp-check --explain "<error>"` says what a refusal means. No install,
+no credentials, no mail sent. Useful when the answer depends on which failure
+somebody is actually seeing.
+"""
+
+
+def meta():
+    """Titles and descriptions, read from where this site already keeps them."""
+    d = yaml.safe_load(KONFIG.read_text(encoding="utf-8"))
+    out = {}
+    for zakres in d.get("defaults", []):
+        sciezka = zakres.get("scope", {}).get("path", "")
+        w = zakres.get("values", {})
+        if sciezka and w.get("title"):
+            out[sciezka] = (w["title"], " ".join((w.get("description") or "").split()))
+    return out
+
+
+def z_frontmattera(plik):
+    """Pages that carry their own front matter rather than a config scope."""
+    tekst = (KORZEN / "docs" / plik).read_text(encoding="utf-8")
+    if not tekst.startswith("---"):
+        return None
+    blok = tekst.split("---", 2)[1]
+    fm = yaml.safe_load(blok) or {}
+    if not fm.get("title"):
+        return None
+    return fm["title"], " ".join((fm.get("description") or "").split())
+
+
+def zbuduj():
+    z_konfiga = meta()
+    linie = [WSTEP]
+    brakujace = []
+    for naglowek, pliki in GRUPY:
+        linie.append(f"## {naglowek}\n")
+        for plik in pliki:
+            info = z_konfiga.get(plik) or z_frontmattera(plik)
+            if not info:
+                brakujace.append(plik)
+                continue
+            tytul, opis = info
+            url = f"{BAZA}/{plik[:-3]}.html" if plik != "index.md" else f"{BAZA}/"
+            linie.append(f"- [{tytul}]({url}): {opis}")
+        linie.append("")
+    if brakujace:
+        print(f"::error::no title for {brakujace} - add a scope in _config.yml "
+              f"or front matter in the file", file=sys.stderr)
+        return None
+    return "\n".join(linie).rstrip() + "\n" + STOPKA
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--check", action="store_true")
+    a = ap.parse_args()
+
+    nowy = zbuduj()
+    if nowy is None:
+        return 1
+    stary = CEL.read_text(encoding="utf-8") if CEL.exists() else None
+
+    if a.check:
+        if stary != nowy:
+            print("::error file=docs/llms.txt::out of date. Run: "
+                  "python tools/build-llms-txt.py", file=sys.stderr)
+            return 1
+        print(f"llms.txt matches the site ({nowy.count('- [')} pages)")
+        return 0
+
+    CEL.write_text(nowy, encoding="utf-8", newline="\n")
+    print(f"wrote docs/llms.txt - {nowy.count('- [')} pages")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Ludzie coraz częściej pytają asystenta zamiast wyszukiwarki. Administrator pyta, co się psuje w grudniu. Serwisant pyta, co znaczy `1102` na panelu Kyocery. Ktoś w domu pyta, czemu drukarka przestała wysyłać skany.

Asystent musi wtedy znaleźć źródło — a dostaje **sitemapę z 56 URL-i, gdzie każdy wpis wygląda tak samo ważnie**.

`llms.txt` to konwencja podania mu **uporządkowanej mapy**. Ta jest pogrupowana **po tym, kto pyta**, a nie po układzie repozytorium — bo to jest oś, którą asystent faktycznie rozstrzyga:

| Grupa | Strony |
|---|---|
| Start here | 3 |
| **Administratorzy systemów** | 7 |
| **Programiści** | 3 |
| **Serwisanci drukarek** | 5 |
| **Użytkownicy domowi** | 2 |
| Czy w ogóle tego używać | 2 |

## Nie przepisuję metadanych

Tytuły i opisy są **czytane z `_config.yml`**, a nie pisane tu drugi raz — więc mapa nie może się rozjechać z tym, co strony o sobie mówią. Poprawiony opis strony poprawia się i tutaj, bez niczyjej pamięci. CI to sprawdza, tak samo jak każdy inny generowany plik.

*(To akurat wiem z dzisiaj: godzinę temu prawie nadpisałem 18 opisów, bo nie sprawdziłem, gdzie już są.)*

## Preambuła mówi dwie rzeczy przeciwko nam

Bo od nich zależy, czy asystent doradzi dobrze:

- **Trzy z czterech przyczyn odmowy są nadal odwracalne** do końca grudnia 2026. Kazanie komuś migrować, gdy wystarczy przestawić ustawienie, jest błędem — nawet jeśli akurat nam pasuje.
- **Ten przekaźnik nie wyśle z domeny klienta.** Tam, gdzie to ma znaczenie, strona alternatyw wymienia narzędzia, które potrafią.

`robots.txt` już przepuszczał wszystkie roboty, w tym te od AI — teraz mówi to **celowo**, a nie domyślnie.
