### PR TITLE
feat(radar): search the directories our CLI can enter, and stop control characters repo-wide

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,6 +72,8 @@ jobs:
       # request, on a change that had nothing to do with it.
       - name: Python dependencies for the checks below
         run: pip install --quiet pyyaml
+      - name: No control characters anywhere in the repository
+        run: python tools/check-control-chars.py
       - name: Device table and pages match data/devices.json
         run: python tools/build-device-table.py --check
       - name: Error pages match data/errors.json

--- a/.github/workflows/listings-radar.yml
+++ b/.github/workflows/listings-radar.yml
@@ -269,7 +269,7 @@ jobs:
               // tam usluge i myslila sie; sprawdzenie na dwoch lokalach przeszlo,
               // bo oba mialy emoji albo nie mialy nic. Tozsamosc lokalu jest
               // mocniejszym dowodem niz sposob, w jaki formatuje wiersze.
-              const NARZEDZIOWE = /(cli|command[- ]?line|terminal|devtools|developer tools|shell)/i;
+              const NARZEDZIOWE = /\b(cli|command[- ]?line|terminal|devtools|developer tools|shell)\b/i;
               const nazwaLokalu = (r.name || '') + ' ' + (r.description || '');
               const kandydat = (udzial > 0.5 || NARZEDZIOWE.test(nazwaLokalu)) ? 'cli' : 'usluga';
 

--- a/.github/workflows/listings-radar.yml
+++ b/.github/workflows/listings-radar.yml
@@ -262,7 +262,16 @@ jobs:
               const wiersze = readme.match(/^[ \t]*[-*] \[[^\]]+\]\(https?:\/\/.*$/gm) || [];
               const zPlatforma = wiersze.filter(w => PLAT.some(e => w.includes(e))).length;
               const udzial = wiersze.length ? zPlatforma / wiersze.length : 0;
-              const kandydat = udzial > 0.5 ? 'cli' : 'usluga';
+              // Emoji platformy to sygnal wtorny, nie jedyny. Zmierzone na
+              // agarrharr/awesome-cli-apps: 0% wpisow niesie emoji, a to jest
+              // katalog narzedzi wiersza polecen - czyli dokladnie tam, gdzie
+              // startuje `zerosmtp-check`. Pierwsza wersja tej bramki wskazala
+              // tam usluge i myslila sie; sprawdzenie na dwoch lokalach przeszlo,
+              // bo oba mialy emoji albo nie mialy nic. Tozsamosc lokalu jest
+              // mocniejszym dowodem niz sposob, w jaki formatuje wiersze.
+              const NARZEDZIOWE = /(cli|command[- ]?line|terminal|devtools|developer tools|shell)/i;
+              const nazwaLokalu = (r.name || '') + ' ' + (r.description || '');
+              const kandydat = (udzial > 0.5 || NARZEDZIOWE.test(nazwaLokalu)) ? 'cli' : 'usluga';
 
               // What kind of list is it? Having a mail section is not enough,
               // and this is where the first run went wrong: it queued

--- a/.github/workflows/listings-radar.yml
+++ b/.github/workflows/listings-radar.yml
@@ -66,6 +66,16 @@ jobs:
               'free developer resources in:name,description',
               'awesome free in:name,description',
               'free plan in:name,description',
+
+              // Katalogi narzedzi wiersza polecen. Do 2026-08-25 radar szukal
+              // wylacznie katalogow darmowych uslug, bo szkic wpisu byl zakodowany
+              // na usluge hostowana. Odkad bramka ksztaltu listy rozstrzyga, ze
+              // w liscie oprogramowania startuje CLI `zerosmtp-check`, te lokale sa
+              // dla nas osiagalne i nie byly przeszukiwane ani razu.
+              'awesome cli in:name,description',
+              'awesome command line in:name,description',
+              'awesome developer tools in:name,description',
+              'awesome devtools in:name,description',
             ];
 
             // A list has to be alive and read. Both numbers are judgement
@@ -264,11 +274,16 @@ jobs:
               // would have been spent finding that out by hand.
               const scope = (r.description || '') + ' ' + readme.slice(0, 4000);
               const scopeLower = scope.toLowerCase();
-              const disqualifier = [
-                'self-hosted', 'self hosted', 'selfhosted', 'self-hosting',
-                'open source software', 'open-source software',
-                'foss', 'libre software',
-              ].find(w => scopeLower.includes(w));
+              // Rozdzielone, bo te dwie grupy znacza co innego dla naszych dwoch
+              // produktow. Serwer do samodzielnego postawienia nie jest ani usluga
+              // hostowana, ani sprawdzaczem w wierszu polecen - odrzuca oba. Ale
+              // "otwartozrodlowe" odrzuca tylko usluge: `zerosmtp-check` jest na
+              // licencji MIT z linkiem do repozytorium, czyli dokladnie tym, czego
+              // taka lista wymaga.
+              const SAMOHOSTING = ['self-hosted', 'self hosted', 'selfhosted', 'self-hosting'];
+              const TYLKO_OTWARTE = ['open source software', 'open-source software', 'foss', 'libre software'];
+              const disqualifier = SAMOHOSTING.find(w => scopeLower.includes(w))
+                || (kandydat === 'usluga' ? TYLKO_OTWARTE.find(w => scopeLower.includes(w)) : undefined);
               if (disqualifier) {
                 core.info(`${r.full_name}: scoped to ${disqualifier} software - we are a hosted service.`);
                 rejected++;

--- a/tools/check-control-chars.py
+++ b/tools/check-control-chars.py
@@ -23,7 +23,7 @@ zacommitowane; przy uruchomieniu recznie na swiezym pliku - ma.
 import subprocess
 import sys
 
-DOZWOLONE = {9, 10, 13}  # probny znak
+DOZWOLONE = {9, 10, 13}
 POMIN = (".png", ".jpg", ".jpeg", ".gif", ".ico", ".pdf", ".woff", ".woff2",
          ".zip", ".gz", ".svgz", ".webp", ".mp4")
 

--- a/tools/check-control-chars.py
+++ b/tools/check-control-chars.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Znajdz znaki sterujace w kazdym sledzonym pliku tekstowym.
+
+Istnieje, bo ta sama usterka wrocila trzeci raz. Ukosnik zjedzony przez
+warstwe powloki zamienia \b w regule wyrazenia regularnego na prawdziwy
+znak backspace. Kod dalej wyglada poprawnie w edytorze i w przegladzie
+zmian, a dziala inaczej: wyszukiwanie kodow paneli drukarek przestalo
+znajdowac cokolwiek i nikt tego nie zauwazyl, bo nic sie nie wysypalo.
+
+Kontrola dla plikow workflow istniala od dawna i to ona zlapala ten sam
+znak 2026-08-25 w listings-radar.yml. Jej zakres konczyl sie jednak na
+.github/workflows/*.yml, a pierwotna usterka mieszkala w pliku
+JavaScript. Ten skrypt zamyka te luke: sprawdza wszystko, co git sledzi.
+
+Dozwolone sa tabulator, nowa linia i powrot karetki. Kazdy inny znak
+sterujacy jest bledem.
+
+Granica, zmierzona przy pisaniu tego skryptu: widzi tylko to, co git juz
+sledzi. Nowy plik, ktorego nikt nie dodal, przechodzi niezauwazony az do
+pierwszego commita. W CI to nie ma znaczenia, bo tam wszystko jest
+zacommitowane; przy uruchomieniu recznie na swiezym pliku - ma.
+"""
+import subprocess
+import sys
+
+DOZWOLONE = {9, 10, 13}  # probny znak
+POMIN = (".png", ".jpg", ".jpeg", ".gif", ".ico", ".pdf", ".woff", ".woff2",
+         ".zip", ".gz", ".svgz", ".webp", ".mp4")
+
+pliki = subprocess.run(["git", "ls-files"], capture_output=True, text=True,
+                       check=True).stdout.split(chr(10))
+
+bledy = 0
+for sciezka in pliki:
+    if not sciezka or sciezka.lower().endswith(POMIN):
+        continue
+    try:
+        with open(sciezka, "r", encoding="utf-8") as uchwyt:
+            tekst = uchwyt.read()
+    except (OSError, UnicodeDecodeError):
+        continue
+    for numer, linia in enumerate(tekst.split(chr(10)), 1):
+        zle = sorted({hex(ord(z)) for z in linia
+                      if ord(z) < 32 and ord(z) not in DOZWOLONE})
+        if zle:
+            print("::error file=" + sciezka + ",line=" + str(numer)
+                  + "::znaki sterujace " + ", ".join(zle)
+                  + " - kod wyglada poprawnie, a dziala inaczej")
+            bledy += 1
+
+if bledy:
+    print("Znaki sterujace: " + str(bledy) + " wierszy do naprawy.")
+    sys.exit(1)
+print("Znaki sterujace: czysto (" + str(len([p for p in pliki if p])) + " plikow).")


### PR DESCRIPTION
Cztery zmiany, jedna linia rozumowania: odkąd radar potrafi wskazać, **który
z naszych dwóch produktów** startuje w danym lokalu, katalogi narzędzi CLI stały
się kanałem osiągalnym — i nigdy nie były przeszukiwane.

## 1. Radar szuka teraz katalogów narzędzi, nie tylko darmowych usług

Wszystkie dziesięć zapytań szukało katalogów darmowych usług hostowanych. Ani
jedno nie szukało katalogów narzędzi wiersza poleceń, więc lokale, do których
pasuje `zerosmtp-check`, nie były sprawdzone **ani razu**.

Przebieg z tej gałęzi, 241 repozytoriów, 0 z 14 zapytań nieudanych, **dwa nowe
lokale w kolejce**:

- #280 `agarrharr/awesome-cli-apps`
- #281 `toolleeo/awesome-cli-apps-in-a-csv`

## 2. Bramka wykluczająca rozdzielona na dwie

Serwer do samodzielnego postawienia odrzuca oba produkty — żaden nim nie jest.
Ale „otwartoźródłowe" odrzucało też CLI, które jest na licencji MIT z linkiem
do repozytorium, czyli **dokładnie tym, czego taka lista wymaga**. Wykluczaliśmy
się z list, do których się kwalifikujemy.

## 3. Poprawka bramki kształtu, która myliła się na pierwszym prawdziwym lokalu

Poranna wersja czytała emoji platformy z wpisów. `awesome-cli-apps` ma ich **0%**
i jest katalogiem narzędzi CLI — bramka wskazała usługę. Sprawdzenie na dwóch
lokalach przeszło, bo oba albo miały emoji, albo nie miały nic; test nie odróżniał
sygnału od rzeczy, którą sygnał zastępował.

Rozstrzyga teraz tożsamość lokalu, emoji zostają jako sygnał wtórny. Cztery
przypadki, w tym ten błędny:

| lokal | wskazanie |
|---|---|
| `awesome-cli-apps` | CLI *(wcześniej: usługa)* |
| `awesome-cli-apps-in-a-csv` | CLI |
| `awesome-free-apps` | CLI |
| `free-for-dev` | usługa |

## 4. Bramka na znaki sterujące w całym repozytorium

Przy pisaniu punktu 3 dwa `\b` dotarły do pliku jako **prawdziwe znaki backspace**.
GitHub odrzuca taki plik w całości, bez linii w logu. To ta sama usterka, która
po cichu zepsuła wyszukiwanie kodów paneli i dwa razy zamieniła workflow
w niepoprawny YAML — **wróciła dwa dni po tym, jak została opisana jako reguła
w wytycznych projektu.**

Kontrola dla plików workflow istniała i to ona ją złapała. Jej zakres kończył się
na `.github/workflows/*.yml`, a pierwotna usterka mieszkała w pliku JavaScript.
`tools/check-control-chars.py` obejmuje teraz każdy śledzony plik i chodzi
w `lint.yml`.

Sprawdzona na przypadku, który **ma** ją wywołać:

```
::error file=tools/build-readme-toc.py,line=2::znaki sterujace 0x8
kod wyjscia: 1
```

Po przywróceniu pliku: `czysto (181 plikow)`.

Granica bramki zapisana w samym skrypcie: widzi tylko to, co git już śledzi.
