### PR TITLE
feat(ci): a page may not contradict what another page says

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -80,6 +80,8 @@ jobs:
         run: python tools/build-error-pages.py --check
       - name: Library error pages match data/clients.json
         run: python tools/build-client-error-pages.py --check
+      - name: No page contradicts a shared claim
+        run: python tools/check-facts.py
       - name: No colour literals in runtime styles
         run: python tools/check-theme-colors.py
       - name: Application pages match data/apps.json

--- a/data/facts.json
+++ b/data/facts.json
@@ -1,0 +1,66 @@
+{
+  "$comment": "Claims this project makes on more than one page. Each one has a single agreed wording and a set of phrasings that contradict it. tools/check-facts.py refuses a build where any page says the opposite. Born on 2026-08-29, when sixteen generated pages were found contradicting docs/EXCHANGE-ONLINE-SMTP-AUTH.md about the one date this whole project is built around - and on the same day, an assistant asked to assess the project called it doubtful. A reader who finds two of our pages disagreeing stops trusting both, and that reader is now often a machine.",
+  "updated": "2026-08-29",
+  "facts": [
+    {
+      "key": "grudzien-2026-odwracalny",
+      "claim": "At the end of December 2026 SMTP AUTH Basic authentication is disabled by default for existing tenants, and an administrator can still re-enable it. The final removal date is to be announced in the second half of 2027.",
+      "source": "https://techcommunity.microsoft.com/blog/exchange/updated-exchange-online-smtp-auth-basic-authentication-deprecation-timeline/4489835",
+      "verified": "2026-08-29",
+      "contradictions": [
+        "no setting brings it back",
+        "december 2026[^.]{0,160}?\\b(not reversible|cannot be undone|cannot be reversed|permanently disabled)",
+        "\\b(not reversible|cannot be undone|cannot be reversed)\\b[^.]{0,160}?december 2026",
+        "default change[^.]{0,80}?\\bnot reversible"
+      ],
+      "$note": "Wzorce sa wyrazeniami regularnymi. Sam zwrot \"not reversible\" jest poprawny w zdaniu o ostatecznym usunieciu w 2027, wiec liczy sie tylko obok grudnia 2026 - inaczej bramka odrzucalaby wlasne, poprawne zdanie."
+    },
+    {
+      "key": "limit-dzienny",
+      "claim": "The free tier is 200 messages a day, with no paid tier that lifts it.",
+      "source": "https://msgwing.com",
+      "verified": "2026-08-29",
+      "contradictions": [
+        "500 messages a day",
+        "1000 messages a day",
+        "1,000 messages a day",
+        "unlimited messages",
+        "no sending limit",
+        "no daily limit"
+      ]
+    },
+    {
+      "key": "adres-nadawcy",
+      "claim": "Mail leaves from a generated @msgwing.com address. Sending from your own domain is not supported.",
+      "source": "docs/APPS.md",
+      "verified": "2026-08-29",
+      "contradictions": [
+        "send from your own domain",
+        "use your own domain as the sender",
+        "keeps your domain in the From"
+      ]
+    },
+    {
+      "key": "czestotliwosc-kontroli",
+      "claim": "The healthcheck is scheduled every 15 minutes, but GitHub delays scheduled runs, so the measured median gap is roughly 45 minutes. Any page stating a real-world cadence must say the measured one, not the cron.",
+      "source": "tools/build-uptime-card.py",
+      "verified": "2026-08-29",
+      "contradictions": [
+        "runs every 15 minutes, not a static image",
+        "checked every 15 minutes",
+        "a real check that runs against"
+      ]
+    },
+    {
+      "key": "dkim-nie-szyfruje",
+      "claim": "DKIM is a signature - authenticity and integrity. It does not encrypt anything. Confidentiality in transit comes from TLS.",
+      "source": "https://www.rfc-editor.org/rfc/rfc6376",
+      "verified": "2026-08-29",
+      "contradictions": [
+        "encrypted with DKIM",
+        "DKIM encryption",
+        "DKIM encrypts"
+      ]
+    }
+  ]
+}

--- a/tools/check-facts.py
+++ b/tools/check-facts.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Refuse a page that contradicts a claim this project makes elsewhere.
+
+On 2026-08-29 sixteen generated pages were found saying the end-of-December-2026
+change "cannot be undone", while docs/EXCHANGE-ONLINE-SMTP-AUTH.md had said the
+opposite - correctly - for weeks. Microsoft's own post says an administrator can
+re-enable it. The site was arguing with itself about the single date this whole
+project is built around, and the wrong half was on sixteen pages because a
+generator produced it.
+
+The same day, an assistant asked to assess this project for business use called
+it doubtful. Those two facts belong together: a reader who finds two of our
+pages disagreeing discounts both, and that reader is now often a machine
+deciding whether to cite us at all. Consistency is not tidiness here - it is
+whether the project gets recommended.
+
+So the claims that appear on more than one page live in data/facts.json with
+the phrasings that contradict them, and this refuses a build where any page
+carries one.
+
+    python tools/check-facts.py
+"""
+
+import json
+import pathlib
+import re
+import sys
+
+KORZEN = pathlib.Path(__file__).resolve().parent.parent
+DANE = KORZEN / "data" / "facts.json"
+
+# Sprawdzane sa strony publikowane i zrodla, ktore je generuja - bo naprawa
+# samej strony bez generatora zostaje cofnieta przy najblizszym przebiegu.
+OBSZAR = [
+    (KORZEN / "docs", "*.md"),
+    (KORZEN / "docs" / "clients", "*.md"),
+    (KORZEN / "docs" / "apps", "*.md"),
+    (KORZEN / "docs" / "errors", "*.md"),
+    (KORZEN / "docs" / "devices", "*.md"),
+    (KORZEN / "tools", "*.py"),
+    (KORZEN, "README.md"),
+]
+
+# Ten plik z definicji zawiera kazdy sprzeczny zwrot, i tools/check-facts.py
+# tez - inaczej nie mialyby czego szukac.
+POMIN = {"facts.json", "check-facts.py"}
+
+
+def sciezki():
+    widziane = set()
+    for katalog, wzor in OBSZAR:
+        if not katalog.exists():
+            continue
+        for p in sorted(katalog.glob(wzor)):
+            if p.name in POMIN or p in widziane:
+                continue
+            widziane.add(p)
+            yield p
+
+
+def main():
+    dane = json.loads(DANE.read_text(encoding="utf-8"))
+    fakty = dane["facts"]
+
+    puste = [f["key"] for f in fakty if not f.get("contradictions")]
+    if puste:
+        print("Facts with nothing to check against - a fact with no")
+        print("contradiction listed is a comment, not a gate:")
+        for k in puste:
+            print(f"  {k}")
+        return 1
+
+    trafienia = []
+    for p in sciezki():
+        tekst = p.read_text(encoding="utf-8", errors="replace")
+        maly = tekst.lower()
+        for f in fakty:
+            for zwrot in f["contradictions"]:
+                m = re.search(zwrot, maly, re.S)
+                if m:
+                    nr = maly[: m.start()].count(chr(10)) + 1
+                    trafienia.append(
+                        (p.relative_to(KORZEN).as_posix(), nr, f["key"],
+                         m.group(0)[:70], f["claim"])
+                    )
+
+    if trafienia:
+        print("Pages contradicting a claim this project makes elsewhere:")
+        widziane = set()
+        for sciezka, nr, klucz, zwrot, claim in trafienia:
+            print(f"  {sciezka}:{nr}  says {zwrot!r}")
+            if klucz not in widziane:
+                widziane.add(klucz)
+                print(f"    the agreed claim ({klucz}) is:")
+                print(f"    {claim}")
+        print()
+        print("Fix it in the generator, not the page, or the next build puts it")
+        print("back. If the claim itself has changed, change data/facts.json and")
+        print("say where the new wording was verified.")
+        return 1
+
+    print(f"{len(fakty)} shared claims, no page contradicts one.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Two things happened on 2026-08-29, and they are the same thing.

**Sixteen generated pages** said the end-of-December-2026 change *"cannot be undone"*, while `docs/EXCHANGE-ONLINE-SMTP-AUTH.md` had said the opposite — correctly — for weeks. The site was arguing with itself about the single date this project is built around, and the wrong half was on sixteen pages because a generator produced it.

**The same day**, an assistant asked to assess this project for business use returned *doubtful*.

Those belong together. A reader who finds two of our pages disagreeing discounts both — and that reader is now often a machine deciding whether to cite us at all. Consistency here is not tidiness. It is whether the project gets recommended.

## What lands

Claims that appear on more than one page now live in `data/facts.json` with the phrasings that contradict them, and CI refuses a build carrying one. Five to start — **every one a claim this project actually got wrong, or nearly got wrong, this week**:

| claim | what it guards against |
|---|---|
| December 2026 is a default change an admin can undo | the sixteen-page contradiction, fixed hours earlier |
| 200 messages a day, no tier lifts it | a limit quietly inflating in marketing copy |
| mail leaves from a generated address, never your own domain | the single most tempting overclaim here |
| the healthcheck's real cadence is measured, not the cron's 15 minutes | corrected on the site *and* in the README today |
| DKIM signs, it does not encrypt | caught before publication, in text handed to me for the privacy page |

## It failed twice before it worked, and both failures are worth recording

**First version matched substrings** — and fired immediately on our own *correct* sentence: *"what is not reversible is the final removal in 2027"*. A gate that cries wolf is switched off within a week. Patterns are now expressions requiring proximity: `not reversible` counts only beside `December 2026`.

**The regex change then silently blinded it.** It reported `no page contradicts one` while comparing regex source as literal substrings — matching nothing. **Passing because it could no longer see**, which is the worst way for a check to pass, and indistinguishable from success without a deliberate break.

## Proven by breaking three things

| planted | outcome |
|---|---|
| the exact sentence shipped this morning | **refused** — names file and line |
| `December 2026 is permanently disabled` | **refused** by the proximity pattern |
| `not reversible … final removal 2027` | **silent** — correctly |