### PR TITLE
feat(docs): WordPress, where a site that cannot send looks fine

### DIFF
--- a/docs/APPS.md
+++ b/docs/APPS.md
@@ -33,6 +33,12 @@ See [README.md](https://github.com/msgwing/ZeroSMTP#readme) for how to obtain a 
 
 ## WordPress (contact forms, WooCommerce, password resets)
 
+> **December 2026 changes this section.** Username-and-password SMTP to
+> Microsoft 365 stops working, and a WordPress site that cannot send looks
+> exactly like one that can. [WordPress email when Basic auth
+> ends](WORDPRESS.md) covers what breaks, which plugins have an OAuth route,
+> and when a relay is the wrong answer.
+
 Install a maintained SMTP plugin — e.g. **WP Mail SMTP** or **Post SMTP** —
 rather than relying on the default `wp_mail()`/PHP `mail()` transport, which
 most hosts throttle or block.

--- a/docs/WORDPRESS.md
+++ b/docs/WORDPRESS.md
@@ -1,0 +1,145 @@
+---
+title: "WordPress email when Basic auth ends"
+description: "WordPress and WooCommerce send order confirmations, password resets and contact-form mail through SMTP. What breaks when Microsoft 365 stops accepting a username and password in December 2026, which plugins have an OAuth route, and when a relay is the wrong answer."
+---
+
+# WordPress email and the Microsoft 365 Basic auth shutdown
+
+A WordPress site that cannot send email does not look broken. It looks fine.
+
+The order page still says thank you. The password-reset form still says *check
+your inbox*. The contact form still shows its success message. Every one of
+those screens is rendered before the mail is handed to the SMTP server, and
+none of them changes when the handoff is refused.
+
+So the failure arrives as an absence, and it arrives at somebody who cannot
+report it to you: the customer who never got the confirmation and assumes the
+order failed, the user who never got the reset link and gave up, the enquiry
+that was never answered because it was never seen.
+
+## What actually stops
+
+If your site authenticates to Microsoft 365 with a username and password —
+which is what every plugin's **Other SMTP** option does — then at the end of
+December 2026 Exchange Online stops accepting it. Not throttles: refuses.
+
+That covers, in rough order of how much it hurts:
+
+- **WooCommerce order confirmations, invoices and shipping notices.** The
+  customer's only receipt.
+- **Password resets.** Locks people out permanently, including administrators.
+- **New-account and email-change confirmations.**
+- **Contact-form and enquiry mail.** Lost leads, no error anywhere.
+- **Core update and security notifications** — including the ones that tell you
+  something is wrong.
+
+## How to tell whether you are affected, today
+
+You are affected if your SMTP plugin is set to **Other SMTP** with an
+`smtp.office365.com` host and a mailbox password in the password field.
+
+You are not affected if the plugin is using a Microsoft 365 / Outlook mailer
+that sent you through a Microsoft consent screen, or a provider that is not
+Microsoft at all.
+
+## The message you will actually see
+
+Not the server's. Your plugin's.
+
+WordPress surfaces PHPMailer's summary through the plugin, one layer further
+from the server, and prints `SMTP connect() failed.` — six words naming no
+code, no tenant and no cause. The wording suggests a network problem. It is
+not.
+
+[What WordPress prints, and what the server said](clients/wordpress-wp-mail-smtp-connect-failed.md)
+covers how to make the plugin show you the real line, which is the only thing
+that tells you whether this is a setting somebody can switch back on or the
+change that cannot be undone.
+
+## Your three routes, honestly
+
+### 1. OAuth through the plugin — best, if you can do it
+
+Both major plugins offer a Microsoft 365 mailer that uses OAuth instead of a
+password:
+
+- **FluentSMTP** lists Microsoft Office (Outlook) among its providers and is
+  free on WordPress.org.
+- **WP Mail SMTP**'s Microsoft 365 / Outlook.com mailer is a paid feature —
+  their documentation states it *"is only available with the Pro license or
+  higher."*
+
+Either way the real gate is not the plugin. It is that OAuth needs an
+**application registered in Microsoft Entra**, which needs somebody with admin
+rights in the tenant. If you have those rights, take this route and stop
+reading — it keeps your own domain in the From address, and nothing on this
+site improves on that.
+
+### 2. A relay — when route 1 is closed to you
+
+Route 1 is closed more often than its documentation assumes. An agency
+maintaining a client's site is not an administrator of the client's tenant. A
+freelancer handed FTP credentials is not either. Neither is anyone on shared
+hosting whose customer's IT is a phone number that answers in three weeks.
+
+That is who a relay is for: the site owner who can change a plugin setting and
+cannot change anything in Entra.
+
+### 3. Move the site's mail off Microsoft 365 entirely
+
+For a transactional store this is frequently the correct answer, and it is not
+ours. A dedicated transactional provider gives you your own sending domain,
+DKIM alignment, bounce handling and volume. [The alternatives
+page](ALTERNATIVES.md) names them without pretending we compete.
+
+## Before you configure ZeroSMTP, two limits that may disqualify it
+
+Stated here rather than discovered after your store's busiest day:
+
+- **Mail leaves from a generated `@msgwing.com` address, not your own domain.**
+  For password resets and contact forms this is usually acceptable. For
+  **WooCommerce order confirmations it often is not** — customers expect the
+  shop's address, and a receipt from an unfamiliar domain gets ignored or
+  reported.
+- **200 messages a day**, with no paid tier that lifts it. A small business
+  site will never touch that. A store with a hundred orders a day, each
+  generating several messages, will.
+
+If either rules you out, route 3 above is where to go, and going there is not
+a defeat.
+
+## Setup, if it still fits
+
+Works with WP Mail SMTP, FluentSMTP, Post SMTP or any plugin offering a plain
+SMTP option.
+
+1. Register at [msgwing.com](https://msgwing.com) and copy the generated login
+   and password — they are shown once.
+2. In the plugin's mailer settings choose **Other SMTP**.
+3. Enter the values below.
+4. Set the **From** address to your generated `@msgwing.com` login. Leaving
+   your own domain there while sending through a different one is the fastest
+   way into a spam folder.
+5. Send the plugin's built-in test email.
+
+| Setting | Value |
+| --- | --- |
+| SMTP host | `mx.msgwing.com` |
+| Port | `587` (STARTTLS) or `465` (SSL/TLS) |
+| Encryption | STARTTLS on 587, or SSL/TLS on 465 — required |
+| Authentication | Enabled |
+| Username | your `@msgwing.com` login |
+| Password | your `@msgwing.com` password |
+| From address | your `@msgwing.com` login |
+
+Then place a test order, or trigger a real password reset. The plugin's test
+email proves the connection; it does not prove that WooCommerce's own mail
+uses it.
+
+## Related
+
+- [What WordPress prints, and what the server said](clients/wordpress-wp-mail-smtp-connect-failed.md)
+- [All library error messages](LIBRARY-ERRORS.md)
+- [Configuring other applications](APPS.md)
+- [What breaks at the end of December 2026](AFFECTED-SYSTEMS.md)
+- [Tools that are a better fit than this one](ALTERNATIVES.md)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -26,6 +26,7 @@ answering somebody's question from this site:
 ## For system administrators
 
 - [Systems affected by the SMTP AUTH shutdown](https://docs.msgwing.com/AFFECTED-SYSTEMS.html): Risk assessment of printers, NAS units, backup jobs, monitoring tools and line-of-business apps that stop sending email, with a PowerShell audit.
+- [WordPress email when Basic auth ends](https://docs.msgwing.com/WORDPRESS.html): WordPress and WooCommerce send order confirmations, password resets and contact-form mail through SMTP. What breaks when Microsoft 365 stops accepting a username and password in December 2026, which plugins have an OAuth route, and when a relay is the wrong answer.
 - [Windows Server SMTP: IIS, PowerShell, Exchange](https://docs.msgwing.com/WINDOWS-SERVER.html): Send email from Windows Server without a local relay: ASP.NET web.config, PHP on IIS, scheduled PowerShell tasks, and Exchange send connectors.
 - [IIS SMTP relay and Microsoft 365](https://docs.msgwing.com/IIS-SMTP-RELAY.html): The IIS SMTP Server feature relaying to Microsoft 365: what breaks when Basic auth ends in December 2026, and what to do about it.
 - [Linux SMTP setup: Debian, Ubuntu, Fedora+](https://docs.msgwing.com/LINUX.html): Per-distribution package names and setup for sending email from Linux scripts and applications.

--- a/tools/build-llms-txt.py
+++ b/tools/build-llms-txt.py
@@ -43,6 +43,7 @@ GRUPY = [
     ]),
     ("For system administrators", [
         "AFFECTED-SYSTEMS.md",
+        "WORDPRESS.md",
         "WINDOWS-SERVER.md",
         "IIS-SMTP-RELAY.md",
         "LINUX.md",


### PR DESCRIPTION
## The gap, measured

The owner's instinct was that WordPress was under-covered. It was worse than under-covered.

| measurement | before |
|---|---|
| occurrences of "WordPress" in the whole docs tree | **14** — and 3 of the 5 files dated from this morning |
| dedicated WordPress page | none; four steps inside `APPS.md`, a page about twenty applications |
| mention of December 2026 in that section | none |
| `wordpress` among the repository's 20 topics | **absent** |

## What that cost, on GitHub search

| query | competitors | our position before |
|---|---|---|
| `wordpress office 365 smtp` | **1** | outside 40 |
| `wordpress smtp relay` | **4** | outside 40 |
| `wordpress smtp` | 478 | outside 40 |

A query with one result in all of GitHub, and we were not it.

## Fixed already, and verified

`scan-to-email` (4 repos, and its words are already in the description, so it fed no match) traded for `wordpress` (30,450 repos). Measured after the change, not assumed from the API's 200:

| query | after |
|---|---|
| `wordpress office 365 smtp` | **1st** |
| `wordpress smtp relay` | **1st** |
| `wordpress smtp` | 27th, from outside 40 |

`printer smtp`, `office 365 smtp printer`, `smtp relay free` and `smtp auth disabled` were re-measured separately and are all **still 1st**. The trade cost nothing.

## What this PR adds

`docs/WORDPRESS.md` — the Google side of the same gap, since the audience for this searches "wordpress not sending email", not GitHub.

The page opens on the actual failure mode: a WordPress site that cannot send **looks healthy**. The order page still says thank you, the reset form still says check your inbox, the contact form still shows its success message — all three render before the mail reaches the SMTP server. The failure lands on the person who cannot report it.

## Two paragraphs that argue against us

Both verified, not recalled:

- **FluentSMTP** lists Microsoft Office (Outlook) among its providers and is free on WordPress.org. **WP Mail SMTP**'s Microsoft 365 mailer is Pro-only — quoted from their documentation: *"is only available with the Pro license or higher."* Anyone holding Entra admin rights should take the OAuth route, keep their own domain in the From address, and skip us. The page says that before it offers anything.
- Mail leaves from a generated `@msgwing.com` address, and the cap is 200 a day. Fine for password resets and contact forms. **Frequently disqualifying for WooCommerce order confirmations** — a receipt from an unfamiliar domain gets ignored or reported. Stated before the setup section, not after somebody's busiest day.

What survives those two paragraphs is still the largest audience this project has outside printers: the agency that does not administer its client's tenant, and the freelancer holding FTP credentials and nothing else. OAuth is closed to them for a reason no plugin fixes.
