### PR TITLE
chore(ci): look for questions once a day, not four times, until the channel wakes up

### DIFF
--- a/.github/workflows/outreach-watch.yml
+++ b/.github/workflows/outreach-watch.yml
@@ -24,7 +24,17 @@ on:
   schedule:
     # Every six hours. Speed is most of the value here: an answer posted
     # four days late lands on a thread nobody is reading any more.
-    - cron: '0 */6 * * *'
+    # Raz dziennie, nie co szesc godzin. Zmierzone 2026-08-25: kanal dal
+    # 16 watkow w calej historii, wszystkie zamkniete, ani jeden oznaczony
+    # jako trafiony, i zero nowych od osmiu dni przy czterech przebiegach
+    # dziennie. Cztery razy dziennie pytac o cos, czego nie ma, to koszt
+    # bez plonu.
+    #
+    # Nie wylaczone, bo grudzien 2026 jest dokladnie momentem, w ktorym
+    # ludzie zaczna pytac publicznie. Przywrocic czestotliwosc, gdy
+    # pierwszy watek od miesiecy sie pojawi - to jest sygnal, ze kanal
+    # ozyl, i wtedy warto patrzec czesciej.
+    - cron: '0 7 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Bot szukający pytań chodził co sześć godzin. Zmierzone dziś:

| co | wartość |
|---|---|
| wątków w całej historii | **16** |
| otwartych | 0 |
| oznaczonych jako trafione | **0** |
| nowych w ostatnich 8 dniach | **0** |
| przebiegów w tym czasie | ~32 |

Niezależny pomiar z drugiej strony zgadza się: pięć fraz razy trzy serwisy dało
**zero** trafień w oknie 90 dni.

Pytanie cztery razy dziennie o coś, czego nie ma, to koszt bez plonu.

**Nie wyłączone.** Grudzień 2026 jest dokładnie momentem, w którym ludzie zaczną
pytać publicznie o wyłączone SMTP AUTH. Zabicie kanału cztery miesiące przed
jego jedyną szansą byłoby oszczędnością droższą niż zysk. Pierwszy nowy wątek
od miesięcy jest sygnałem, że kanał ożył — i wtedy częstotliwość wraca.

Rozróżnienie zapisane też w przeglądzie kadrowym: **etat zwalnia się, gdy nie ma
pracy; mechanizm wyłącza się, gdy nie ma szansy, że będzie.** To nie to samo.
