### PR TITLE
fix(ci): send a browser user agent, so a filter's 403 stops looking like a dead link

### DIFF
--- a/.github/workflows/advisory-review.yml
+++ b/.github/workflows/advisory-review.yml
@@ -88,7 +88,19 @@ jobs:
                 const r = await fetch(url, {
                   redirect: 'follow',
                   signal: AbortSignal.timeout(20000),
-                  headers: { 'user-agent': 'Mozilla/5.0 (compatible; zerosmtp-advisory-review)' },
+                  // Pełny nagłówek przeglądarki, nie nazwa bota. Zendesk
+                  // i część portali producentów odrzucają wszystko inne
+                  // przez 403, a 403 od filtra nie odróżnia się w logu od
+                  // 403 od serwera. 2026-08-25 przegląd zgłosił Cerberus
+                  // jako niezweryfikowany; ten sam adres z nagłówkiem
+                  // przeglądarki odpowiada 200. Sprawdzanie, które nie
+                  // dociera do strony, produkuje pracę ręczną co miesiąc.
+                  headers: {
+                    'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
+                      + 'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36',
+                    'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+                    'accept-language': 'en-US,en;q=0.9',
+                  },
                 });
                 zywe.set(url, r.status === 200 ? 'ok'
                             : (r.status === 404 || r.status === 410) ? `gone (${r.status})`


### PR DESCRIPTION
Miesięczny przegląd oświadczeń przedstawiał się jako bot. Zendesk i część
portali producentów odrzucają to przez 403 — a **403 od filtra nie odróżnia się
w logu od 403 od serwera**.

2026-08-25 przegląd zgłosił Cerberus jako niezweryfikowany. Ten sam adres
z nagłówkiem przeglądarki odpowiada:

```
HTTP/1.1 200 OK
```

Link nigdy nie był wątpliwy. Wątpliwe było zapytanie.

**Stan po sprawdzeniu ręcznym: 19 linków, 0 martwych, 0 niezweryfikowanych.**

To ta sama klasa błędu co „16 martwych linków" sprzed dwóch dni — ograniczanie
zapytań i filtrowanie po nagłówku wyglądają jak nieobecność. Sprawdzanie, które
nie dociera do strony, nie produkuje ustalenia; produkuje godzinę ręcznej pracy
co miesiąc.

`python .github/check-workflows.py` czysty.
