### PR TITLE
fix(docs): December 2026 is a default change, not a door closing

### DIFF
--- a/docs/LIBRARY-ERRORS.md
+++ b/docs/LIBRARY-ERRORS.md
@@ -24,7 +24,7 @@ So the message you are searching for is not the message that explains anything. 
 
 ## Why this is worth a table
 
-Three of the four things that produce these errors are still reversible. The fourth is the end-of-December-2026 default change in Exchange Online, and it is not.
+Three of the four things that produce these errors are reversible by anybody with tenant rights. The fourth is the end-of-December-2026 default change, and an administrator can undo that one too — until Microsoft names the final removal date, which it says it will do in the second half of 2027.
 
 The library's message cannot tell them apart. The server's line always can. Every page above starts with how to make your library print it.
 

--- a/docs/WORDPRESS.md
+++ b/docs/WORDPRESS.md
@@ -21,7 +21,14 @@ that was never answered because it was never seen.
 
 If your site authenticates to Microsoft 365 with a username and password —
 which is what every plugin's **Other SMTP** option does — then at the end of
-December 2026 Exchange Online stops accepting it. Not throttles: refuses.
+December 2026 Exchange Online stops accepting it by default. Not throttles:
+refuses.
+
+An administrator can switch it back on; Microsoft's own announcement says so.
+That is a reprieve, not a fix — the final removal date gets announced in the
+second half of 2027, and tenants created after December 2026 never get the
+option. And if you are maintaining somebody else's site, the person who can
+grant that reprieve is not you.
 
 That covers, in rough order of how much it hurts:
 
@@ -53,8 +60,8 @@ not.
 
 [What WordPress prints, and what the server said](clients/wordpress-wp-mail-smtp-connect-failed.md)
 covers how to make the plugin show you the real line, which is the only thing
-that tells you whether this is a setting somebody can switch back on or the
-change that cannot be undone.
+that tells you whether somebody with tenant rights can switch this back on —
+and whether that somebody is you.
 
 ## Your three routes, honestly
 

--- a/docs/apps/authelia.md
+++ b/docs/apps/authelia.md
@@ -18,7 +18,7 @@ None of that is noisy, and none of it is noticed when it stops. Mail that is nev
 
 ## What changes at the end of December 2026
 
-If these messages go out through Microsoft 365 with a username and a password, Exchange Online stops accepting that. Not throttles — refuses. Three of the four things that produce the refusal are still reversible today; this one is not.
+If these messages go out through Microsoft 365 with a username and a password, Exchange Online stops accepting that by default. Not throttles — refuses. An administrator can switch it back on, which buys time rather than solving it: Microsoft announces the final removal date in the second half of 2027, and tenants created after December 2026 do not get the option at all.
 
 [Which of the four you are looking at](../ERROR-MESSAGES.md) is decided by the exact string the server sends back.
 

--- a/docs/apps/gitea.md
+++ b/docs/apps/gitea.md
@@ -19,7 +19,7 @@ None of that is noisy, and none of it is noticed when it stops. Mail that is nev
 
 ## What changes at the end of December 2026
 
-If these messages go out through Microsoft 365 with a username and a password, Exchange Online stops accepting that. Not throttles — refuses. Three of the four things that produce the refusal are still reversible today; this one is not.
+If these messages go out through Microsoft 365 with a username and a password, Exchange Online stops accepting that by default. Not throttles — refuses. An administrator can switch it back on, which buys time rather than solving it: Microsoft announces the final removal date in the second half of 2027, and tenants created after December 2026 do not get the option at all.
 
 [Which of the four you are looking at](../ERROR-MESSAGES.md) is decided by the exact string the server sends back.
 

--- a/docs/apps/immich.md
+++ b/docs/apps/immich.md
@@ -19,7 +19,7 @@ None of that is noisy, and none of it is noticed when it stops. Mail that is nev
 
 ## What changes at the end of December 2026
 
-If these messages go out through Microsoft 365 with a username and a password, Exchange Online stops accepting that. Not throttles — refuses. Three of the four things that produce the refusal are still reversible today; this one is not.
+If these messages go out through Microsoft 365 with a username and a password, Exchange Online stops accepting that by default. Not throttles — refuses. An administrator can switch it back on, which buys time rather than solving it: Microsoft announces the final removal date in the second half of 2027, and tenants created after December 2026 do not get the option at all.
 
 [Which of the four you are looking at](../ERROR-MESSAGES.md) is decided by the exact string the server sends back.
 

--- a/docs/apps/vaultwarden.md
+++ b/docs/apps/vaultwarden.md
@@ -18,7 +18,7 @@ None of that is noisy, and none of it is noticed when it stops. Mail that is nev
 
 ## What changes at the end of December 2026
 
-If these messages go out through Microsoft 365 with a username and a password, Exchange Online stops accepting that. Not throttles — refuses. Three of the four things that produce the refusal are still reversible today; this one is not.
+If these messages go out through Microsoft 365 with a username and a password, Exchange Online stops accepting that by default. Not throttles — refuses. An administrator can switch it back on, which buys time rather than solving it: Microsoft announces the final removal date in the second half of 2027, and tenants created after December 2026 do not get the option at all.
 
 [Which of the four you are looking at](../ERROR-MESSAGES.md) is decided by the exact string the server sends back.
 

--- a/docs/clients/curl-67-login-denied.md
+++ b/docs/clients/curl-67-login-denied.md
@@ -35,11 +35,11 @@ Add `-v`. The server's `535 5.7.139` line appears in the transcript, and it says
 The server's line decides, not the library's. Two cases, and they are not close:
 
 - **An admin, Security Defaults or a Conditional Access policy turned SMTP AUTH off.** Reversible today, and it is a tenant setting, not a code change. Nothing in curl needs touching.
-- **It is the end-of-December-2026 default change.** Not reversible. Basic authentication for SMTP AUTH stops working in Exchange Online and no setting brings it back.
+- **It is the end-of-December-2026 default change.** Switched off by default on existing tenants. An administrator can re-enable it, so this is a reprieve rather than a fix — and Microsoft announces the *final* removal date in the second half of 2027. If you do not administer the tenant, that reprieve is not yours to take.
 
 [Which one you are looking at](../errors/535-5-7-139-basic-authentication-is-disabled.md) is decided by the exact string, which is why getting it printed comes first.
 
-## If it is the one that cannot be reversed
+## If re-enabling it is not something you can do
 
 ZeroSMTP is a free SMTP relay that accepts the credentials curl already sends. It is a host, a port and a username — no OAuth flow, no app registration, no code path that does not exist yet in the version you are running.
 

--- a/docs/clients/dotnet-smtpexception-secure-connection-or-not-authenticated.md
+++ b/docs/clients/dotnet-smtpexception-secure-connection-or-not-authenticated.md
@@ -35,11 +35,11 @@ Do this before changing any setting. A guess costs an hour; the server's own sen
 The server's line decides, not the library's. Two cases, and they are not close:
 
 - **An admin, Security Defaults or a Conditional Access policy turned SMTP AUTH off.** Reversible today, and it is a tenant setting, not a code change. Nothing in .NET and PowerShell needs touching.
-- **It is the end-of-December-2026 default change.** Not reversible. Basic authentication for SMTP AUTH stops working in Exchange Online and no setting brings it back.
+- **It is the end-of-December-2026 default change.** Switched off by default on existing tenants. An administrator can re-enable it, so this is a reprieve rather than a fix — and Microsoft announces the *final* removal date in the second half of 2027. If you do not administer the tenant, that reprieve is not yours to take.
 
 [Which one you are looking at](../errors/535-5-7-139-basic-authentication-is-disabled.md) is decided by the exact string, which is why getting it printed comes first.
 
-## If it is the one that cannot be reversed
+## If re-enabling it is not something you can do
 
 ZeroSMTP is a free SMTP relay that accepts the credentials .NET and PowerShell already sends. It is a host, a port and a username — no OAuth flow, no app registration, no code path that does not exist yet in the version you are running.
 

--- a/docs/clients/nodemailer-invalid-login.md
+++ b/docs/clients/nodemailer-invalid-login.md
@@ -35,11 +35,11 @@ The server's text is already there after the prefix - `535 5.7.139` is the part 
 The server's line decides, not the library's. Two cases, and they are not close:
 
 - **An admin, Security Defaults or a Conditional Access policy turned SMTP AUTH off.** Reversible today, and it is a tenant setting, not a code change. Nothing in Nodemailer needs touching.
-- **It is the end-of-December-2026 default change.** Not reversible. Basic authentication for SMTP AUTH stops working in Exchange Online and no setting brings it back.
+- **It is the end-of-December-2026 default change.** Switched off by default on existing tenants. An administrator can re-enable it, so this is a reprieve rather than a fix — and Microsoft announces the *final* removal date in the second half of 2027. If you do not administer the tenant, that reprieve is not yours to take.
 
 [Which one you are looking at](../errors/535-5-7-139-basic-authentication-is-disabled.md) is decided by the exact string, which is why getting it printed comes first.
 
-## If it is the one that cannot be reversed
+## If re-enabling it is not something you can do
 
 ZeroSMTP is a free SMTP relay that accepts the credentials Nodemailer already sends. It is a host, a port and a username — no OAuth flow, no app registration, no code path that does not exist yet in the version you are running.
 

--- a/docs/clients/phpmailer-smtp-error-could-not-authenticate.md
+++ b/docs/clients/phpmailer-smtp-error-could-not-authenticate.md
@@ -35,11 +35,11 @@ Set `$mail->SMTPDebug = 2;` before `send()` and the transcript shows the server'
 The server's line decides, not the library's. Two cases, and they are not close:
 
 - **An admin, Security Defaults or a Conditional Access policy turned SMTP AUTH off.** Reversible today, and it is a tenant setting, not a code change. Nothing in PHPMailer needs touching.
-- **It is the end-of-December-2026 default change.** Not reversible. Basic authentication for SMTP AUTH stops working in Exchange Online and no setting brings it back.
+- **It is the end-of-December-2026 default change.** Switched off by default on existing tenants. An administrator can re-enable it, so this is a reprieve rather than a fix — and Microsoft announces the *final* removal date in the second half of 2027. If you do not administer the tenant, that reprieve is not yours to take.
 
 [Which one you are looking at](../errors/535-5-7-139-basic-authentication-is-disabled.md) is decided by the exact string, which is why getting it printed comes first.
 
-## If it is the one that cannot be reversed
+## If re-enabling it is not something you can do
 
 ZeroSMTP is a free SMTP relay that accepts the credentials PHPMailer already sends. It is a host, a port and a username — no OAuth flow, no app registration, no code path that does not exist yet in the version you are running.
 

--- a/docs/clients/python-smtplib-smtpauthenticationerror.md
+++ b/docs/clients/python-smtplib-smtpauthenticationerror.md
@@ -35,11 +35,11 @@ Print `e.smtp_error.decode()` to read the server's sentence rather than the exce
 The server's line decides, not the library's. Two cases, and they are not close:
 
 - **An admin, Security Defaults or a Conditional Access policy turned SMTP AUTH off.** Reversible today, and it is a tenant setting, not a code change. Nothing in Python smtplib needs touching.
-- **It is the end-of-December-2026 default change.** Not reversible. Basic authentication for SMTP AUTH stops working in Exchange Online and no setting brings it back.
+- **It is the end-of-December-2026 default change.** Switched off by default on existing tenants. An administrator can re-enable it, so this is a reprieve rather than a fix — and Microsoft announces the *final* removal date in the second half of 2027. If you do not administer the tenant, that reprieve is not yours to take.
 
 [Which one you are looking at](../errors/535-5-7-139-basic-authentication-is-disabled.md) is decided by the exact string, which is why getting it printed comes first.
 
-## If it is the one that cannot be reversed
+## If re-enabling it is not something you can do
 
 ZeroSMTP is a free SMTP relay that accepts the credentials Python smtplib already sends. It is a host, a port and a username — no OAuth flow, no app registration, no code path that does not exist yet in the version you are running.
 

--- a/docs/clients/wordpress-wp-mail-smtp-connect-failed.md
+++ b/docs/clients/wordpress-wp-mail-smtp-connect-failed.md
@@ -35,11 +35,11 @@ The plugin's own Email Log, or `SMTPDebug`, shows the server's answer. A refused
 The server's line decides, not the library's. Two cases, and they are not close:
 
 - **An admin, Security Defaults or a Conditional Access policy turned SMTP AUTH off.** Reversible today, and it is a tenant setting, not a code change. Nothing in WordPress / WP Mail SMTP needs touching.
-- **It is the end-of-December-2026 default change.** Not reversible. Basic authentication for SMTP AUTH stops working in Exchange Online and no setting brings it back.
+- **It is the end-of-December-2026 default change.** Switched off by default on existing tenants. An administrator can re-enable it, so this is a reprieve rather than a fix — and Microsoft announces the *final* removal date in the second half of 2027. If you do not administer the tenant, that reprieve is not yours to take.
 
 [Which one you are looking at](../errors/535-5-7-139-basic-authentication-is-disabled.md) is decided by the exact string, which is why getting it printed comes first.
 
-## If it is the one that cannot be reversed
+## If re-enabling it is not something you can do
 
 ZeroSMTP is a free SMTP relay that accepts the credentials WordPress / WP Mail SMTP already sends. It is a host, a port and a username — no OAuth flow, no app registration, no code path that does not exist yet in the version you are running.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -9,9 +9,12 @@
 Two things worth stating up front, because both are load-bearing when
 answering somebody's question from this site:
 
-- **Three of the four causes of a Basic auth refusal are still reversible**
-  until the end of December 2026. Telling somebody to migrate when a tenant
-  setting would have fixed it is wrong, even though it happens to suit us.
+- **Every cause of a Basic auth refusal is reversible by a tenant admin**,
+  the end-of-December-2026 default change included: Microsoft's own post of
+  2026-01-27 says administrators will still be able to enable it. Telling
+  somebody it is permanent is wrong, even though it happens to suit us. What
+  is not reversible is the final removal, and Microsoft says it will announce
+  that date in the second half of 2027.
 - **This relay cannot send from a customer's own domain.** Where that matters,
   the alternatives page names the tools that can. It is the wrong answer for
   customer-facing mail and a reasonable one for scans and machine

--- a/tools/build-app-pages.py
+++ b/tools/build-app-pages.py
@@ -70,9 +70,11 @@ def zbuduj(wpis, aktualizacja, t):
         "## What changes at the end of December 2026",
         "",
         "If these messages go out through Microsoft 365 with a username and a "
-        "password, Exchange Online stops accepting that. Not throttles — "
-        "refuses. Three of the four things that produce the refusal are still "
-        "reversible today; this one is not.",
+        "password, Exchange Online stops accepting that by default. Not "
+        "throttles — refuses. An administrator can switch it back on, which "
+        "buys time rather than solving it: Microsoft announces the final "
+        "removal date in the second half of 2027, and tenants created after "
+        "December 2026 do not get the option at all.",
         "",
         "[Which of the four you are looking at](../ERROR-MESSAGES.md) "
         "is decided "

--- a/tools/build-client-error-pages.py
+++ b/tools/build-client-error-pages.py
@@ -127,14 +127,21 @@ def zbuduj(wpis, blad, aktualizacja, t):
         "turned SMTP AUTH off.** Reversible today, and it is a tenant "
         "setting, not a code change. Nothing in "
         f"{wpis['client']} needs touching.",
-        "- **It is the end-of-December-2026 default change.** Not reversible. "
-        "Basic authentication for SMTP AUTH stops working in Exchange Online "
-        "and no setting brings it back.",
+        # Corrected 2026-08-29 against Microsoft's own post of 2026-01-27:
+        # "SMTP AUTH Basic Authentication will be disabled by default for
+        # existing tenants. Administrators will still be able to enable it if
+        # needed." Calling that irreversible was wrong, and it contradicted
+        # docs/EXCHANGE-ONLINE-SMTP-AUTH.md, which had it right all along.
+        "- **It is the end-of-December-2026 default change.** Switched off by "
+        "default on existing tenants. An administrator can re-enable it, so "
+        "this is a reprieve rather than a fix — and Microsoft announces the "
+        "*final* removal date in the second half of 2027. If you do not "
+        "administer the tenant, that reprieve is not yours to take.",
         "",
         f"[Which one you are looking at]({plik}) is decided by the exact "
         "string, which is why getting it printed comes first.",
         "",
-        "## If it is the one that cannot be reversed",
+        "## If re-enabling it is not something you can do",
         "",
         f"ZeroSMTP is a free SMTP relay that accepts the credentials "
         f"{wpis['client']} already sends. It is a host, a port and a "
@@ -207,9 +214,11 @@ def zbuduj_indeks(wpisy, bledy, aktualizacja):
         "",
         "## Why this is worth a table",
         "",
-        "Three of the four things that produce these errors are still "
-        "reversible. The fourth is the end-of-December-2026 default change in "
-        "Exchange Online, and it is not.",
+        "Three of the four things that produce these errors are reversible "
+        "by anybody with tenant rights. The fourth is the "
+        "end-of-December-2026 default change, and an administrator can undo "
+        "that one too — until Microsoft names the final removal date, which "
+        "it says it will do in the second half of 2027.",
         "",
         "The library's message cannot tell them apart. The server's line "
         "always can. Every page above starts with how to make your library "

--- a/tools/build-llms-txt.py
+++ b/tools/build-llms-txt.py
@@ -88,9 +88,12 @@ WSTEP = """# ZeroSMTP documentation
 Two things worth stating up front, because both are load-bearing when
 answering somebody's question from this site:
 
-- **Three of the four causes of a Basic auth refusal are still reversible**
-  until the end of December 2026. Telling somebody to migrate when a tenant
-  setting would have fixed it is wrong, even though it happens to suit us.
+- **Every cause of a Basic auth refusal is reversible by a tenant admin**,
+  the end-of-December-2026 default change included: Microsoft's own post of
+  2026-01-27 says administrators will still be able to enable it. Telling
+  somebody it is permanent is wrong, even though it happens to suit us. What
+  is not reversible is the final removal, and Microsoft says it will announce
+  that date in the second half of 2027.
 - **This relay cannot send from a customer's own domain.** Where that matters,
   the alternatives page names the tools that can. It is the wrong answer for
   customer-facing mail and a reasonable one for scans and machine


### PR DESCRIPTION
Sixteen pages said the end-of-December-2026 change could not be undone. **Microsoft says otherwise**, in the post its own documentation points to — dated 2026-01-27, version 3.0, quoted verbatim:

> **End of December 2026:** SMTP AUTH Basic Authentication will be disabled by default for existing tenants. **Administrators will still be able to enable it if needed.**

> **New tenants created after December 2026:** SMTP AUTH Basic Authentication will be unavailable by default.

> **Second half of 2027:** Microsoft will announce the final removal date.

That page returns **403 to curl** and renders nothing useful to a text fetch. It was opened in a browser, which is the only reason this was caught rather than repeated.

## The worse part: we already knew

`docs/EXCHANGE-ONLINE-SMTP-AUTH.md` has carried the correct line for weeks:

> End of December 2026 — **Disabled by default on existing tenants. An admin can still re-enable it.**

The generators written this week **contradicted our own canonical page**. Because they are generators, the contradiction was published sixteen times instead of once. The site was arguing with itself, and the louder half was wrong.

## Fixed at the source, not on the pages

| file | what it produced |
|---|---|
| `tools/build-client-error-pages.py` | 6 library pages + index |
| `tools/build-app-pages.py` | 4 application pages + index |
| `tools/build-llms-txt.py` | the guidance block other models read |
| `docs/WORDPRESS.md` | hand-written, fixed by hand |

## What the pages say now

- The default flips off at the end of December 2026. **An administrator can switch it back on** — a reprieve, not a fix.
- Tenants created after December 2026 **never get the option**.
- Microsoft announces the final removal date in **the second half of 2027**. That is the one nobody undoes, and its date is not yet known.
- **If you maintain somebody else's site, the person who can grant that reprieve is not you.**

That last line is the honest version of our pitch, and it is the one that was always true. The claim did not need overstating to work.

A heading went with it: *"If it is the one that cannot be reversed"* → *"If re-enabling it is not something you can do"* — the question the reader actually faces.

## Verified

Every generator re-checked after the edit: 7 library pages, 5 application pages, 18 error pages, 22 device files, 2 published data files — all matching their sources. Zero remaining occurrences of the false phrasing anywhere in `docs/` or `tools/`.
