### PR TITLE
fix(labeler): stop labelling every issue windows because it mentions Exchange

### DIFF
--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -21,11 +21,19 @@ jobs:
           script: |
             const RULES = [
               { label: 'printers', color: '5319e7', keywords: ['printer', 'scan-to-email', 'scan to email', 'canon', 'epson', 'brother', 'hp printer'] },
-              { label: 'windows', color: '0e8a16', keywords: ['windows server', 'powershell', 'iis', 'exchange'] },
+              // 'exchange' usuniete 2026-08-25. Ten projekt istnieje z powodu
+              // Exchange Online, wiec slowo wystepuje praktycznie w kazdym
+              // zgloszeniu. Zmierzone: trzy zgloszenia z ta etykieta i zadne
+              // nie dotyczy Windowsa - zadanie lint dla Lua, opis grudniowej
+              // awarii i prosba o przyklad w Perlu.
+              { label: 'windows', color: '0e8a16', keywords: ['windows server', 'powershell', 'iis', 'active directory'] },
               { label: 'linux', color: 'fbca04', keywords: ['ubuntu', 'debian', 'rocky', 'fedora', 'opensuse', 'postfix', 'msmtp', 'exim'] },
               { label: 'docs', color: '0075ca', keywords: ['documentation', 'readme', 'typo', 'docs/'] },
               { label: 'question', color: 'd876e3', keywords: ['how do i', 'how to', 'can i', 'is it possible'] },
-              { label: 'bug', color: 'd73a4a', keywords: ['error', 'failed', 'failure', 'exception', 'traceback', 'not working', "doesn't work", 'timeout'] },
+              // 'error' usuniete z tej samej przyczyny: dokumentujemy komunikaty
+              // bledu, wiec slowo jest w tresci projektu, nie w objawie usterki.
+              // Zostaja sformulowania opisujace zepsute dzialanie, a nie temat.
+              { label: 'bug', color: 'd73a4a', keywords: ['traceback', 'stack trace', 'not working', "doesn't work", 'crashes', 'regression'] },
             ];
 
             const title = (context.payload.issue.title || '').toLowerCase();


### PR DESCRIPTION
Reguła `windows` dopasowywała słowo **`exchange`**. Ten projekt istnieje z powodu
Exchange Online, więc to słowo jest praktycznie w każdym zgłoszeniu, jakie tu
powstało.

**Zmierzone: trzy zgłoszenia noszą etykietę `windows` i ani jedno nie dotyczy
Windowsa.**

| zgłoszenie | o czym naprawdę jest |
|---|---|
| #191 | przypięcie wersji Lua w zadaniu lint |
| #164 | co dokładnie psuje się w grudniu |
| #24 | prośba o przykład w Perlu |

Reguła `bug` miała ten sam kształt błędu z tej samej przyczyny — dopasowywała
`error`, a my **dokumentujemy komunikaty błędu**, więc to słowo jest tematem
projektu, nie objawem usterki. Tak właśnie prośba o testy trafiła oznaczona jako
usterka.

Obie reguły dopasowują teraz sformułowania opisujące **zepsute działanie**, a nie
sformułowania opisujące, czym ten projekt jest.
