### PR TITLE
docs: skad bierze sie login, na stronach ktore podaja host

### DIFF
--- a/docs/APPS.md
+++ b/docs/APPS.md
@@ -6,6 +6,15 @@ server" to send notifications, password resets, contact-form messages, or
 alerts. It cannot be used as an inbox, so skip any "incoming mail" /
 IMAP / POP3 field these applications might also offer.
 
+> **The username and password come from an account, and the account is free.**
+> Register at [msgwing.com](https://msgwing.com), activate, and copy the
+> generated login and password — they are shown once. Mail leaves from that
+> generated `@msgwing.com` address rather than your own domain, and the cap is
+> 200 messages a day with no paid tier that lifts it. Both limits are stated
+> here rather than discovered later; if either one rules this out for you,
+> [the alternatives page](ALTERNATIVES.md) names the tools that do not have
+> them.
+
 ## Connection values (same for every application)
 
 | Setting | Value |

--- a/docs/LINUX.md
+++ b/docs/LINUX.md
@@ -10,6 +10,15 @@ don't have to guess package names per distro.
 > GitHub Codespace via the badge in the [README](https://github.com/msgwing/ZeroSMTP#readme)) — every
 > runtime in the tables below comes preinstalled.
 
+> **The username and password come from an account, and the account is free.**
+> Register at [msgwing.com](https://msgwing.com), activate, and copy the
+> generated login and password — they are shown once. Mail leaves from that
+> generated `@msgwing.com` address rather than your own domain, and the cap is
+> 200 messages a day with no paid tier that lifts it. Both limits are stated
+> here rather than discovered later; if either one rules this out for you,
+> [the alternatives page](ALTERNATIVES.md) names the tools that do not have
+> them.
+
 ## Base tools (curl, openssl)
 
 Needed for [`check-connection.sh`](https://github.com/msgwing/ZeroSMTP/blob/main/check-connection.sh) and

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -24,6 +24,15 @@ The connection values are the same everywhere:
 | Username / From | your `@msgwing.com` login |
 | Password | your `@msgwing.com` password |
 
+> **The username and password come from an account, and the account is free.**
+> Register at [msgwing.com](https://msgwing.com), activate, and copy the
+> generated login and password — they are shown once. Mail leaves from that
+> generated `@msgwing.com` address rather than your own domain, and the cap is
+> 200 messages a day with no paid tier that lifts it. Both limits are stated
+> here rather than discovered later; if either one rules this out for you,
+> [the alternatives page](ALTERNATIVES.md) names the tools that do not have
+> them.
+
 ## Zabbix
 
 Zabbix's email alerting is a **Media type**, configured in the frontend or

--- a/docs/SYSTEM-MTA.md
+++ b/docs/SYSTEM-MTA.md
@@ -10,6 +10,15 @@ Get your credentials first: register and activate an account at
 [msgwing.com](https://msgwing.com), then copy your `@msgwing.com` login and
 password.
 
+> **The username and password come from an account, and the account is free.**
+> Register at [msgwing.com](https://msgwing.com), activate, and copy the
+> generated login and password — they are shown once. Mail leaves from that
+> generated `@msgwing.com` address rather than your own domain, and the cap is
+> 200 messages a day with no paid tier that lifts it. Both limits are stated
+> here rather than discovered later; if either one rules this out for you,
+> [the alternatives page](ALTERNATIVES.md) names the tools that do not have
+> them.
+
 ## Top pick: Postfix (satellite / smarthost mode)
 
 Postfix is Debian's and most Ubuntu servers' default MTA, so this is almost

--- a/docs/WINDOWS-SERVER.md
+++ b/docs/WINDOWS-SERVER.md
@@ -10,6 +10,15 @@
 > The modern equivalent — connecting directly to `mx.msgwing.com`, no local
 > relay component needed — is the recommended approach below.
 
+> **The username and password come from an account, and the account is free.**
+> Register at [msgwing.com](https://msgwing.com), activate, and copy the
+> generated login and password — they are shown once. Mail leaves from that
+> generated `@msgwing.com` address rather than your own domain, and the cap is
+> 200 messages a day with no paid tier that lifts it. Both limits are stated
+> here rather than discovered later; if either one rules this out for you,
+> [the alternatives page](ALTERNATIVES.md) names the tools that do not have
+> them.
+
 ## Top pick: point your app straight at ZeroSMTP (no local relay needed)
 
 You don't need any Windows feature installed at all — ASP.NET, classic


### PR DESCRIPTION
Luka **biznesowa**, nie techniczna — i była na stronach niosących ruch.

`WINDOWS-SERVER`, `SYSTEM-MTA`, `APPS`, `MONITORING` i `LINUX` drukują `mx.msgwing.com` oraz `your-username@msgwing.com` **od jedenastu do siedemnastu razy każda**, jako wartości do wklejenia w plik konfiguracyjny — i **nigdy nie mówią, że login pochodzi z konta**.

Człowiek czyta host jako publiczny punkt końcowy, wkleja go i dostaje odmowę. **Te pięć stron niesie około 265 wyświetleń tego serwisu.**

`PRINTERS`, przy 335 wyświetleniach, **już to mówi** — *„register a free account at msgwing.com and activate it"* — i właśnie dzięki temu luka była w ogóle widoczna. `TROUBLESHOOTING` mówi to w formie, której wymaga jej kontekst: wskazuje, skąd hasło pochodzi, a nie gdzie się rejestrować. **Żadnej z tych dwóch nie ruszałem.**

Blok podaje **oba limity tym samym tchem co ofertę**: poczta wychodzi z wygenerowanego adresu, nie z domeny czytelnika, i 200 dziennie bez płatnego progu. Powiedzenie tego **tutaj, a nie po skonfigurowaniu drukarki**, jest różnicą między limitem a niespodzianką — a strona alternatyw jest podlinkowana w tym samym zdaniu.

---

**Prostuję przy okazji własny pomiar.** Pierwsze podejście szukało frazy „Get a free account" i zaraportowało, że **dwadzieścia z dwudziestu trzech stron nie ma wezwania** — łącznie z `PRINTERS`. To był mój wzorzec wyszukiwania, nie stan serwisu: strony formułują to prozą. **Luka jest prawdziwa, ale dotyczy pięciu stron, nie dwudziestu.**
