### PR TITLE
fix(metrics): npm weekly totals are the same trap clones were

### DIFF
--- a/tools/metrics.py
+++ b/tools/metrics.py
@@ -57,6 +57,51 @@ LICZNIKI = [
 ]
 
 
+def npm(pakiet):
+    """Daily download series for one npm package, and an honest reading of it.
+
+    Added 2026-08-29 after "594 downloads a week" was nearly written into a
+    board goal. The series behind it was:
+
+        0 0 0 0 0 0 0 496 22 23 36 12 2 3
+
+    One day of 496 and a tail in single figures. The weekly total is the
+    496 - a mirror or a scanner picking the package up once - and reporting
+    it as reach would have repeated exactly the mistake traffic/clones cost
+    this company three decisions ago.
+
+    So the weekly total is shown as contaminated and the median of the days
+    that actually had downloads is shown as the number to use.
+    """
+    import urllib.request
+    adres = f"https://api.npmjs.org/downloads/range/last-month/{pakiet}"
+    try:
+        with urllib.request.urlopen(adres, timeout=20) as o:
+            d = json.load(o)
+    except Exception as e:
+        # 404 z rejestru npm znaczy "pakiet nie jest opublikowany", a nie
+        # awarie. Cel 4 wisi na tym odczycie, wiec musi odrozniac brak
+        # publikacji od braku odpowiedzi.
+        kod = getattr(e, "code", None)
+        if kod == 404:
+            return None, "jeszcze nieopublikowany"
+        return None, f"nie odczytano ({type(e).__name__})"
+
+    dni = [x["downloads"] for x in d.get("downloads", [])]
+    if not dni:
+        return None, "brak danych"
+
+    ostatnie = dni[-14:]
+    niezerowe = sorted(x for x in ostatnie if x)
+    if not niezerowe:
+        return {"mediana": 0, "suma7": sum(dni[-7:]), "szczyt": 0, "dni": ostatnie}, None
+
+    mediana = niezerowe[len(niezerowe) // 2]
+    szczyt = max(ostatnie)
+    return {"mediana": mediana, "suma7": sum(dni[-7:]), "szczyt": szczyt,
+            "dni": ostatnie}, None
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--all", action="store_true",
@@ -99,6 +144,21 @@ def main():
         print("   skad ludzie (unikalnych, 14 dni)")
         for r in ref:
             print(f"      {r['uniques']:>4}  {r['referrer']}")
+
+    for pakiet in ("zerosmtp-check", "zerosmtp-mcp"):
+        w, blad = npm(pakiet)
+        print()
+        if blad:
+            print(f"   npm {pakiet}: {blad}")
+            continue
+        print(f"   npm {pakiet} (14 dni)")
+        print(f"      mediana dnia z pobraniami       {w['mediana']:>6}   <- ta liczba")
+        print(f"      najwiekszy pojedynczy dzien     {w['szczyt']:>6}")
+        print(f"    ! suma 7 dni                      {w['suma7']:>6}   "
+              f"zanieczyszczona przez szczyt, NIE uzywac")
+        print(f"      szereg: {' '.join(str(x) for x in w['dni'])}")
+        brudne.append(f"npm {pakiet}: suma tygodniowa - jeden dzien potrafi byc "
+                      f"lustrem, patrz na mediane")
 
     if brudne:
         print()


### PR DESCRIPTION
**"594 downloads a week"** was four words away from being written into a board goal. The series behind it:

```
0 0 0 0 0 0 0 496 22 23 36 12 2 3
```

One day of **496** and a tail in single figures. The weekly total *is* the 496 — a mirror or a scanner picking the package up once. The honest reading is the median of days that had any downloads at all: **22, and falling.**

This is exactly what `traffic/clones` cost this company three decisions ago, arriving through a different door.

## Same treatment, not a note somebody has to remember

| line | shown as |
|---|---|
| median of days with downloads | **the number to use** |
| largest single day | named, so the spike is visible |
| 7-day total | under the **contaminated** heading |
| the raw series | printed beside all three |

Nobody has to trust the summary — the fourteen daily figures are right there.

## 404 is not a failure

An unpublished package now reports *"jeszcze nieopublikowany"* rather than `HTTPError`. **Goal 4** — the AI channel, measured by `zerosmtp-mcp` installs, since nobody installs an MCP server except to plug it into an assistant — hangs on that reading. A metric that cannot tell *"nobody installed it"* from *"the registry did not answer"* is worse than no metric.