### PR TITLE
feat(tools): one source for the numbers that enter a decision

### DIFF
--- a/tools/metrics.py
+++ b/tools/metrics.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Liczby, ktorych wolno uzywac w decyzjach. Jedno zrodlo, z ostrzezeniami.
+
+DLACZEGO TO ISTNIEJE:
+2026-08-27 licznik `traffic/clones` trafil do trzech decyzji zarzadu jako
+dowod zasiegu - do briefu konkursowego dla czterech agentow, do opisu PR #312
+i do wyliczenia "konwersji 0,3%". Byl **artefaktem naszej wlasnej automatyki**:
+kazdy z osiemnastu workflowow klonuje repozytorium, wiec 112 przebiegow dalo
+433 klony, a 79 commitow dalo 2276.
+
+Przy 1657 klonach bylo 68 unikalnych - **24 klony na "osobe"**. Zaden czlowiek
+tak nie robi. Biegacz Actions owszem.
+
+Regula, ktora z tego wynika: **licznik, na ktory wplywa wlasna automatyka, nie
+jest miara zasiegu.** Reguly jednak zawodza - ta firma ma to udokumentowane -
+wiec zamiast zapisu powstal ten skrypt. Liczba, ktorej tu nie ma, nie wchodzi
+do decyzji bez wyraznego zastrzezenia.
+
+UZYCIE:
+    python tools/metrics.py            # liczby czyste
+    python tools/metrics.py --all      # takze zanieczyszczone, z ostrzezeniem
+"""
+import argparse
+import json
+import subprocess
+import sys
+
+REPO = "msgwing/ZeroSMTP"
+
+
+def gh(sciezka):
+    w = subprocess.run(["gh", "api", sciezka], capture_output=True, text=True)
+    if w.returncode != 0:
+        return None
+    try:
+        return json.loads(w.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+# Czy nasza wlasna automatyka moze podbic ten licznik?
+#   False = czysty, wolno uzywac w decyzji
+#   True  = zanieczyszczony, wolno tylko z zastrzezeniem
+LICZNIKI = [
+    ("odslony, unikalnych / 14 dni", "traffic/views", "uniques", False,
+     "Actions nie ogladaja stron."),
+    ("odslony, suma / 14 dni", "traffic/views", "count", False,
+     "Suma jest szumna, ale nie nasza - patrz raczej na unikalnych."),
+    ("klony, unikalnych / 14 dni", "traffic/clones", "uniques", True,
+     "KAZDY przebieg workflow klonuje repozytorium. 18 workflowow."),
+    ("klony, suma / 14 dni", "traffic/clones", "count", True,
+     "To samo, tylko mocniej. 79 commitow dalo 2276 klonow."),
+    ("gwiazdki", "", "stargazers_count", False,
+     "Kazda dotad przyszla od osoby, ktora forkowala albo kontrybuowala."),
+    ("forki", "", "forks_count", False, ""),
+    ("obserwujacy", "", "subscribers_count", False, ""),
+]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--all", action="store_true",
+                    help="pokaz takze liczniki zanieczyszczone wlasna automatyka")
+    args = ap.parse_args()
+
+    meta = gh(f"repos/{REPO}") or {}
+    cache = {}
+
+    print("LICZBY, KTORYCH WOLNO UZYWAC W DECYZJACH")
+    print("=" * 62)
+    brudne = []
+    for nazwa, sciezka, pole, zanieczyszczony, uwaga in LICZNIKI:
+        if zanieczyszczony and not args.all:
+            brudne.append(nazwa)
+            continue
+        if sciezka:
+            if sciezka not in cache:
+                cache[sciezka] = gh(f"repos/{REPO}/{sciezka}")
+            zrodlo = cache[sciezka]
+        else:
+            zrodlo = meta
+        wartosc = (zrodlo or {}).get(pole)
+        # Brak odpowiedzi to nie jest zero - mechanika 6.
+        pokaz = "nie zmierzono" if wartosc is None else str(wartosc)
+        znak = "  !" if zanieczyszczony else "   "
+        print(f"{znak} {nazwa:34} {pokaz:>10}")
+        if uwaga and (args.all or not zanieczyszczony):
+            print(f"      {uwaga}")
+
+    ref = gh(f"repos/{REPO}/traffic/popular/referrers")
+    if ref is None:
+        print()
+        print("   skad ludzie                        nie zmierzono")
+        print("      Wymaga tokena uzytkownika. GITHUB_TOKEN w workflow zwraca 403")
+        print("      przy contents:read ORAZ contents:write - to ograniczenie")
+        print("      platformy, nie uprawnien.")
+    else:
+        print()
+        print("   skad ludzie (unikalnych, 14 dni)")
+        for r in ref:
+            print(f"      {r['uniques']:>4}  {r['referrer']}")
+
+    if brudne:
+        print()
+        print("POMINIETE - zanieczyszczone wlasna automatyka:")
+        for b in brudne:
+            print(f"   ! {b}")
+        print("   Pokaz je przez --all, ale NIE uzywaj w decyzji bez zastrzezenia.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Przyczyna, nie objaw

Licznik klonów trafił **trzy razy w jeden dzień** do decyzji zarządu jako dowód
zasięgu — do briefu dla czterech agentów naraz, do opisu PR i do wyliczenia
„konwersji 0,3%".

Jest artefaktem naszej własnej automatyki. Każdy z osiemnastu workflowów klonuje
repozytorium:

| dzień | nasza aktywność | klony | unikalnych |
|---|---|---|---|
| 08-23 | 79 commitów | **2276** | 151 |
| 08-26 | 112 przebiegów | 433 | 53 |
| 08-16 | start intensywnej pracy | 1657 | **68** |

Przy 1657 klonach i 68 unikalnych wychodzi **24 klony na „osobę"**. Żaden
człowiek tak nie robi. Biegacz Actions owszem.

## Dlaczego skrypt, a nie zapis w pliku

Reguła „licznik podbijany własną automatyką nie jest miarą zasięgu" jest
prawdziwa i **jest tym rodzajem reguły, który w tej firmie już zawodził**.

`tools/metrics.py` drukuje liczby czyste, ukrywa zanieczyszczone za `--all`
i przy każdej mówi, czy Actions mogą nią ruszyć.

**Fałszywa przesłanka nie ma jak wejść do briefu, jeśli nie da się jej stamtąd
wziąć.**

## Prawdziwe liczby, po odfiltrowaniu

```
odslony, unikalnych / 14 dni     89
gwiazdki                          3
forki                             5
obserwujacy                       2

skad ludzie:
   23  Google
   18  github.com
   18  free-for.dev
```

## I uwaga właściciela o formie

Sprostowanie zameldowałem jako „muszę Cię rozczarować". To osłabia rzecz wartą
usłyszenia i przenosi uwagę na nastrój zamiast na ustalenie.

**Usunięcie liczby, która zatrułaby każdą kolejną decyzję, jest wynikiem pracy,
nie porażką.** Zapisane jako mechanika 10: meldować co było założone, co
zmierzono, co z tego wynika — bez przepraszania.
