### PR TITLE
docs: prawdziwe liczby w porownaniu, lacznie z tym gdzie przegrywamy

### DIFF
--- a/docs/ALTERNATIVES.md
+++ b/docs/ALTERNATIVES.md
@@ -18,13 +18,50 @@ part is standard. What differs is what happens *before* you can use them.
 | **DNS records to configure** | None | SPF + DKIM (and DMARC, recommended) |
 | **Sends from your own domain** | ❌ shared `@msgwing.com` address | ✅ once verified |
 | **Sender reputation** | Managed for you — shared domain, actively monitored for abuse | Yours to build and protect — a fresh domain/IP has no reputation yet, and one bad list wrecks it |
-| **Free tier** | 200/day, permanent | Roughly 300/day–3,000/month, mostly permanent |
+| **Free tier** | 200/day, permanent | 100/month to 12,000/month — [the numbers are below](#what-the-free-tiers-actually-allow) |
 | **Credit card required** | No | Usually no |
 | **Best fit** | Printers, NAS units, scripts, legacy devices — anything that just needs mail to leave, from anyone | Apps and products sending under your own brand |
 
 Sources: [SMTP2GO — verified senders](https://support.smtp2go.com/hc/en-gb/articles/115004408567-Verified-Senders)
 (verification required for normal sending), [Brevo domain authentication](https://community.brevo.com/t/smtp-domain-authentication-sender-domain-verification/760)
 (not required to start, recommended for deliverability).
+
+## What the free tiers actually allow
+
+The vague version of this comparison — "roughly 300/day to 3,000/month" — was
+doing us no favours and is not much use to anybody deciding. The published free
+tiers, as surveyed by
+[EmailToolTester's roundup of free SMTP servers](https://www.emailtooltester.com/en/blog/free-smtp-servers/):
+
+| Service | Free tier | Own domain |
+| --- | --- | --- |
+| SendPulse | 12,000/month | required |
+| Brevo | 300/day | recommended |
+| Mailtrap | 4,000/month | required |
+| Maileroo | 3,000/month | required |
+| MailerSend | 500/month | required |
+| Mailjet | 200/day | required |
+| **ZeroSMTP** | **200/day** | **not possible** |
+| SendGrid | 100/day | required |
+| Elastic Email | 100/day | required |
+| Postmark | 100/month | required |
+
+Two things worth reading off that table, and the second is against us.
+
+**On volume we are mid-pack, not bottom.** 200 a day matches Mailjet, doubles
+SendGrid and Elastic Email, and is sixty times what Postmark's free tier
+allows. For a printer sending scans this is not the constraint anybody thinks
+it is.
+
+**On everything else those services are more capable.** They send from your
+domain, report deliverability, handle bounces and suppression lists, and scale
+when you outgrow the free tier. We do none of that and never will. If you are
+building a product that emails customers, one of them is the right answer and
+this is not a close call.
+
+Limits move. These were current when this page was last reviewed; check the
+provider before deciding on the strength of a number in somebody else's table,
+including ours.
 
 ## Which one fits you
 


### PR DESCRIPTION
Właściciel zapytał, jak wypadamy wobec darmowych usług SMTP, które ludzie faktycznie znajdują. Sprawdziłem **zestawienie EmailToolTester** — czyli stronę, która na to pytanie rankuje — i wyciągnąłem **opublikowane limity**, zamiast je opisywać.

## Nasza własna strona zaniżała nas

Pisała: *„mniej więcej 300/dzień do 3000/miesiąc"* dla wszystkich innych. Dość mgliście, żeby było bezużyteczne dla czytelnika — i, jak się okazuje, **stawiało nasze 200/dzień na dnie zakresu, na którym go nie ma.**

| Usługa | Darmowy próg |
|---|---|
| SendPulse | 12 000 / mies. |
| Brevo | 300 / dzień |
| Mailtrap | 4 000 / mies. |
| **ZeroSMTP** | **200 / dzień** |
| Mailjet | 200 / dzień |
| SendGrid | 100 / dzień |
| Elastic Email | 100 / dzień |
| **Postmark** | **100 / miesiąc** |

**200 dziennie dorównuje Mailjetowi, dwukrotnie bije SendGrida i Elastic Email, i jest sześćdziesiąt razy większe niż darmowy próg Postmarka.** Dla drukarki wysyłającej skany wolumen **nie jest tym ograniczeniem**, za które wszyscy go biorą.

## Drugi odczyt jest przeciwko nam i stoi tym samym tchem

Każda z tych usług wysyła **z domeny klienta**, raportuje dostarczalność, obsługuje odbicia i listy wykluczeń, i skaluje się poza darmowy próg. **My nie robimy nic z tego i nigdy nie będziemy.** Ktoś budujący produkt, który mailuje do klientów, powinien wziąć jedną z nich — i to nie jest bliska decyzja.

Powiedzenie tego **nie jest skromnością**. Porównanie, które wymienia tylko to, co wygrywamy, czyta się jak marketing i zostaje zdyskontowane w całości — **łącznie z częściami, które są prawdziwe.** A liczba 200/dzień jest jedną z prawdziwych.
