### PR TITLE
docs: skredytuj z nazwiska ludzi, ktorych to praca

### DIFF
--- a/data/devices.json
+++ b/data/devices.json
@@ -179,7 +179,9 @@
       "status": "check-advisory",
       "models": [],
       "evidence": "https://support.lexmark.com/content/support/guides/en/kb20211110020010549/setup-installation-and-configuration-issues/how-to-set-up-oauth-2-authentication.html",
-      "notes": "Lexmark documents OAuth 2.0 authentication for printers starting with the FW24 firmware release, including Outlook Live and Microsoft 365. The Email Server flow is configured through the printer's Embedded Web Server and requires OAuth 2.0 registration. Verify the specific device and firmware before assuming support."
+      "notes": "Lexmark documents OAuth 2.0 authentication for printers starting with the FW24 firmware release, including Outlook Live and Microsoft 365. The Email Server flow is configured through the printer's Embedded Web Server and requires OAuth 2.0 registration. Verify the specific device and firmware before assuming support.",
+      "contributor": "Mohitingale13",
+      "contributor_pr": 223
     },
     {
       "vendor": "HP",
@@ -189,7 +191,9 @@
       "evidence": "https://support.hp.com/nz-en/document/ish_13623350-13600809-16",
       "notes": "HP documents OAuth 2.0 support for Microsoft 365 Scan to Email on HP Enterprise and HP Managed printers running FutureSmart firmware 5.7 and newer. However, HP also states that certain LaserJet Pro models, including the M478-M479 and M428-M429f, do not support OAuth 2.0. Verify the exact product family and firmware before assuming Microsoft 365 SMTP AUTH compatibility.",
       "guide": "HP-PRINTER-SMTP.md",
-      "guide_title": "HP printer: \"SMTP server requires authentication\""
+      "guide_title": "HP printer: \"SMTP server requires authentication\"",
+      "contributor": "Mohitingale13",
+      "contributor_pr": 230
     },
     {
       "vendor": "Sharp",
@@ -197,7 +201,9 @@
       "status": "partial",
       "models": [],
       "evidence": "https://global.sharp/restricted/products/copier/downloads/manuals/bp70m65/us/contents_09-07_003.html",
-      "notes": "Sharp documents OAuth 2.0 authentication for Microsoft 365 and Exchange Online SMTP on multiple newer printer and MFP models, including BP-series devices. Sharp does not appear to publish a centralized compatibility list or universal firmware floor for the full printer/MFP range. Verify the exact model's SMTP settings or current manual before assuming OAuth 2.0 support."
+      "notes": "Sharp documents OAuth 2.0 authentication for Microsoft 365 and Exchange Online SMTP on multiple newer printer and MFP models, including BP-series devices. Sharp does not appear to publish a centralized compatibility list or universal firmware floor for the full printer/MFP range. Verify the exact model's SMTP settings or current manual before assuming OAuth 2.0 support.",
+      "contributor": "Mohitingale13",
+      "contributor_pr": 238
     },
     {
       "vendor": "Toshiba",
@@ -205,7 +211,9 @@
       "status": "check-advisory",
       "models": [],
       "evidence": "https://www.toshibatec.com/information/20260113_01.html",
-      "notes": "Toshiba Tec publishes a model-by-model Exchange Online OAuth 2.0 compatibility table for its MFPs, including firmware release information, compatible models, pending firmware updates, and explicitly incompatible models. Verify the exact model and current firmware status against Toshiba's published advisory before assuming Microsoft 365 SMTP AUTH compatibility."
+      "notes": "Toshiba Tec publishes a model-by-model Exchange Online OAuth 2.0 compatibility table for its MFPs, including firmware release information, compatible models, pending firmware updates, and explicitly incompatible models. Verify the exact model and current firmware status against Toshiba's published advisory before assuming Microsoft 365 SMTP AUTH compatibility.",
+      "contributor": "Mohitingale13",
+      "contributor_pr": 245
     },
     {
       "vendor": "Synology",
@@ -213,7 +221,9 @@
       "status": "check-advisory",
       "models": [],
       "evidence": "https://kb.synology.com/en-us/DSM/help/DSM/AdminCenter/system_notification_email?version=7",
-      "notes": "Synology DSM 7 supports Outlook as an email notification service with an interactive Sign In flow rather than manual SMTP credentials. Synology documents OAuth-based authentication for this Outlook integration, but availability and behavior depend on the DSM version. Verify the exact DSM version and current Outlook notification configuration before assuming Microsoft 365 SMTP AUTH OAuth compatibility."
+      "notes": "Synology DSM 7 supports Outlook as an email notification service with an interactive Sign In flow rather than manual SMTP credentials. Synology documents OAuth-based authentication for this Outlook integration, but availability and behavior depend on the DSM version. Verify the exact DSM version and current Outlook notification configuration before assuming Microsoft 365 SMTP AUTH OAuth compatibility.",
+      "contributor": "Mohitingale13",
+      "contributor_pr": 252
     }
   ]
 }

--- a/docs/CODE-EXAMPLES.md
+++ b/docs/CODE-EXAMPLES.md
@@ -28,6 +28,17 @@ Ready-to-run, production-ready examples for `mx.msgwing.com:465` (SSL/TLS) or
 | Swift | [swift-zerosmtp.swift](https://github.com/msgwing/ZeroSMTP/blob/main/swift-zerosmtp.swift) |
 | PowerShell | [pwsh-zerosmtp.ps1](https://github.com/msgwing/ZeroSMTP/blob/main/pwsh-zerosmtp.ps1) |
 
+> The **Elixir**, **Lua** and **Dart** examples were contributed by
+> [@slegarraga](https://github.com/slegarraga) in
+> [#83](https://github.com/msgwing/ZeroSMTP/pull/83),
+> [#84](https://github.com/msgwing/ZeroSMTP/pull/84) and
+> [#85](https://github.com/msgwing/ZeroSMTP/pull/85). Every example here is run
+> in CI on each change, so a language nobody on this project writes daily stays
+> correct rather than quietly rotting.
+>
+> Missing a language you use? A working example is a genuinely useful
+> contribution and it gets credited here by name.
+
 ## Deployment recipes
 
 Not every migration is a code change — often the SMTP settings live in a

--- a/docs/data/devices.json
+++ b/docs/data/devices.json
@@ -179,7 +179,9 @@
       "status": "check-advisory",
       "models": [],
       "evidence": "https://support.lexmark.com/content/support/guides/en/kb20211110020010549/setup-installation-and-configuration-issues/how-to-set-up-oauth-2-authentication.html",
-      "notes": "Lexmark documents OAuth 2.0 authentication for printers starting with the FW24 firmware release, including Outlook Live and Microsoft 365. The Email Server flow is configured through the printer's Embedded Web Server and requires OAuth 2.0 registration. Verify the specific device and firmware before assuming support."
+      "notes": "Lexmark documents OAuth 2.0 authentication for printers starting with the FW24 firmware release, including Outlook Live and Microsoft 365. The Email Server flow is configured through the printer's Embedded Web Server and requires OAuth 2.0 registration. Verify the specific device and firmware before assuming support.",
+      "contributor": "Mohitingale13",
+      "contributor_pr": 223
     },
     {
       "vendor": "HP",
@@ -189,7 +191,9 @@
       "evidence": "https://support.hp.com/nz-en/document/ish_13623350-13600809-16",
       "notes": "HP documents OAuth 2.0 support for Microsoft 365 Scan to Email on HP Enterprise and HP Managed printers running FutureSmart firmware 5.7 and newer. However, HP also states that certain LaserJet Pro models, including the M478-M479 and M428-M429f, do not support OAuth 2.0. Verify the exact product family and firmware before assuming Microsoft 365 SMTP AUTH compatibility.",
       "guide": "HP-PRINTER-SMTP.md",
-      "guide_title": "HP printer: \"SMTP server requires authentication\""
+      "guide_title": "HP printer: \"SMTP server requires authentication\"",
+      "contributor": "Mohitingale13",
+      "contributor_pr": 230
     },
     {
       "vendor": "Sharp",
@@ -197,7 +201,9 @@
       "status": "partial",
       "models": [],
       "evidence": "https://global.sharp/restricted/products/copier/downloads/manuals/bp70m65/us/contents_09-07_003.html",
-      "notes": "Sharp documents OAuth 2.0 authentication for Microsoft 365 and Exchange Online SMTP on multiple newer printer and MFP models, including BP-series devices. Sharp does not appear to publish a centralized compatibility list or universal firmware floor for the full printer/MFP range. Verify the exact model's SMTP settings or current manual before assuming OAuth 2.0 support."
+      "notes": "Sharp documents OAuth 2.0 authentication for Microsoft 365 and Exchange Online SMTP on multiple newer printer and MFP models, including BP-series devices. Sharp does not appear to publish a centralized compatibility list or universal firmware floor for the full printer/MFP range. Verify the exact model's SMTP settings or current manual before assuming OAuth 2.0 support.",
+      "contributor": "Mohitingale13",
+      "contributor_pr": 238
     },
     {
       "vendor": "Toshiba",
@@ -205,7 +211,9 @@
       "status": "check-advisory",
       "models": [],
       "evidence": "https://www.toshibatec.com/information/20260113_01.html",
-      "notes": "Toshiba Tec publishes a model-by-model Exchange Online OAuth 2.0 compatibility table for its MFPs, including firmware release information, compatible models, pending firmware updates, and explicitly incompatible models. Verify the exact model and current firmware status against Toshiba's published advisory before assuming Microsoft 365 SMTP AUTH compatibility."
+      "notes": "Toshiba Tec publishes a model-by-model Exchange Online OAuth 2.0 compatibility table for its MFPs, including firmware release information, compatible models, pending firmware updates, and explicitly incompatible models. Verify the exact model and current firmware status against Toshiba's published advisory before assuming Microsoft 365 SMTP AUTH compatibility.",
+      "contributor": "Mohitingale13",
+      "contributor_pr": 245
     },
     {
       "vendor": "Synology",
@@ -213,7 +221,9 @@
       "status": "check-advisory",
       "models": [],
       "evidence": "https://kb.synology.com/en-us/DSM/help/DSM/AdminCenter/system_notification_email?version=7",
-      "notes": "Synology DSM 7 supports Outlook as an email notification service with an interactive Sign In flow rather than manual SMTP credentials. Synology documents OAuth-based authentication for this Outlook integration, but availability and behavior depend on the DSM version. Verify the exact DSM version and current Outlook notification configuration before assuming Microsoft 365 SMTP AUTH OAuth compatibility."
+      "notes": "Synology DSM 7 supports Outlook as an email notification service with an interactive Sign In flow rather than manual SMTP credentials. Synology documents OAuth-based authentication for this Outlook integration, but availability and behavior depend on the DSM version. Verify the exact DSM version and current Outlook notification configuration before assuming Microsoft 365 SMTP AUTH OAuth compatibility.",
+      "contributor": "Mohitingale13",
+      "contributor_pr": 252
     }
   ]
 }

--- a/docs/devices/hp-printers-and-mfps.md
+++ b/docs/devices/hp-printers-and-mfps.md
@@ -34,6 +34,8 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 
 [Create a free account](https://msgwing.com) · [what to put in the device's SMTP fields](../PRINTERS.md) · [the code examples](../CODE-EXAMPLES.md)
 
+*HP entry contributed by [@Mohitingale13](https://github.com/Mohitingale13) in [#230](https://github.com/msgwing/ZeroSMTP/pull/230).*
+
 ## Related
 
 - **[HP printer: "SMTP server requires authentication"](../HP-PRINTER-SMTP.md)** — the detailed guide for HP, including what the error on the panel actually means

--- a/docs/devices/lexmark-printers-and-mfps.md
+++ b/docs/devices/lexmark-printers-and-mfps.md
@@ -34,6 +34,8 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 
 [Create a free account](https://msgwing.com) · [what to put in the device's SMTP fields](../PRINTERS.md) · [the code examples](../CODE-EXAMPLES.md)
 
+*Lexmark entry contributed by [@Mohitingale13](https://github.com/Mohitingale13) in [#223](https://github.com/msgwing/ZeroSMTP/pull/223).*
+
 ## Related
 
 - [What the error message means](../ERROR-MESSAGES.md) — if the Lexmark device is reporting a code rather than a sentence

--- a/docs/devices/sharp-printers-and-mfps.md
+++ b/docs/devices/sharp-printers-and-mfps.md
@@ -34,6 +34,8 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 
 [Create a free account](https://msgwing.com) · [what to put in the device's SMTP fields](../PRINTERS.md) · [the code examples](../CODE-EXAMPLES.md)
 
+*Sharp entry contributed by [@Mohitingale13](https://github.com/Mohitingale13) in [#238](https://github.com/msgwing/ZeroSMTP/pull/238).*
+
 ## Related
 
 - [What the error message means](../ERROR-MESSAGES.md) — if the Sharp device is reporting a code rather than a sentence

--- a/docs/devices/synology-nas-notification-email.md
+++ b/docs/devices/synology-nas-notification-email.md
@@ -34,6 +34,8 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 
 [Create a free account](https://msgwing.com) · [what to put in the device's SMTP fields](../PRINTERS.md) · [the code examples](../CODE-EXAMPLES.md)
 
+*Synology entry contributed by [@Mohitingale13](https://github.com/Mohitingale13) in [#252](https://github.com/msgwing/ZeroSMTP/pull/252).*
+
 ## Related
 
 - [What the error message means](../ERROR-MESSAGES.md) — if the Synology device is reporting a code rather than a sentence

--- a/docs/devices/toshiba-printers-and-mfps.md
+++ b/docs/devices/toshiba-printers-and-mfps.md
@@ -34,6 +34,8 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 
 [Create a free account](https://msgwing.com) · [what to put in the device's SMTP fields](../PRINTERS.md) · [the code examples](../CODE-EXAMPLES.md)
 
+*Toshiba entry contributed by [@Mohitingale13](https://github.com/Mohitingale13) in [#245](https://github.com/msgwing/ZeroSMTP/pull/245).*
+
 ## Related
 
 - [What the error message means](../ERROR-MESSAGES.md) — if the Toshiba device is reporting a code rather than a sentence

--- a/tools/build-device-table.py
+++ b/tools/build-device-table.py
@@ -253,6 +253,17 @@ def zbuduj_strone(wpis, aktualizacja):
         ]
 
     czesci += [
+        # Credit by username, on the page rather than only in the git history.
+        # The one page on this site that ranks first for anything - the Canon
+        # certificate case - is also the only one that named who reported it.
+        # That is not a coincidence worth ignoring: a contributor who is named
+        # has a reason to send the link on, and the next person can see that a
+        # real human stood behind the row.
+        *([f"*{wpis['vendor']} entry contributed by "
+           f"[@{wpis['contributor']}](https://github.com/{wpis['contributor']}) "
+           f"in [#{wpis['contributor_pr']}]"
+           f"(https://github.com/msgwing/ZeroSMTP/pull/{wpis['contributor_pr']}).*",
+           ""] if wpis.get("contributor") else []),
         "## Related",
         "",
         # A vendor with a page of its own gets it first. Only where one exists:


### PR DESCRIPTION
Właściciel zapytał o forki. **Cztery — a dwie osoby za nimi mają tu wmergowaną pracę, która nigdzie ich nie wymienia.**

| Kto | Co wniósł |
|---|---|
| **@Mohitingale13** | HP, Lexmark, Sharp, Toshiba, Synology — **pięć producentów w dwa dni**, każdy ze stroną producenta jako dowodem |
| **@slegarraga** | przykłady Elixir, Lua i Dart — **6 sierpnia, i nie wiedziałem o nich do dziś** |

Jedynym skredytowanym gdziekolwiek był **@kevinbytnar**, w studium przypadku certyfikatu Canona.

## I to nie jest przypadek wart zignorowania

Ta strona jest **jedyną na tym serwisie, która rankuje na pozycji 1** — `isrg root x1`.

Skredytowany kontrybutor **ma powód, żeby podać link dalej**, a czytelnik widzi, że za wierszem stał prawdziwy człowiek, a nie scrape.

## Jak to jest zrobione

Kredyt dla wpisów urządzeń idzie do `data/devices.json` i **renderuje się przez generator** — więc przyszły wpis poniesie go bez niczyjej pamięci.

Przykłady kodu skredytowane na miejscu, obok informacji, że **każdy przykład jest uruchamiany w CI**. To jest to, co czyni wniesienie przykładu wartym czyjegoś wieczoru: język, którego nikt tu nie pisze na co dzień, **pozostaje poprawny zamiast po cichu gnić**.

---

`community-lead.md` **już mówił**, że kontrybucje są *„credited by GitHub username when added"*. Było zapisane i niezrobione.
