### PR TITLE
feat(docs): wpis urzadzenia moze wskazac swoj szczegolowy poradnik

### DIFF
--- a/data/devices.json
+++ b/data/devices.json
@@ -187,7 +187,9 @@
       "status": "partial",
       "models": [],
       "evidence": "https://support.hp.com/nz-en/document/ish_13623350-13600809-16",
-      "notes": "HP documents OAuth 2.0 support for Microsoft 365 Scan to Email on HP Enterprise and HP Managed printers running FutureSmart firmware 5.7 and newer. However, HP also states that certain LaserJet Pro models, including the M478-M479 and M428-M429f, do not support OAuth 2.0. Verify the exact product family and firmware before assuming Microsoft 365 SMTP AUTH compatibility."
+      "notes": "HP documents OAuth 2.0 support for Microsoft 365 Scan to Email on HP Enterprise and HP Managed printers running FutureSmart firmware 5.7 and newer. However, HP also states that certain LaserJet Pro models, including the M478-M479 and M428-M429f, do not support OAuth 2.0. Verify the exact product family and firmware before assuming Microsoft 365 SMTP AUTH compatibility.",
+      "guide": "HP-PRINTER-SMTP.md",
+      "guide_title": "HP printer: \"SMTP server requires authentication\""
     }
   ]
 }

--- a/docs/devices/hp-printers-and-mfps.md
+++ b/docs/devices/hp-printers-and-mfps.md
@@ -36,6 +36,8 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 
 ## Related
 
+- **[HP printer: "SMTP server requires authentication"](../HP-PRINTER-SMTP.md)** — the detailed guide for HP, including what the error on the panel actually means
+
 - [What the error message means](../ERROR-MESSAGES.md) — if the HP device is reporting a code rather than a sentence
 - [The full compatibility list](../DEVICE-COMPATIBILITY.md) — every vendor, in one table
 - [Setup by printer brand](../PRINTERS.md) — where the SMTP fields actually live in each vendor's interface

--- a/tools/build-device-table.py
+++ b/tools/build-device-table.py
@@ -255,6 +255,12 @@ def zbuduj_strone(wpis, aktualizacja):
     czesci += [
         "## Related",
         "",
+        # A vendor with a page of its own gets it first. Only where one exists:
+        # a "further reading" line pointing at a page that covers ten brands is
+        # not further reading, it is the same link the section already carries.
+        *([f"- **[{wpis['guide_title']}](../{wpis['guide']})** — the detailed "
+           f"guide for {wpis['vendor']}, including what the error on the panel "
+           f"actually means", ""] if wpis.get("guide") else []),
         f"- [What the error message means](../ERROR-MESSAGES.md) — if the "
         f"{wpis['vendor']} device is reporting a code rather than a sentence",
         "- [The full compatibility list](../DEVICE-COMPATIBILITY.md) — every "


### PR DESCRIPTION
HP ma teraz **dwie strony**: generowany wpis kompatybilności — wiersz faktów z oświadczeniem producenta za nim — oraz `HP-PRINTER-SMTP.md`, która tłumaczy, co znaczy *„SMTP server requires authentication"* i co zrobić z każdą z jej trzech przyczyn.

**Nic ich nie łączyło.** Czytelnik, który znalazł wiersz kompatybilności, dostawał status i żadnej drogi dalej.

Generator renderuje ten link **wyłącznie tam, gdzie wpis go nazywa**. Ten warunek ma znaczenie: linijka „dalsza lektura" wskazująca stronę o dziesięciu markach **nie jest dalszą lekturą** — to ten sam link, który sekcja `Related` już niesie.

## Dlaczego jeden link, a nie trzydzieści cztery

Kuszące było dorzucenie nowych stron do sekcji `Related` na **każdej** generowanej stronie. Trzy linki wchodzące stają się trzydziestoma czterema i **liczby wyglądają lepiej**.

Czytelnik strony o `5.7.233` — dzienny limit wysyłki tenanta — **nie zyskuje nic** z linku do poradnika o drukarkach HP.

Linkowanie wewnętrzne pomaga wtedy, gdy jest **tym linkiem, którego ktoś chciał następnie**.
