### PR TITLE
docs: przybysze z Marketplace dostaja to, po co przyszli, nad zagieciem

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,29 @@ from a shared `@msgwing.com` address rather than your own
 
 <!-- END GENERATED CONTENTS -->
 
+> ### Arrived from the GitHub Marketplace?
+>
+> This page is the README of the whole project, which is a free SMTP relay — so
+> the action you came for is below the fold. Here it is:
+>
+> ```yaml
+> - uses: msgwing/ZeroSMTP@v1.7.0
+>   with:
+>     host: smtp.office365.com
+>     cert-expiry-days: '14'
+> ```
+>
+> It checks outbound SMTP from the runner — ports, TLS, certificate and the
+> AUTH mechanisms offered — and **fails the job when the mail server's
+> certificate is inside the window you set**. Nobody watches a mail
+> certificate; it expires on a Sunday and the first report is somebody saying
+> scanning stopped working.
+>
+> No install and no npm: the tool has no dependencies, so the action runs the
+> file shipped beside it. Every input, and the scheduled-canary setup that
+> reports without failing, is in [**GitHub Actions**](#github-actions) further
+> down.
+
 ## What's in here
 
 | | |


### PR DESCRIPTION
**Sprawdzone na opublikowanej wystawce**, nie założone.

| Element | Stan |
|---|---|
| Tytuł, opis | ✅ poprawne |
| Fragment `uses:` | ✅ GitHub generuje sam |
| **Treść strony** | ❌ README całego repozytorium |
| **Kategoria** | ❌ żadna |

Marketplace pokazuje jako treść **README tego repozytorium**, które otwiera się zdaniem *„Everything you need for the Microsoft 365 SMTP AUTH shutdown"* — czyli pitchem przekaźnika pocztowego.

Programista przeglądający Marketplace w poszukiwaniu akcji CI **ląduje na stronie produktowej czegoś innego** i musi przewinąć listę kompatybilności, 21 przykładów kodu i wykres gwiazdek, zanim dowie się, co ta akcja robi.

Krótki blok u góry odpowiada na to **na miejscu**: fragment YAML, co sprawdza, okno wygaśnięcia certyfikatu — czyli **właściwy powód wstawienia tego do pipeline'u** — i link do pełnych wejść niżej. Zaadresowany do przybyszów z Marketplace, żeby nie czytał się jak szum dla kogoś, kto przyszedł po przekaźnik.

## Czego to nie naprawia i nie może stąd

**Wystawka nie jest w żadnej kategorii Marketplace**, więc nikt przeglądający po kategoriach do niej nie dotrze. To ustawia się na samej wystawce, nie w `action.yml`.
