### PR TITLE
feat(seo): strony referencyjne oznaczone jako TechArticle

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -70,6 +70,18 @@ defaults:
     values:
       layout: default
       image: /assets/social-preview.png
+  # The generated reference pages. Scoped by directory so a page added by
+  # tools/build-error-pages.py or build-device-table.py inherits the markup
+  # without anybody remembering to list it - the alternative is a per-file
+  # scope that goes stale the first time a generator runs.
+  - scope:
+      path: "errors"
+    values:
+      schema: reference
+  - scope:
+      path: "devices"
+    values:
+      schema: reference
   - scope:
       path: "index.md"
     values:

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -174,6 +174,37 @@
       ]
     }
     </script>
+    {% elsif page.schema == "reference" %}
+    {%- comment -%}
+      The generated pages under errors/ and devices/. TechArticle rather than
+      FAQPage on purpose: these are not written as questions and answers, and
+      claiming FAQ markup for prose that is not a Q&A is the kind of thing that
+      earns a manual action. What it buys is not a rich result - it is that a
+      crawler, and increasingly an assistant, can tell this is a technical
+      reference about one named thing rather than a marketing page.
+    {%- endcomment -%}
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "TechArticle",
+      "headline": {{ page.title | jsonify }},
+      "description": {{ page.description | jsonify }},
+      "url": {{ page.url | absolute_url | jsonify }},
+      "inLanguage": "en",
+      "isAccessibleForFree": true,
+      "proficiencyLevel": "Beginner",
+      "about": {
+        "@type": "Thing",
+        "name": "Microsoft 365 SMTP AUTH Basic authentication shutdown"
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "ZeroSMTP",
+        "url": "https://docs.msgwing.com/"
+      }
+    }
+    </script>
+
     {% endif %}
 
     <link rel="icon" type="image/x-icon" href="{{ '/assets/favicon.ico' | relative_url }}">


### PR DESCRIPTION
**34 generowane strony** w `errors/` i `devices/` nie niosły żadnych danych strukturalnych poza `WebPage`, które `jekyll-seo-tag` emituje dla wszystkiego. Robot nie miał czym odróżnić technicznej referencji o jednym nazwanym błędzie od dowolnej innej strony serwisu.

## TechArticle, a nie FAQPage — celowo

Te strony to **proza, nie pytania i odpowiedzi**. Deklarowanie znaczników FAQ dla treści, która nie jest Q&A, to sposób, w jaki serwis zarabia na **ręczną karę**.

Co to daje: **nie rich result**, tylko to, że robot — i coraz częściej asystent odpowiadający na czyjeś pytanie — potrafi rozpoznać, na jakiego rodzaju stronę patrzy i czego ona dotyczy.

## Zakres po katalogu, nie po pliku

Strona dodana przez `build-error-pages.py` albo `build-device-table.py` **dziedziczy to bez niczyjej pamięci**. Lista per plik zwietrzałaby przy pierwszym uruchomieniu generatora — czyli dokładnie ta porażka, którą indeks stron błędów zaliczył dziś rano.

`headline` i `description` idą z front matteru strony przez `jsonify`, więc **znaczniki nie mogą twierdzić czegoś innego, niż mówi sama strona**.
