### PR TITLE
docs(action): zapis wybranych kategorii Marketplace i uzasadnienia

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,21 @@ name: 'ZeroSMTP Check'
 description: 'Check outbound SMTP from a runner: ports, TLS, AUTH, and fail the job when the mail certificate is near expiry.'
 author: 'msgwing'
 
+# Marketplace categories, set 2026-08-23: Monitoring (primary), Utilities.
+#
+# Recorded here because they are not part of this file - GitHub keeps them on
+# the release, so nothing in the repository would otherwise say what was
+# chosen or why, and the next release would be a guess.
+#
+# Monitoring rather than Testing, deliberately. What makes this worth putting
+# in a pipeline is not that it checks ports: it is that it fails the build when
+# the mail server's certificate is inside the window you set. Nobody watches a
+# mail certificate, it expires on a Sunday, and the first report is somebody
+# saying scanning stopped working. Testing would have attracted people looking
+# for a unit-test runner and disappointed them.
+#
+# To change them: repository -> Releases -> edit the release -> Release Action.
+
 branding:
   icon: 'mail'
   color: 'purple'


### PR DESCRIPTION
Wystawka jest teraz w **Monitoring** i **Utilities** — potwierdzone na opublikowanej stronie, nie założone.

Kategorie mieszkają **na wydaniu**, nie w tym pliku, więc bez zapisania ich nic w repozytorium nie mówiłoby, co wybrano — a następne wydanie byłoby zgadywanką.

## Monitoring, a nie Testing — celowo

Tym, co czyni tę akcję wartą wstawienia do pipeline'u, **nie jest sprawdzanie portów**. Jest nim **wywalanie builda, gdy certyfikat serwera pocztowego wchodzi w zadane okno**.

Nikt nie pilnuje certyfikatu poczty. Wygasa w niedzielę, a pierwszym zgłoszeniem jest ktoś mówiący, że skanowanie przestało działać.

`Testing` przyciągnęłoby ludzi szukających uruchamiacza testów jednostkowych i odesłało ich z niczym.

---

Tym samym wystawka jest **kompletna**: nazwa, opis, treść i kategoria. Jeszcze dziś rano była osiągalna wyłącznie z bezpośredniego linku, a jej treścią było README tego projektu otwierające się pitchem przekaźnika pocztowego.
