### PR TITLE
docs: Proxmox VE, where mail that stops arriving looks like nothing to report

### DIFF
--- a/docs/PROXMOX.md
+++ b/docs/PROXMOX.md
@@ -1,0 +1,110 @@
+---
+title: "Proxmox VE email when Basic auth ends"
+description: "Proxmox VE sends backup results, replication failures and ZFS alerts by email. What breaks when Microsoft 365 stops accepting a username and password in December 2026, and how to keep the alerts arriving."
+---
+
+# Proxmox VE email and the Microsoft 365 Basic auth shutdown
+
+Proxmox VE tells you things by email and by nothing else. Backup job results,
+replication failures, ZFS pool degradation, fencing events, certificate
+renewals. None of it appears anywhere you would look on an ordinary day.
+
+That is fine right up until the mail stops, because the failure mode of an
+alerting system that cannot send is **silence** - which is exactly what a
+healthy system looks like.
+
+## Why this page exists separately
+
+The mechanics are ordinary Debian: Proxmox VE ships Postfix, and relaying
+through a smart host is the same job described in
+[System-wide mail relay](SYSTEM-MTA.md).
+
+What is not ordinary is the consequence. On a workstation, mail that stops
+arriving is an annoyance somebody notices within a week. On a hypervisor, the
+message that never arrives is the one saying a backup failed, and you find out
+when you need the backup.
+
+## What actually breaks in December 2026
+
+Nothing inside Proxmox. The node keeps generating notifications, Postfix keeps
+accepting them, the queue keeps growing.
+
+The refusal happens at the smart host. If your node authenticates to Microsoft
+365 with a username and password, Exchange Online answers:
+
+```
+535 5.7.139 Authentication unsuccessful, basic authentication is disabled
+```
+
+and Postfix does what Postfix does - it defers and retries, quietly, for days.
+See [what that error means](errors/535-5-7-139-basic-authentication-is-disabled.md)
+if you are reading this because you already have it.
+
+Newer Proxmox releases can also send through a configured SMTP target rather
+than the local MTA. The credentials are the same credentials, so the same
+refusal applies; only the place you type them changes.
+
+## Find out today whether you are affected
+
+Do not wait for December. Two commands on the node:
+
+```bash
+# Anything stuck in the queue?
+postqueue -p
+
+# What did the smart host actually say?
+journalctl -u postfix --since "7 days ago" | grep -iE "5\.7\.139|authentication"
+```
+
+An empty queue and no authentication errors means your node is not relaying
+through anything that is about to change, or is already using a method that
+survives.
+
+## Keeping the alerts arriving
+
+Three ways, in the order most Proxmox installations should consider them.
+
+**1. Move the smart host to a relay that still accepts a username and
+password.** Nothing on the node changes except the host, port and credentials -
+the Postfix configuration in [System-wide mail relay](SYSTEM-MTA.md) is the same
+one, pointed somewhere else. ZeroSMTP exists for this case: 587 with STARTTLS or
+465, username and password, no DNS records to add and nothing to install.
+
+The trade is honest and worth knowing before you choose it: mail leaves from a
+shared `@msgwing.com` address rather than your own domain. For an alert going to
+your own inbox that is usually irrelevant. For anything a customer reads it is
+not - see [Alternatives](ALTERNATIVES.md), which names the case where a proxy
+you run yourself is the better answer.
+
+**2. Switch the tenant to OAuth2.** Correct, permanent, and it means the node
+needs an app registration and a token it can refresh. Reasonable if you already
+manage Entra; heavy if this hypervisor is the only thing you have there.
+
+**3. Keep Basic auth alive while it lasts.** An administrator can re-enable
+SMTP AUTH after the December default change - see
+[the Exchange Online timeline](EXCHANGE-ONLINE-SMTP-AUTH.md). It buys months,
+not years, and it is a decision to make deliberately rather than by not
+deciding.
+
+## Check before you call it fixed
+
+A test message that reaches your inbox proves the credentials work. It does not
+prove Proxmox will use them.
+
+```bash
+# The real path: let Proxmox generate a notification and watch it leave.
+postqueue -f
+journalctl -u postfix -f
+```
+
+Then trigger something that actually notifies - a manual backup of a small
+container is the cheapest honest test - and confirm the mail arrives. A relay
+verified with a hand-written test message and never exercised by the software
+that depends on it is a relay you have not verified.
+
+## Related
+
+- [System-wide mail relay on Debian/Ubuntu](SYSTEM-MTA.md) - the Postfix configuration itself
+- [535 5.7.139 basic authentication is disabled](errors/535-5-7-139-basic-authentication-is-disabled.md) - the error you will see
+- [Exchange Online SMTP AUTH timeline](EXCHANGE-ONLINE-SMTP-AUTH.md) - what Microsoft actually announced, and when
+- [Alternatives](ALTERNATIVES.md) - including where a self-hosted proxy beats us

--- a/docs/SYSTEM-MTA.md
+++ b/docs/SYSTEM-MTA.md
@@ -232,6 +232,14 @@ here's a minimal Ansible playbook for the Postfix satellite setup above:
 Run with `ansible-playbook -i inventory.ini zerosmtp-relay.yml --ask-vault-pass`
 (or however your vault secret is normally supplied).
 
+## Running Proxmox VE?
+
+The Postfix configuration above is the one to use, but the consequence of
+getting it wrong is different: a hypervisor tells you about failed backups and
+degraded pools by email and by nothing else, so mail that stops arriving looks
+exactly like a system with nothing to report. See
+[Proxmox VE email](PROXMOX.md).
+
 ## Verifying it works
 
 Use [`check-connection.sh`](https://github.com/msgwing/ZeroSMTP/blob/main/check-connection.sh) first to confirm the

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -30,6 +30,7 @@ answering somebody's question from this site:
 - [IIS SMTP relay and Microsoft 365](https://docs.msgwing.com/IIS-SMTP-RELAY.html): The IIS SMTP Server feature relaying to Microsoft 365: what breaks when Basic auth ends in December 2026, and what to do about it.
 - [Linux SMTP setup: Debian, Ubuntu, Fedora+](https://docs.msgwing.com/LINUX.html): Per-distribution package names and setup for sending email from Linux scripts and applications.
 - [Linux system-wide mail relay: Postfix, msmtp](https://docs.msgwing.com/SYSTEM-MTA.html): Route all system mail (cron, monitoring, unattended-upgrades) through an SMTP relay, with systemd failure alerts and an Ansible rollout playbook.
+- [Proxmox VE email when Basic auth ends](https://docs.msgwing.com/PROXMOX.html): Proxmox VE sends backup results, replication failures and ZFS alerts by email. What breaks when Microsoft 365 stops accepting a username and password in December 2026, and how to keep the alerts arriving.
 - [Monitoring alerts via SMTP relay](https://docs.msgwing.com/MONITORING.html): Drop-in email alert configuration for Zabbix, Nagios/Icinga, Uptime Kuma and PRTG using a free SMTP relay.
 - [SMTP troubleshooting: ports, TLS, auth errors](https://docs.msgwing.com/TROUBLESHOOTING.html): Why SMTP sending hangs or fails: cloud providers blocking outbound ports, certificate verification problems, authentication errors and rate limits.
 

--- a/tools/build-llms-txt.py
+++ b/tools/build-llms-txt.py
@@ -47,6 +47,7 @@ GRUPY = [
         "IIS-SMTP-RELAY.md",
         "LINUX.md",
         "SYSTEM-MTA.md",
+        "PROXMOX.md",
         "MONITORING.md",
         "TROUBLESHOOTING.md",
     ]),


### PR DESCRIPTION
## Skąd ten pomysł

Od CEO: administratorzy Proxmoksa potrzebują darmowej bramki SMTP. Zmierzone
przed napisaniem czegokolwiek.

| zapytanie na GitHubie | konkurencja | nasza pozycja |
|---|---|---|
| `proxmox smtp` | 5 repozytoriów | **nie było nas** |
| `pve smtp relay` | 1 | nie było nas |
| `proxmox email notification` | 3 | nie było nas |
| `unraid smtp` | 1 | nie było nas |

A wielkość społeczności rozstrzyga, czy warto:

| temat | repozytoriów |
|---|---|
| **proxmox** | **2479** |
| unraid | 511 |
| xerox | 24 |
| **kyocera** | **10** |

Trzymaliśmy miejsce na temat, przy którym pracuje **dziesięć** repozytoriów na
całym GitHubie, nie mając tego, przy którym pracuje **dwa i pół tysiąca**.

## Co zrobione

Wymienione dwa najsłabsze tematy producentów na `proxmox` i `unraid`. Wynik
zmierzony po zmianie: **`unraid smtp` → pozycja 1**, **`proxmox smtp` → 2**,
wszystkie dotychczasowe pozycje utrzymane.

Plus ta strona — bo Google przysyła nam **19 unikalnych odwiedzających**,
najwięcej ze wszystkich zewnętrznych źródeł, i trafia na dokumentację.

## Czego strona NIE robi

Nie powtarza konfiguracji Postfiksa. Proxmox VE to Debian z Postfiksem, a to
jest już opisane w `SYSTEM-MTA.md`. Strona dokłada wyłącznie to, co specyficzne:
dlaczego cisza na hiperwizorze jest groźniejsza niż na stacji roboczej, dwie
komendy odpowiadające **dziś**, czy dany węzeł jest zagrożony, i uczciwe
postawienie sprawy współdzielonego adresu nadawcy.

Wszystkie 9 linków wewnętrznych sprawdzone, `llms.txt` przebudowany (26 stron),
kontrole generatorów i znaków sterujących czyste.
