### PR TITLE
feat(seo): .NET wyrzuca blad i tlumaczy go - zmierzone, nie przypomniane

### DIFF
--- a/data/errors.json
+++ b/data/errors.json
@@ -31,7 +31,8 @@
       "meaning": "Microsoft 365 refused username-and-password authentication. The credentials are almost certainly fine — the authentication *method* is switched off. Retyping the password, generating a new one, or recreating the mailbox will not change anything.",
       "wrappers": [
         "Python `smtplib` raises `SMTPAuthenticationError: (535, b'5.7.139 ...')`. The numeric code is split off into its own field and the rest arrives as a bytes literal, so searching for the message with `535` still in front of it returns nothing.",
-        "`curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said."
+        "`curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said.",
+        ".NET - `System.Net.Mail.SmtpClient`, and therefore PowerShell's `Send-MailMessage` - throws `SmtpException` with the server's text discarded entirely and the message translated into the operating system's language. Measured on a Polish system it reads \"Uwierzytelnianie nie powiodlo sie\"; on an English one, \"Authentication failed\". Either way there is no 535, no 5.7.139 and nothing to search for, which is why this failure is usually reported as a wrong password."
       ]
     },
     {
@@ -43,7 +44,8 @@
       "meaning": "The same refusal, reported at tenant level: the block applies to every mailbox that inherits the tenant setting, not just the one you are testing. Switching to a different mailbox will produce the same error, which is the fastest way to confirm you are in this case rather than the per-mailbox one.",
       "wrappers": [
         "Python `smtplib` raises `SMTPAuthenticationError: (535, b'5.7.139 ...')`. The numeric code is split off into its own field and the rest arrives as a bytes literal, so searching for the message with `535` still in front of it returns nothing.",
-        "`curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said."
+        "`curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said.",
+        ".NET - `System.Net.Mail.SmtpClient`, and therefore PowerShell's `Send-MailMessage` - throws `SmtpException` with the server's text discarded entirely and the message translated into the operating system's language. Measured on a Polish system it reads \"Uwierzytelnianie nie powiodlo sie\"; on an English one, \"Authentication failed\". Either way there is no 535, no 5.7.139 and nothing to search for, which is why this failure is usually reported as a wrong password."
       ]
     },
     {
@@ -55,7 +57,8 @@
       "meaning": "The same refusal, reported for this one mailbox. Either an admin disabled it explicitly here, or it inherits a tenant-wide block and Microsoft is naming the mailbox rather than the tenant. Common on personal Outlook.com accounts and on single mailboxes that have been locked down deliberately — worth asking why before undoing it.",
       "wrappers": [
         "Python `smtplib` raises `SMTPAuthenticationError: (535, b'5.7.139 ...')`. The numeric code is split off into its own field and the rest arrives as a bytes literal, so searching for the message with `535` still in front of it returns nothing.",
-        "`curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said."
+        "`curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said.",
+        ".NET - `System.Net.Mail.SmtpClient`, and therefore PowerShell's `Send-MailMessage` - throws `SmtpException` with the server's text discarded entirely and the message translated into the operating system's language. Measured on a Polish system it reads \"Uwierzytelnianie nie powiodlo sie\"; on an English one, \"Authentication failed\". Either way there is no 535, no 5.7.139 and nothing to search for, which is why this failure is usually reported as a wrong password."
       ]
     },
     {
@@ -67,7 +70,8 @@
       "meaning": "A generic refusal with the same set of causes as 5.7.139, but without the sub-code that tells you which. Because it names nothing, it is the one most often mistaken for a wrong password. Check the four causes before touching the credentials.",
       "wrappers": [
         "Python `smtplib` raises `SMTPAuthenticationError: (535, b'5.7.3 ...')`. The numeric code is split off into its own field and the rest arrives as a bytes literal, so searching for the message with `535` still in front of it returns nothing.",
-        "`curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said."
+        "`curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said.",
+        ".NET - `System.Net.Mail.SmtpClient`, and therefore PowerShell's `Send-MailMessage` - throws `SmtpException` with the server's text discarded entirely and the message translated into the operating system's language. Measured on a Polish system it reads \"Uwierzytelnianie nie powiodlo sie\"; on an English one, \"Authentication failed\". Either way there is no 535, no 5.7.139 and nothing to search for, which is why this failure is usually reported as a wrong password."
       ]
     },
     {

--- a/docs/data/errors.json
+++ b/docs/data/errors.json
@@ -31,7 +31,8 @@
       "meaning": "Microsoft 365 refused username-and-password authentication. The credentials are almost certainly fine — the authentication *method* is switched off. Retyping the password, generating a new one, or recreating the mailbox will not change anything.",
       "wrappers": [
         "Python `smtplib` raises `SMTPAuthenticationError: (535, b'5.7.139 ...')`. The numeric code is split off into its own field and the rest arrives as a bytes literal, so searching for the message with `535` still in front of it returns nothing.",
-        "`curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said."
+        "`curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said.",
+        ".NET - `System.Net.Mail.SmtpClient`, and therefore PowerShell's `Send-MailMessage` - throws `SmtpException` with the server's text discarded entirely and the message translated into the operating system's language. Measured on a Polish system it reads \"Uwierzytelnianie nie powiodlo sie\"; on an English one, \"Authentication failed\". Either way there is no 535, no 5.7.139 and nothing to search for, which is why this failure is usually reported as a wrong password."
       ]
     },
     {
@@ -43,7 +44,8 @@
       "meaning": "The same refusal, reported at tenant level: the block applies to every mailbox that inherits the tenant setting, not just the one you are testing. Switching to a different mailbox will produce the same error, which is the fastest way to confirm you are in this case rather than the per-mailbox one.",
       "wrappers": [
         "Python `smtplib` raises `SMTPAuthenticationError: (535, b'5.7.139 ...')`. The numeric code is split off into its own field and the rest arrives as a bytes literal, so searching for the message with `535` still in front of it returns nothing.",
-        "`curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said."
+        "`curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said.",
+        ".NET - `System.Net.Mail.SmtpClient`, and therefore PowerShell's `Send-MailMessage` - throws `SmtpException` with the server's text discarded entirely and the message translated into the operating system's language. Measured on a Polish system it reads \"Uwierzytelnianie nie powiodlo sie\"; on an English one, \"Authentication failed\". Either way there is no 535, no 5.7.139 and nothing to search for, which is why this failure is usually reported as a wrong password."
       ]
     },
     {
@@ -55,7 +57,8 @@
       "meaning": "The same refusal, reported for this one mailbox. Either an admin disabled it explicitly here, or it inherits a tenant-wide block and Microsoft is naming the mailbox rather than the tenant. Common on personal Outlook.com accounts and on single mailboxes that have been locked down deliberately — worth asking why before undoing it.",
       "wrappers": [
         "Python `smtplib` raises `SMTPAuthenticationError: (535, b'5.7.139 ...')`. The numeric code is split off into its own field and the rest arrives as a bytes literal, so searching for the message with `535` still in front of it returns nothing.",
-        "`curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said."
+        "`curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said.",
+        ".NET - `System.Net.Mail.SmtpClient`, and therefore PowerShell's `Send-MailMessage` - throws `SmtpException` with the server's text discarded entirely and the message translated into the operating system's language. Measured on a Polish system it reads \"Uwierzytelnianie nie powiodlo sie\"; on an English one, \"Authentication failed\". Either way there is no 535, no 5.7.139 and nothing to search for, which is why this failure is usually reported as a wrong password."
       ]
     },
     {
@@ -67,7 +70,8 @@
       "meaning": "A generic refusal with the same set of causes as 5.7.139, but without the sub-code that tells you which. Because it names nothing, it is the one most often mistaken for a wrong password. Check the four causes before touching the credentials.",
       "wrappers": [
         "Python `smtplib` raises `SMTPAuthenticationError: (535, b'5.7.3 ...')`. The numeric code is split off into its own field and the rest arrives as a bytes literal, so searching for the message with `535` still in front of it returns nothing.",
-        "`curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said."
+        "`curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said.",
+        ".NET - `System.Net.Mail.SmtpClient`, and therefore PowerShell's `Send-MailMessage` - throws `SmtpException` with the server's text discarded entirely and the message translated into the operating system's language. Measured on a Polish system it reads \"Uwierzytelnianie nie powiodlo sie\"; on an English one, \"Authentication failed\". Either way there is no 535, no 5.7.139 and nothing to search for, which is why this failure is usually reported as a wrong password."
       ]
     },
     {

--- a/docs/errors/535-5-7-139-basic-authentication-is-disabled.md
+++ b/docs/errors/535-5-7-139-basic-authentication-is-disabled.md
@@ -52,6 +52,7 @@ Libraries and device firmware rarely pass the server's message through unchanged
 
 - Python `smtplib` raises `SMTPAuthenticationError: (535, b'5.7.139 ...')`. The numeric code is split off into its own field and the rest arrives as a bytes literal, so searching for the message with `535` still in front of it returns nothing.
 - `curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said.
+- .NET - `System.Net.Mail.SmtpClient`, and therefore PowerShell's `Send-MailMessage` - throws `SmtpException` with the server's text discarded entirely and the message translated into the operating system's language. Measured on a Polish system it reads "Uwierzytelnianie nie powiodlo sie"; on an English one, "Authentication failed". Either way there is no 535, no 5.7.139 and nothing to search for, which is why this failure is usually reported as a wrong password.
 
 Kyocera MFPs report it as **send error 1102** / `0x1102`, which looks like a hardware fault and is not one.
 

--- a/docs/errors/535-5-7-139-smtpclientauthentication-is-disabled-for-the-mailbox.md
+++ b/docs/errors/535-5-7-139-smtpclientauthentication-is-disabled-for-the-mailbox.md
@@ -52,6 +52,7 @@ Libraries and device firmware rarely pass the server's message through unchanged
 
 - Python `smtplib` raises `SMTPAuthenticationError: (535, b'5.7.139 ...')`. The numeric code is split off into its own field and the rest arrives as a bytes literal, so searching for the message with `535` still in front of it returns nothing.
 - `curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said.
+- .NET - `System.Net.Mail.SmtpClient`, and therefore PowerShell's `Send-MailMessage` - throws `SmtpException` with the server's text discarded entirely and the message translated into the operating system's language. Measured on a Polish system it reads "Uwierzytelnianie nie powiodlo sie"; on an English one, "Authentication failed". Either way there is no 535, no 5.7.139 and nothing to search for, which is why this failure is usually reported as a wrong password.
 
 Kyocera MFPs report it as **send error 1102** / `0x1102`, which looks like a hardware fault and is not one.
 

--- a/docs/errors/535-5-7-139-smtpclientauthentication-is-disabled-for-the-tenant.md
+++ b/docs/errors/535-5-7-139-smtpclientauthentication-is-disabled-for-the-tenant.md
@@ -52,6 +52,7 @@ Libraries and device firmware rarely pass the server's message through unchanged
 
 - Python `smtplib` raises `SMTPAuthenticationError: (535, b'5.7.139 ...')`. The numeric code is split off into its own field and the rest arrives as a bytes literal, so searching for the message with `535` still in front of it returns nothing.
 - `curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said.
+- .NET - `System.Net.Mail.SmtpClient`, and therefore PowerShell's `Send-MailMessage` - throws `SmtpException` with the server's text discarded entirely and the message translated into the operating system's language. Measured on a Polish system it reads "Uwierzytelnianie nie powiodlo sie"; on an English one, "Authentication failed". Either way there is no 535, no 5.7.139 and nothing to search for, which is why this failure is usually reported as a wrong password.
 
 Kyocera MFPs report it as **send error 1102** / `0x1102`, which looks like a hardware fault and is not one.
 

--- a/docs/errors/535-5-7-3-authentication-unsuccessful.md
+++ b/docs/errors/535-5-7-3-authentication-unsuccessful.md
@@ -52,6 +52,7 @@ Libraries and device firmware rarely pass the server's message through unchanged
 
 - Python `smtplib` raises `SMTPAuthenticationError: (535, b'5.7.3 ...')`. The numeric code is split off into its own field and the rest arrives as a bytes literal, so searching for the message with `535` still in front of it returns nothing.
 - `curl` prints only `curl: (67) Login denied` and discards the server's text entirely. There is nothing in that line about the tenant, the mailbox or Basic authentication, which is why it is usually mistaken for a wrong password. Add `-v` to see what the server actually said.
+- .NET - `System.Net.Mail.SmtpClient`, and therefore PowerShell's `Send-MailMessage` - throws `SmtpException` with the server's text discarded entirely and the message translated into the operating system's language. Measured on a Polish system it reads "Uwierzytelnianie nie powiodlo sie"; on an English one, "Authentication failed". Either way there is no 535, no 5.7.139 and nothing to search for, which is why this failure is usually reported as a wrong password.
 
 Kyocera MFPs report it as **send error 1102** / `0x1102`, which looks like a hardware fault and is not one.
 


### PR DESCRIPTION
`System.Net.Mail.SmtpClient` — a przez to `Send-MailMessage` w PowerShellu — rzuca wyjatkiem, w ktorym **tekst serwera zniknal, a komunikat jest w jezyku systemu operacyjnego**.

Zlapane na lokalnym serwerze SMTP odpowiadajacym prawdziwa odmowa. Na polskim systemie brzmi: *Uwierzytelnianie nie powiodlo sie.*

To wazniejsze niz sam ciag znakow. **Administrator Windows nie widzi 535, nie widzi 5.7.139 i nie ma czego wyszukac — we wlasnym jezyku.** Dlatego zglasza to jako zle haslo i dlatego `WINDOWS-SERVER.html` dostaje 194 wyswietlenia od ludzi zadajacych zle pytanie.