### PR TITLE
feat(ci): sprawdzaj czy strony producentow istnieja, i mow gdy nie da sie stwierdzic

### DIFF
--- a/.github/workflows/advisory-review.yml
+++ b/.github/workflows/advisory-review.yml
@@ -59,6 +59,49 @@ jobs:
 
             const entries = data.entries || [];
 
+            // Whether a vendor page still exists is a fact, not a judgement, so
+            // it gets checked rather than listed for somebody to click. The
+            // judgement - did the advisory change in a way that matters - stays
+            // with a person, which is what the note below is about.
+            //
+            // This matters more than it looks. Every row in devices.json is only
+            // worth citing because a vendor page stands behind it. When one of
+            // those pages moves, the row keeps asserting something with nothing
+            // holding it up, and nobody finds out until a reader clicks.
+            // Three outcomes, not two, and the difference is the whole point.
+            //
+            // 404 and 410 are the vendor saying the page is gone: definite, and
+            // the row behind it has lost its evidence. Anything else - a
+            // timeout, a 403, a connection refused - means we could not reach
+            // the page from a data centre, which is not the same thing at all.
+            // Several of these vendors rate-limit or block non-residential
+            // addresses: support.hp.com answered 200 by hand this morning and
+            // refused a connection an hour later from the same machine.
+            //
+            // Flagging those as broken would fill this checklist with alarms
+            // that are not real, and a checklist that cries wolf stops being
+            // read - which costs more than the check was ever worth.
+            const zywe = new Map();
+            const adresy = [...new Set(entries.map(e => e.evidence).filter(Boolean))];
+            for (const url of adresy) {
+              try {
+                const r = await fetch(url, {
+                  redirect: 'follow',
+                  signal: AbortSignal.timeout(20000),
+                  headers: { 'user-agent': 'Mozilla/5.0 (compatible; zerosmtp-advisory-review)' },
+                });
+                zywe.set(url, r.status === 200 ? 'ok'
+                            : (r.status === 404 || r.status === 410) ? `gone (${r.status})`
+                            : `unverified (${r.status})`);
+              } catch (e) {
+                zywe.set(url, 'unverified (no response)');
+              }
+            }
+            const zgine = adresy.filter(u => String(zywe.get(u)).startsWith('gone'));
+            const niepewne = adresy.filter(u => String(zywe.get(u)).startsWith('unverified'));
+            core.info(`evidence: ${adresy.length} links, ${zgine.length} gone, `
+              + `${niepewne.length} unverified from this runner`);
+
             // Group by vendor so a vendor with several product lines is one
             // checklist line, not four.
             const byVendor = new Map();
@@ -73,7 +116,19 @@ jobs:
                 const links = rows
                   .map(r => r.evidence)
                   .filter((url, i, all) => url && all.indexOf(url) === i)
-                  .map(url => `[advisory](${url})`)
+                  .map(url => {
+                    const st = zywe.get(url);
+                    // A link that does not answer 200 is flagged in the line
+                    // itself. Burying it in a summary somewhere means the
+                    // reviewer ticks the box and the row stays broken.
+                    if (st === 'ok') return `[advisory](${url})`;
+                    if (String(st).startsWith('gone')) {
+                      return `[advisory](${url}) **— ${st}, this row has lost its evidence**`;
+                    }
+                    // Said quietly on purpose: it is a note that the check
+                    // could not be taken, not a claim that anything is wrong.
+                    return `[advisory](${url}) *(${st} from CI — check by hand)*`;
+                  })
                   .join(' · ');
                 const statuses = [...new Set(rows.map(r => r.status))].join(', ');
                 return `- [ ] **${vendor}** — currently \`${statuses}\` — ${links}`;


### PR DESCRIPTION
Każdy wiersz w `data/devices.json` jest wart cytowania dlatego, że **stoi za nim strona producenta**. Gdy taka strona się przenosi, wiersz **dalej coś twierdzi, nie mając za sobą niczego** — i nikt się nie dowiaduje, dopóki czytelnik nie kliknie.

Dwadzieścia wierszy, siedemnaście zewnętrznych linków, **zero sprawdzania**. Miesięczny przegląd wypisywał je człowiekowi do klikania.

## Fakt zautomatyzowany, ocena zostawiona

Czy strona istnieje — **fakt**, więc jest sprawdzana. Czy oświadczenie zmieniło się w sposób istotny — **ocena**, więc zostaje przy człowieku. Ten workflow już rysował tę granicę i zostaję po tej samej stronie.

## Trzy wyniki, nie dwa — i trzeci jest tym, który czyni to użytecznym

| Wynik | Znaczenie |
|---|---|
| `ok` | strona odpowiada |
| **`gone (404/410)`** | producent mówi, że strony nie ma — **wiersz stracił dowód** |
| `unverified` | **nie dało się dosięgnąć z serwerowni** — co jest zupełnie innym stwierdzeniem |

To rozróżnienie nie jest teoretyczne. **`support.hp.com` odpowiedziało 200 z ręki dziś rano i odmówiło połączenia godzinę później z tej samej maszyny.** Kilku z tych producentów ogranicza ruch albo blokuje adresy nieresydencjalne.

**Pierwsza wersja tego sprawdzenia oznaczyła wszystkie szesnaście linków jako zepsute** — a to była sieć, nie producenci.

Wysłanie tamtej wersji dałoby miesięczną listę pełną nieprawdziwych alarmów. **Lista, która krzyczy „wilk", przestaje być czytana** — a to kosztuje więcej, niż całe sprawdzenie było kiedykolwiek warte.
