### PR TITLE
fix(test): compare the whole line, so the link that routes reporters is actually covered

### DIFF
--- a/packages/zerosmtp-check/test/zerosmtp-check.test.js
+++ b/packages/zerosmtp-check/test/zerosmtp-check.test.js
@@ -88,7 +88,15 @@ describe('zerosmtp-check', () => {
     test('handles completely unknown error text without throwing', () => {
       const result = explain('some completely unknown error text not in corpus 12345');
       assert.ok(result.startsWith('No match for that one.'));
-      assert.ok(result.includes('https://github.com/msgwing/ZeroSMTP/issues/new'));
+      // Porownanie CALEJ linii, nie fragmentu. Poprzednia wersja sprawdzala
+      // adres bez `?template=error-string.yml`, wiec przeszlaby, gdyby ten
+      // parametr zniknal - a on kieruje zglaszajacego do wlasciwego
+      // formularza. Przy okazji znika ksztalt `X.includes('https://...')`,
+      // ktory CodeQL czyta jako niepelna sanityzacje adresu.
+      const linie = result.split('\n').map((l) => l.trim());
+      assert.ok(linie.includes(
+        'https://github.com/msgwing/ZeroSMTP/issues/new?template=error-string.yml',
+      ));
     });
 
     test('handles empty input without throwing', () => {


### PR DESCRIPTION
Alert 15, waga **wysoka**: `js/incomplete-url-substring-sanitization`.

## Jako znalezisko bezpieczeństwa — fałszywy alarm

Sprawdzany ciąg to **nasz własny tekst wyjściowy**, nie dane od atakującego.
Nie ma tu żadnej sanityzacji do obejścia. CodeQL widzi kształt
`X.includes('https://...')` i nie odróżnia go od sprawdzania adresu.

## Ale wskazał realną słabość testu

Asercja szukała `https://github.com/msgwing/ZeroSMTP/issues/new`, a kod wypisuje
ten adres **plus `?template=error-string.yml`**.

Usuń parametr — fragment nadal tam jest, więc **stary test przechodził na
zepsutym kodzie**. A ten parametr kieruje zgłaszającego do strukturalnego
formularza zamiast do pustego zgłoszenia.

## Poprawka

Porównanie **całych przyciętych linii na dokładną równość**. Mocniejsze niż
szukanie fragmentu i bez kształtu, który myli skaner.

## Sprawdzone przez celowe zepsucie

```
parametr usuniety celowo:   pass 24  fail 1
po przywroceniu:            pass 25  fail 0
```

Dokładnie jeden test się wywala. **Bramka, której nie widziałem jak się wywala,
nie byłaby sprawdzona** — to ten sam warunek, którego wymagałem od kontrybutora
przy #300, więc stosuję go do siebie.
