### PR TITLE
feat(ci): a contributor whose work was merged should not see their issue still open

### DIFF
--- a/.github/workflows/ready-for-approval.yml
+++ b/.github/workflows/ready-for-approval.yml
@@ -322,3 +322,87 @@ jobs:
               });
               core.notice('Utworzono ' + issue.data.html_url);
             }
+
+  # Praca kontrybutora zostala scalona, a jego zgloszenie zostalo otwarte.
+  #
+  # 2026-08-27: #310 od @TrueFurina dodalo Sophosa do listy zgodnosci OAuth i
+  # zostalo scalone. Zgloszenie #291, ktore o to prosilo, zostalo otwarte przez
+  # kolejne godziny - bo w opisie scalanego wniosku nie bylo `Closes #291`.
+  # Z zewnatrz wyglada to tak, jakby czyjas praca zostala zignorowana, i jest to
+  # dokladnie ten kontrybutor, ktorego nie stac nam stracic.
+  #
+  # Ta kontrola jest CELOWO waska. Pierwsza wersja, sprawdzana recznie tego
+  # samego dnia, dopasowywala sama nazwe producenta - i wskazala Xeroxa, Ricoha
+  # i Canona jako "zrobione", bo ich urzadzenia sa w danych. Tamte zgloszenia
+  # dotycza kodow bledow z paneli, nie listy OAuth: narzedzie odpowiedzialo na
+  # pytanie "czy producent jest w danych" zamiast na "czy ta praca jest
+  # zrobiona". Stad dwa niezalezne zabezpieczenia ponizej - wzorzec tytulu ORAZ
+  # etykieta - a nie jedno.
+  zrobione-a-otwarte:
+    if: github.event_name != 'issues'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const owner = context.repo.owner, repo = context.repo.repo;
+            const ETYKIETA = 'zrobione-a-otwarte';
+
+            const dane = JSON.parse(
+              fs.readFileSync('data/devices.json', 'utf8')).entries;
+            const wDanych = JSON.stringify(dane).toLowerCase();
+
+            const watki = (await github.rest.issues.listForRepo({
+              owner, repo, state: 'open', per_page: 100,
+            })).data;
+
+            let oznaczonych = 0;
+            for (const w of watki) {
+              if (w.pull_request) continue;
+              const etykiety = (w.labels || []).map(l => l.name);
+
+              // Zabezpieczenie 1: zgloszenia trzymane otwarte swiadomie -
+              // te, ktore czekaja na sprzet - nie sa niczyim przeoczeniem.
+              if (etykiety.includes('stan:celowe')) continue;
+              if (etykiety.includes(ETYKIETA)) continue;
+
+              // Zabezpieczenie 2: wzorzec tytulu. Tylko zgloszenia, ktore
+              // prosza dokladnie o wiersz w liscie zgodnosci - nie o kody
+              // paneli, nie o cokolwiek innego dotyczacego tego producenta.
+              const m = w.title.match(
+                /^Add (.+?) to the OAuth compatibility list/i);
+              if (!m) continue;
+
+              const producent = m[1].trim().toLowerCase();
+              if (producent.length < 3) continue;
+              if (!wDanych.includes(producent)) continue;
+
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: w.number, labels: [ETYKIETA],
+              });
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: w.number,
+                body: [
+                  '`' + m[1].trim() + '` teraz wystepuje w `data/devices.json`,',
+                  'a to zgloszenie jest nadal otwarte.',
+                  '',
+                  'Zwykle znaczy to, ze scalony wniosek nie mial w opisie',
+                  '`Closes #' + w.number + '`. Jesli praca jest zrobiona -',
+                  'zamknij to zgloszenie i podaj autora. Jesli nie -',
+                  'zdejmij etykietke `' + ETYKIETA + '`.',
+                  '',
+                  'Powod, dla ktorego to nie zamyka sie samo: kontrybutor,',
+                  'ktorego praca zostala scalona, a zgloszenie wisi otwarte,',
+                  'widzi to jako zignorowanie. Zamkniecie ma miec jego',
+                  'nazwisko w tresci.',
+                ].join(' ').replace(/  +/g, ' '),
+              });
+              oznaczonych++;
+            }
+
+            core.info(`oznaczonych jako zrobione-a-otwarte: ${oznaczonych}`);


### PR DESCRIPTION
## What happened today

[#310](https://github.com/msgwing/ZeroSMTP/pull/310) from @TrueFurina added Sophos to the OAuth compatibility list. Merged this morning; the table went from 20 rows to 21.

[#291](https://github.com/msgwing/ZeroSMTP/issues/291) — the issue asking for exactly that — **stayed open for hours afterwards**, because the pull request body never said `Closes #291`. That was our omission when the issue was written, not the contributor's.

From outside, a merged contribution with its issue still open reads as work that was ignored. This is the one repeat contributor this project has.

## Why a check and not a rule

"Remember to close the issue" is forgotten the first time it is inconvenient. Added as a **fifth job to the workflow that already watches for things nobody noticed**, rather than as a twenty-first workflow — the same argument `hr-lead` makes against role sprawl applies to these files.

## Why it is this narrow

Not caution — measurement. The first version, run by hand against the real tracker this morning, matched on the vendor name alone:

| Issue | Vendor in `devices.json` | Naive check | Correct answer |
|---|---|---|---|
| #291 Add Sophos to the OAuth compatibility list | yes | flag | **flag** |
| #265 Document Xerox panel error codes | yes | flag | **silent** |
| #266 Document Ricoh panel error codes | yes | flag | **silent** |
| #267 Document Canon panel error codes | yes | flag | **silent** |

Three false flags out of four. Those issues ask for panel error codes, not a compatibility row — the check had answered *"is this vendor in the data"* when the question was *"is this work finished"*.

So **two independent guards, not one**: the title must match the compatibility-list pattern, **and** the issue must not carry `stan:celowe`. Either alone would have produced those three false flags.

## Tested the way a gate has to be

A check that only does anything when something is wrong executes zero times while everything is fine, so "it passed" means nothing until it has been made to refuse. Six cases:

| Case | Expected | Result |
|---|---|---|
| Sophos, in the data, plain issue | **fires** — this is #291 | ✅ |
| TrueNAS, not in the data | silent | ✅ |
| Xerox panel codes, `stan:celowe` | silent | ✅ |
| Ricoh panel codes, no label | silent — title shape alone stops it | ✅ |
| Sophos, held open deliberately | silent | ✅ |
| Sophos, already flagged | silent — idempotent | ✅ |

It fires on exactly the one that failed today, and on nothing else.

## What it does when it fires

Labels the issue and comments once, in Polish, saying the vendor is now in the data and the issue is probably closable — and asking that the close **name the contributor**. It does not close anything by itself: an automatic close that is wrong costs more than the open issue did.
