### PR TITLE
feat(radar): decide which of our two products enters a list, before drafting the entry

### DIFF
--- a/.github/workflows/listings-radar.yml
+++ b/.github/workflows/listings-radar.yml
@@ -237,6 +237,23 @@ jobs:
               }
               const section = heading[0].replace(/^#+\s*/, '').trim().slice(0, 60);
 
+              // Który z naszych dwóch bytów tu startuje? Radar opisywał lokal
+              // i nigdy tego nie rozstrzygał, więc szkic zawsze proponował
+              // usługę hostowaną. 2026-08-25 kosztowało to zamknięcie
+              // Axorax/awesome-free-apps jako "nie kwalifikujemy się", podczas
+              // gdy leżał tam nasz poprawny, otwarty PR - bo złożone było CLI,
+              // a oceniana była usługa. Dwa byty, rozłączne zbiory list.
+              //
+              // Sygnał jest mechaniczny: lista programów do zainstalowania
+              // znaczy wpisy emoji platformy. Zmierzone na awesome-free-apps:
+              // 601 wpisów, praktycznie każdy z emoji Windows/macOS/Linux,
+              // a jedyne wiersze bez nich to automatyczny spis treści.
+              const PLAT = [0x1FA9F, 0x1F34E, 0x1F427].map(c => String.fromCodePoint(c));
+              const wiersze = readme.match(/^[ \t]*[-*] \[[^\]]+\]\(https?:\/\/.*$/gm) || [];
+              const zPlatforma = wiersze.filter(w => PLAT.some(e => w.includes(e))).length;
+              const udzial = wiersze.length ? zPlatforma / wiersze.length : 0;
+              const kandydat = udzial > 0.5 ? 'cli' : 'usluga';
+
               // What kind of list is it? Having a mail section is not enough,
               // and this is where the first run went wrong: it queued
               // awesome-selfhosted and awesome-sysadmin, both of which
@@ -290,6 +307,8 @@ jobs:
               }
 
               candidates.push({
+                kandydat,
+                udzial: Math.round(udzial * 100),
                 id,
                 full_name: r.full_name,
                 url: r.html_url,
@@ -318,12 +337,21 @@ jobs:
             }
 
             // --- draft --------------------------------------------------------------
-            const ENTRY =
+            // Dwa byty, dwa szkice. Który z nich wchodzi, rozstrzyga bramka
+            // kształtu listy wyżej - nie autor zgłoszenia w biegu.
+            const ENTRY_USLUGA =
               '- [ZeroSMTP](https://msgwing.com) — Free SMTP relay that still ' +
               'accepts plain username-and-password SMTP AUTH, for printers, ' +
               'scanners, NAS units and legacy apps that cannot do OAuth2. ' +
               '200 messages/day; sends from a shared @msgwing.com address ' +
               'rather than your own domain.';
+
+            // Sformułowanie wzięte z wpisu, który faktycznie przeszedł format
+            // Axorax/awesome-free-apps#275 - nie napisane od nowa.
+            const ENTRY_CLI =
+              '- [zerosmtp-check](https://github.com/msgwing/ZeroSMTP/tree/main/packages/zerosmtp-check) ' +
+              '- Checks whether outbound SMTP works from a machine, testing ports, ' +
+              'TLS and authentication, and explains the error your mail client printed.';
 
             for (const c of picked) {
               const body = [
@@ -338,6 +366,10 @@ jobs:
                 ...(c.prTarget
                   ? [`⚠️ **This repository does not take pull requests.** Its PR template redirects to ${c.prTarget} — submit there, not here.`, '']
                   : []),
+                c.kandydat === 'cli'
+                  ? `**Kandydatem jest CLI \`zerosmtp-check\`, nie usługa.** ${c.udzial}% wpisów tej listy niesie emoji platformy, czyli jest to lista oprogramowania do zainstalowania. Usługa hostowana nie ma tu kategorii; narzędzie uruchamiane poleceniem ma.`
+                  : `**Kandydatem jest usługa ZeroSMTP.** Tylko ${c.udzial}% wpisów niesie emoji platformy, więc lista nie jest katalogiem programów do zainstalowania i wpis o usłudze ma tu sens.`,
+                '',
                 'Nothing has been submitted. This is a draft.',
                 '',
                 '### Check before submitting',
@@ -355,7 +387,7 @@ jobs:
                 '### Draft entry',
                 '',
                 '```markdown',
-                ENTRY,
+                c.kandydat === 'cli' ? ENTRY_CLI : ENTRY_USLUGA,
                 '```',
                 '',
                 'The 200/day cap and the shared from-address stay in. They are ' +


### PR DESCRIPTION
## Co to naprawia

Radar opisywał **lokal** i nigdy nie rozstrzygał, **który z naszych dwóch
produktów** ma tam startować. Szkic wpisu był zakodowany na usługę hostowaną —
zawsze, niezależnie od tego, jaka to lista.

Dziś to kosztowało realną pomyłkę. Zamknąłem `Axorax/awesome-free-apps` jako
„nie kwalifikujemy się", bo sekcja `Email Clients` zawiera instalowane klienty
poczty, a usługa hostowana nie jest klientem. Ocena była poprawna — tylko
dotyczyła nie tego produktu. W tym samym czasie leżał tam **nasz własny,
poprawnie sformatowany, otwarty PR**: `Axorax/awesome-free-apps#275`,
`Add: zerosmtp-check`, w sekcji `Developer Tools`.

Mamy dwa produkty i kwalifikują się do **rozłącznych** zbiorów list.

## Jak bramka decyduje

Sygnał jest mechaniczny, nie uznaniowy: lista programów do zainstalowania
znaczy wpisy emoji platformy. Liczymy udział takich wpisów i przy przewadze
kandydatem jest CLI, w przeciwnym razie usługa.

## Sprawdzone na dwóch lokalach, których wynik już znamy

| lokal | wpisów | z emoji platformy | kandydat | czy zgadza się z rzeczywistością |
|---|---|---|---|---|
| `Axorax/awesome-free-apps` | 579 | **100%** | CLI | tak — nasz PR z CLI leży tam otwarty |
| `ripienaar/free-for-dev` | 1296 | **0%** | usługa | tak — wpis o usłudze przeszedł i przysyła 29% całego ruchu |

Dwa znane wyniki, dwa trafienia. To nie jest bramka wymyślona i wypuszczona
w ciemno — jest sprawdzona na przypadkach, w których wiadomo, jaka odpowiedź
jest poprawna.

## Co widzi czytelnik kolejki

Zgłoszenie mówi teraz wprost, kto startuje i na jakiej podstawie, zamiast
zostawiać to do odgadnięcia przy czytaniu cudzych zasad przez godzinę.

`python .github/check-workflows.py` czysty, YAML parsuje się.
