### PR TITLE
fix(docs): near-white text on near-white boxes, in dark mode

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -80,6 +80,8 @@ jobs:
         run: python tools/build-error-pages.py --check
       - name: Library error pages match data/clients.json
         run: python tools/build-client-error-pages.py --check
+      - name: No colour literals in runtime styles
+        run: python tools/check-theme-colors.py
       - name: Application pages match data/apps.json
         run: python tools/build-app-pages.py --check
       - name: Blast radius page matches data/blast-radius.json

--- a/docs/ALTERNATIVES.md
+++ b/docs/ALTERNATIVES.md
@@ -140,7 +140,7 @@ receipts to your customers, it is not.
   notifications, marketing).
 
 This is the same honest split covered in
-[option 4 of the Exchange Online migration guide](EXCHANGE-ONLINE-SMTP-AUTH.md#4-a-third-party-smtp-service-that-still-accepts-usernamepassword) —
+[option 5 of the Exchange Online migration guide](EXCHANGE-ONLINE-SMTP-AUTH.md#5-a-third-party-smtp-service-that-still-accepts-usernamepassword) —
 this page just puts the comparison front and center instead of as one
 paragraph among several options.
 

--- a/docs/EXCHANGE-ONLINE-SMTP-AUTH.md
+++ b/docs/EXCHANGE-ONLINE-SMTP-AUTH.md
@@ -76,14 +76,40 @@ Limitations worth knowing before you commit: Direct Send only delivers to
 your own tenant's domains, needs a static IP with correct SPF, and is
 subject to its own throttling.
 
-### 3. A dedicated on-prem relay (Postfix, IIS SMTP, etc.)
+### 3. High Volume Email (HVE) — what Microsoft's own notice points you at
+
+When Microsoft's documentation tells you client SMTP submission is going away,
+the first replacement it names is
+[High Volume Email](https://learn.microsoft.com/en-us/exchange/mail-flow-best-practices/high-volume-mails-m365):
+a dedicated account type on its own endpoint, `smtp.hve.mx.microsoft` on port
+587, which **accepts a username and password** and keeps working even where
+`SMTPClientAuthenticationDisabled` is `True` for the tenant.
+
+That sounds like the whole problem solved, and for internal scan-to-email it
+often is. Three things decide whether it is solved for you, and all three are
+easy to read past:
+
+- **Internal recipients only.** HVE cannot deliver outside your tenant. If a
+  scanner mails a document to a client, an accountant or anyone at another
+  company, HVE is not the answer.
+- **It is no longer free.** HVE bills pay-as-you-go at **$0.000042 per
+  delivered recipient** ($42 per million) against an Azure subscription, and
+  an account without a billing policy assigned **cannot send at all**. Older
+  write-ups describing HVE as a free preview are out of date.
+- **10 MB per message, 50 recipients per message, 100 accounts per tenant.**
+  A scanner set to 600 dpi will exceed 10 MB on a long document.
+
+Also worth knowing: if **Security Defaults** are on in Microsoft Entra ID,
+basic authentication is disabled for HVE too, and it can only use OAuth.
+
+### 4. A dedicated on-prem relay (Postfix, IIS SMTP, etc.)
 
 Point the devices at an internal relay, and let *that* relay handle modern
 auth upstream. This keeps your domain as the sender and requires no device
 changes, but it's another server to run, patch, and monitor. Our
 [SYSTEM-MTA.md](SYSTEM-MTA.md) covers the Postfix side of this pattern.
 
-### 4. A third-party SMTP service that still accepts username/password
+### 5. A third-party SMTP service that still accepts username/password
 
 Commercial relays (SendGrid, Mailgun, Brevo, SMTP2GO, Amazon SES…) accept
 plain SMTP AUTH and let you verify your own domain, so devices keep working
@@ -92,7 +118,7 @@ business sending on its own domain it's typically the right one — see
 [ZeroSMTP vs. other free relays](ALTERNATIVES.md) for exactly what that
 verification step involves.
 
-### 5. ZeroSMTP — where it actually fits
+### 6. ZeroSMTP — where it actually fits
 
 This project is a free relay that accepts ordinary SMTP AUTH
 (username + password, TLS) on `mx.msgwing.com`. For a device that can't do
@@ -117,7 +143,7 @@ So:
 - ❌ **Bad fit:** customer-facing mail, anything that must come from your
   company domain, anything above a couple hundred messages a day, or a
   regulated environment where the sending identity matters. Use option 1, 2,
-  or 4 for those.
+  or 5 for those.
 
 If that trade-off works for your case, the [Quickstart](https://github.com/msgwing/ZeroSMTP#quickstart)
 takes about a minute, and [PRINTERS.md](PRINTERS.md) has per-brand settings
@@ -143,12 +169,12 @@ Does the mail have to come FROM your own domain?
 │           ├── Yes ──► OAuth 2.0 / Graph API            (option 1)
 │           └── No  ──► Static IP available?
 │                       ├── Yes ──► Direct Send / relay connector  (option 2)
-│                       └── No  ──► On-prem relay (option 3) or paid SMTP (option 4)
+│                       └── No  ──► On-prem relay (option 4) or paid SMTP (option 5)
 └── No  ──► Low volume, non-critical (scans, device alerts)?
-            ├── No  ──► Paid SMTP service                 (option 4)
+            ├── No  ──► Paid SMTP service                 (option 5)
             └── Yes ──► Has the vendor shipped OAuth firmware for your model?
                         ├── Yes ──► Apply the firmware. Nothing else needed.
-                        ├── No  ──► ZeroSMTP                          (option 5)
+                        ├── No  ──► ZeroSMTP                          (option 6)
                         └── Don't know ──► Check the compatibility list first
 ```
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -917,7 +917,7 @@
     (function(){
       var el = document.getElementById('zc-quiz');
       if (!el) return;
-      el.style.cssText = 'background:#f6f8fa;border:1px solid #d0d7de;border-radius:6px;padding:20px;margin:20px 0;font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\',Helvetica,Arial,sans-serif;max-width:520px;';
+      el.style.cssText = 'background:var(--panel);border:1px solid var(--line);border-radius:6px;padding:20px;margin:20px 0;font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\',Helvetica,Arial,sans-serif;max-width:520px;';
 
       var steps = {
         start: {
@@ -993,7 +993,7 @@
         var step = steps[key];
         var html = '<div style="font-weight:600;margin-bottom:10px;">' + step.q + '</div>';
         step.options.forEach(function(opt){
-          html += '<button data-next="' + opt.next + '" style="display:block;width:100%;text-align:left;background:#fff;border:1px solid #d0d7de;border-radius:6px;padding:8px 12px;margin:6px 0;cursor:pointer;font-size:14px;">' + opt.label + '</button>';
+          html += '<button data-next="' + opt.next + '" style="display:block;width:100%;text-align:left;background:var(--panel);border:1px solid var(--line);border-radius:6px;padding:8px 12px;margin:6px 0;cursor:pointer;font-size:14px;">' + opt.label + '</button>';
         });
         el.innerHTML = html;
         Array.prototype.forEach.call(el.querySelectorAll('button'), function(btn){
@@ -1015,10 +1015,10 @@
         }
         el.innerHTML =
           '<div style="font-weight:600;margin-bottom:8px;">Recommendation</div>' +
-          '<div style="background:#dafbe1;border:1px solid #2ea043;border-radius:6px;padding:12px 14px;"><strong>' + r.title + '</strong><p style="margin:8px 0 0;">' + r.body + '</p></div>' +
+          '<div style="background:var(--tint);border:1px solid var(--ok);border-radius:6px;padding:12px 14px;"><strong>' + r.title + '</strong><p style="margin:8px 0 0;">' + r.body + '</p></div>' +
           '<div style="margin-top:10px;font-size:13px;">' +
           '<a href="#" id="zc-restart">&larr; start over</a>' +
-          '<span style="color:#57606a;"> · this recommendation has its own link &mdash; copy the address bar to share it</span>' +
+          '<span style="color:var(--muted);"> · this recommendation has its own link &mdash; copy the address bar to share it</span>' +
           '</div>';
         document.getElementById('zc-restart').addEventListener('click', function(e){
           e.preventDefault();
@@ -1043,10 +1043,10 @@
       var mount = document.getElementById('zc-brand-picker-mount');
       if (!mount) return;
 
-      mount.style.cssText = 'background:#f6f8fa;border:1px solid #d0d7de;border-radius:6px;padding:16px 20px;margin:16px 0;font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\',Helvetica,Arial,sans-serif;max-width:640px;';
+      mount.style.cssText = 'background:var(--panel);border:1px solid var(--line);border-radius:6px;padding:16px 20px;margin:16px 0;font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\',Helvetica,Arial,sans-serif;max-width:640px;';
       mount.innerHTML =
         '<label for="zc-brand-picker" style="font-weight:600;display:block;margin-bottom:8px;">Printer brand</label>' +
-        '<select id="zc-brand-picker" style="width:100%;padding:8px;border:1px solid #d0d7de;border-radius:6px;font-size:14px;margin-bottom:12px;">' +
+        '<select id="zc-brand-picker" style="width:100%;padding:8px;border:1px solid var(--line);border-radius:6px;font-size:14px;margin-bottom:12px;">' +
         '<option value="">Select a brand…</option></select>' +
         '<div id="zc-brand-output" style="font-size:14px;"></div>';
 
@@ -1078,7 +1078,7 @@
         var b = brands[parseInt(select.value, 10)];
         output.innerHTML =
           '<p>' + b.path + '</p>' +
-          '<p style="color:#57606a;">Server: <code>mx.msgwing.com</code> &middot; Port: <code>587</code> (STARTTLS) or <code>465</code> (SSL/TLS) &middot; full settings table above.</p>';
+          '<p style="color:var(--muted);">Server: <code>mx.msgwing.com</code> &middot; Port: <code>587</code> (STARTTLS) or <code>465</code> (SSL/TLS) &middot; full settings table above.</p>';
       });
     })();
     </script>

--- a/tools/check-theme-colors.py
+++ b/tools/check-theme-colors.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Refuse a colour literal in any style the page builds at runtime.
+
+Found on a phone, 2026-08-29: text at contrast 1.09 - near-white on
+near-white, invisible. Two widgets set `background:#f6f8fa` in an inline
+style string while the text inside inherited `--ink`, which is #1B1830 in
+light mode and #EFECFA in dark. The background stayed light when the theme
+flipped and the text did not, so the whole widget went blank.
+
+Thirty elements on one page. It was not visible in review because reviewing
+happens in light mode, where a light background is exactly right.
+
+The rule this enforces: a colour inside a `style="..."` or `cssText` string
+in the layout must come from a custom property, because those are the only
+values defined twice - once per theme. A literal is defined once and is
+therefore wrong in one of the two.
+
+Syntax highlighting is exempt. Those rules live in a real stylesheet under
+`.highlight`, they colour text on a code block that paints its own dark
+background in both themes, and they are a palette rather than a theme.
+
+    python tools/check-theme-colors.py
+"""
+
+import pathlib
+import re
+import sys
+
+KORZEN = pathlib.Path(__file__).resolve().parent.parent
+UKLAD = KORZEN / "docs" / "_layouts" / "default.html"
+
+# Wlasciwosci, ktore niosa kolor. `border` lapie tez `border:1px solid #fff`.
+WLASCIWOSCI = r"(?:background|background-color|color|border|border-color|outline|fill|stroke)"
+
+# Literal koloru: #abc, #aabbcc, rgb(), rgba(), albo nazwa z tej krotkiej listy.
+# Nazwy pelne (`white`, `black`) sa tu, bo to one wygladaja najniewinniej.
+LITERAL = r"(#[0-9a-fA-F]{3,8}\b|rgba?\([^)]*\)|\b(?:white|black|silver|gainsboro|whitesmoke)\b)"
+
+# Ciagi, ktore strona sklada w czasie dzialania: atrybut style= wewnatrz
+# lancucha JavaScriptu, oraz przypisania do cssText / style.background itd.
+WZORY_RUNTIME = [
+    re.compile(r"style\s*=\\?[\"'][^\"']*?" + WLASCIWOSCI + r"\s*:\s*" + LITERAL),
+    re.compile(r"cssText\s*=\s*[\"'][^\"']*?" + WLASCIWOSCI + r"\s*:\s*" + LITERAL),
+    re.compile(r"\.style\.(?:background|backgroundColor|color|borderColor)\s*=\s*[\"']" + LITERAL),
+]
+
+
+def main():
+    tekst = UKLAD.read_text(encoding="utf-8")
+    znalezione = []
+
+    for nr, linia in enumerate(tekst.split("\n"), 1):
+        for wzor in WZORY_RUNTIME:
+            for m in wzor.finditer(linia):
+                znalezione.append((nr, m.group(1), linia.strip()[:96]))
+
+    if znalezione:
+        print("Colour literals in styles the page builds at runtime:")
+        for nr, kolor, linia in znalezione:
+            print(f"  docs/_layouts/default.html:{nr}  {kolor}")
+            print(f"    {linia}")
+        print()
+        print("A literal is defined once; a theme needs two values. Use a custom")
+        print("property - var(--panel), var(--paper), var(--ink), var(--muted),")
+        print("var(--line), var(--tint), var(--ok), var(--fault) - so the value")
+        print("changes with the theme and the text stays on top of its own")
+        print("background rather than disappearing into it.")
+        return 1
+
+    print(f"Runtime styles carry no colour literals ({UKLAD.name}).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Reported from a phone: text on one of the pages was white and unreadable.

## Reproduced, then measured

Emulated a phone viewport in **dark mode** and measured the contrast of every text node on the page.

**Thirty elements at contrast 1.09.** That is near-white on near-white — invisible, not merely poor.

| | |
|---|---|
| text colour | `rgb(239,236,250)` — `--ink` in dark mode |
| background | `rgb(246,248,250)` — **hardcoded light** |

## The cause

Two widgets set their background in an inline style string:

```
background:#f6f8fa
```

…and let the text inside inherit `--ink`, which is `#1B1830` in light mode and `#EFECFA` in dark. **The background never moved. The text did.**

It survived review because **review happens in light mode**, where a light background is exactly right and nothing looks wrong.

## Fixed everywhere, not just where it was seen

Every colour literal in a style the page builds at runtime is now a custom property: two widget mounts, four borders, two muted greys, one button background, and the green recommendation box — which had the same defect in a friendlier colour.

**Syntax highlighting is untouched.** Those rules live in a real stylesheet, on a code block that paints its own background in both themes; they are a palette, not a theme.

## The gate, because the rule would not survive the next widget

`tools/check-theme-colors.py` refuses a colour literal inside any `style=` or `cssText` string in the layout, and runs in `lint.yml`.

Tested by putting `#f6f8fa` back on line 920 — it names the line and the colour and refuses. Restored: passes.

## The auditor was checked before it was believed

A deliberately unreadable paragraph was planted and confirmed caught at **1.12**. An auditor that has never reported anything is indistinguishable from one that cannot see.