### PR TITLE
test: add automated test suite for zerosmtp-check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -358,7 +358,7 @@ jobs:
       - name: Help text
         run: node packages/zerosmtp-check/index.js --help
       - name: Run test suite
-        run: node --test packages/zerosmtp-check/test/
+        run: node --test packages/zerosmtp-check/test/zerosmtp-check.test.js
       - name: Unresolvable host exits 2
         run: |
           set +e

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -357,6 +357,8 @@ jobs:
       # check: a diagnostic that compiles and lies is worse than none.
       - name: Help text
         run: node packages/zerosmtp-check/index.js --help
+      - name: Run test suite
+        run: node --test packages/zerosmtp-check/test/
       - name: Unresolvable host exits 2
         run: |
           set +e

--- a/packages/zerosmtp-check/index.js
+++ b/packages/zerosmtp-check/index.js
@@ -377,7 +377,7 @@ const BLIND = [
   },
 ];
 
-function explain(text) {
+export function explain(text) {
   const lower = text.toLowerCase();
   const out = [];
 
@@ -437,7 +437,7 @@ function explain(text) {
     + '  arguments: npx zerosmtp-check';
 }
 
-function explainJson(text) {
+export function explainJson(text) {
   const code = enhancedCode(text);
   const matches = code
     ? narrowByScope(ERRORS.filter(e => e.enhanced === code), text.toLowerCase())

--- a/packages/zerosmtp-check/package.json
+++ b/packages/zerosmtp-check/package.json
@@ -8,7 +8,7 @@
   },
   "main": "./index.js",
   "scripts": {
-    "test": "node --test test/"
+    "test": "node --test test/zerosmtp-check.test.js"
   },
   "files": [
     "index.js",

--- a/packages/zerosmtp-check/package.json
+++ b/packages/zerosmtp-check/package.json
@@ -7,6 +7,9 @@
     "zerosmtp-check": "./index.js"
   },
   "main": "./index.js",
+  "scripts": {
+    "test": "node --test test/"
+  },
   "files": [
     "index.js",
     "errors.js",

--- a/packages/zerosmtp-check/test/zerosmtp-check.test.js
+++ b/packages/zerosmtp-check/test/zerosmtp-check.test.js
@@ -1,0 +1,127 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { explain, explainJson } from '../index.js';
+import { ERRORS, DEVICE_CODES } from '../errors.js';
+
+const execFileAsync = promisify(execFile);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const CLI_PATH = join(__dirname, '..', 'index.js');
+
+describe('zerosmtp-check', () => {
+  describe('ERROR pattern matching', () => {
+    for (const error of ERRORS) {
+      test(`matches ${error.code} - ${error.slug}`, () => {
+        // Construct contextual input:
+        // When multiple errors share the same enhanced code (e.g. 535 5.7.139),
+        // narrowByScope uses 'tenant' or 'mailbox' keywords in lowercased text.
+        let input = `${error.code} ${error.message}`;
+        if (error.scope.toLowerCase() === 'tenant') {
+          input += ' for the tenant';
+        } else if (error.scope.toLowerCase() === 'mailbox') {
+          input += ' for the mailbox';
+        }
+
+        const result = explain(input);
+
+        // Verify the explanation matched this specific error
+        assert.ok(
+          !result.startsWith('No match for that one.'),
+          `Expected match for ${error.code} (${error.slug}), got "No match"`
+        );
+        assert.ok(
+          result.includes(error.slug),
+          `Expected explanation for ${error.code} to include slug "${error.slug}"`
+        );
+        assert.ok(
+          result.includes(error.code),
+          `Expected explanation for ${error.code} to include code "${error.code}"`
+        );
+      });
+    }
+  });
+
+  describe('Device panel code matching', () => {
+    for (const [code, info] of Object.entries(DEVICE_CODES)) {
+      test(`matches exact panel code ${code}`, () => {
+        const text = `Printer error ${code} occurred`;
+        const result = explain(text);
+        assert.ok(!result.startsWith('No match for that one.'));
+        assert.ok(result.includes(`${code} - ${info.vendor} device code`));
+        assert.ok(result.includes(info.note));
+      });
+
+      test(`matches 0x-prefixed panel code 0x${code}`, () => {
+        const text = `Device reported error 0x${code} on panel`;
+        const result = explain(text);
+        assert.ok(!result.startsWith('No match for that one.'));
+        assert.ok(result.includes(`${code} - ${info.vendor} device code`));
+      });
+
+      test(`rejects numbers with similar digits (boundary test for ${code})`, () => {
+        // Test word boundary rejection to protect against regex regressions (like \b as backspace)
+        const nonMatching = [
+          `Error ${code}0 on panel`,
+          `Error 0${code} on panel`,
+          `Error 9${code} on panel`,
+          `Error ${code}9 on panel`,
+          `Error ${code}a on panel`,
+        ];
+
+        for (const input of nonMatching) {
+          const result = explain(input);
+          assert.ok(
+            result.startsWith('No match for that one.'),
+            `Expected "${input}" to not match panel code ${code}`
+          );
+        }
+      });
+    }
+  });
+
+  describe('Unknown / edge cases', () => {
+    test('handles completely unknown error text without throwing', () => {
+      const result = explain('some completely unknown error text not in corpus 12345');
+      assert.ok(result.startsWith('No match for that one.'));
+      assert.ok(result.includes('https://github.com/msgwing/ZeroSMTP/issues/new'));
+    });
+
+    test('handles empty input without throwing', () => {
+      const result = explain('');
+      assert.ok(result.startsWith('Nothing to explain.'));
+    });
+
+    test('explainJson structured return for unknown text', () => {
+      const result = explainJson('some unknown error string');
+      assert.equal(result.matched, false);
+      assert.equal(result.matches.length, 0);
+    });
+  });
+
+  describe('CLI integration', () => {
+    test('--explain on known error exits with code 0', async () => {
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        [CLI_PATH, '--explain', '535 5.7.139 Authentication unsuccessful, SmtpClientAuthentication is disabled for the Tenant']
+      );
+      assert.ok(stdout.includes('5.7.139'));
+      assert.ok(stdout.includes('tenant'));
+    });
+
+    test('--explain on unknown error exits with code 1', async () => {
+      await assert.rejects(
+        execFileAsync(process.execPath, [CLI_PATH, '--explain', 'completely unknown error not in database']),
+        (err) => {
+          assert.equal(err.code, 1);
+          assert.ok(err.stdout.includes('No match for that one.'));
+          return true;
+        }
+      );
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR change?

Resolves #293 by adding an automated regression test suite for `packages/zerosmtp-check` using Node.js's built-in `node:test` runner.

### Changes & Coverage

- Added a dependency-free test suite using `node:test` and `node:assert/strict`.
- Exported `explain` and `explainJson` from `index.js` for direct testing while keeping internal helpers private.
- Added coverage for all 17 entries in `ERRORS`, including scope disambiguation for shared enhanced codes.
- Added device panel code regression tests covering:
  - exact `1102`
  - `0x1102`
  - similar values such as `11020`, `01102`, and `1102a`
- Added tests for unknown and empty input, including `explainJson`.
- Added CLI integration tests for recognized and unrecognized errors.
- Added `"test": "node --test test/"` to `package.json`.
- Added the test suite to the `zerosmtp-check` CI job.
- Preserved the existing `files` list so tests are excluded from the published package.

### Verification

- 25/25 tests passing locally.
- `git diff --check` passes.
- `npm pack --dry-run` confirms the test directory is excluded from the package.
- Intentionally mutating the historical `\b` regression causes the panel-code tests to fail, confirming the regression is covered.