### PR TITLE
fix(docs): the page listed Paperless-ngx as missing, one paragraph below its own row

### DIFF
--- a/data/apps.json
+++ b/data/apps.json
@@ -180,5 +180,32 @@
       "source": "https://docs.paperless-ngx.com/configuration/",
       "source_title": "Configuration"
     }
+  ],
+  "$not_covered_comment": "Kandydaci zmierzeni 2026-08-27 jako zerowe pokrycie. Generator odejmuje od tej listy wszystko, co ma juz wpis - inaczej strona wymienia jako brakujaca aplikacje, ktorej strona stoi akapit wyzej. Tak wlasnie bylo z Paperless-ngx.",
+  "not_covered": [
+    {
+      "name": "Netdata",
+      "slug": "netdata"
+    },
+    {
+      "name": "Jellyfin",
+      "slug": "jellyfin"
+    },
+    {
+      "name": "Paperless-ngx",
+      "slug": "paperless-ngx"
+    },
+    {
+      "name": "Portainer",
+      "slug": "portainer"
+    },
+    {
+      "name": "changedetection.io",
+      "slug": "changedetection"
+    },
+    {
+      "name": "Wiki.js",
+      "slug": "wikijs"
+    }
   ]
 }

--- a/docs/SELF-HOSTED.md
+++ b/docs/SELF-HOSTED.md
@@ -24,7 +24,7 @@ Each page names the exact settings, quotes where they came from, and states the 
 
 ## What is not here
 
-Netdata, Jellyfin, Paperless-ngx, Portainer, changedetection.io and Wiki.js are all in the same position and are not covered yet. They are missing because nobody has read their documentation carefully enough to name the settings without guessing, not because they do not fit.
+Netdata, Jellyfin, Portainer, changedetection.io and Wiki.js are all in the same position and are not covered yet. They are missing because nobody has read their documentation carefully enough to name the settings without guessing, not because they do not fit.
 
 [Tell us which one you run](https://github.com/msgwing/ZeroSMTP/issues/new/choose) and it moves up the list.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1088,7 +1088,7 @@ Each page names the exact settings, quotes where they came from, and states the 
 
 ## What is not here
 
-Netdata, Jellyfin, Paperless-ngx, Portainer, changedetection.io and Wiki.js are all in the same position and are not covered yet. They are missing because nobody has read their documentation carefully enough to name the settings without guessing, not because they do not fit.
+Netdata, Jellyfin, Portainer, changedetection.io and Wiki.js are all in the same position and are not covered yet. They are missing because nobody has read their documentation carefully enough to name the settings without guessing, not because they do not fit.
 
 [Tell us which one you run](https://github.com/msgwing/ZeroSMTP/issues/new/choose) and it moves up the list.
 

--- a/tools/build-app-pages.py
+++ b/tools/build-app-pages.py
@@ -146,7 +146,18 @@ def zbuduj(wpis, aktualizacja, t):
     return "\n".join(czesci)
 
 
-def zbuduj_indeks(wpisy, aktualizacja):
+def przecinki(nazwy):
+    """Angielska lista z "and" przed ostatnim elementem.
+
+    Bez tego strona konczy sie "Portainer, changedetection.io, Wiki.js are all",
+    co czyta sie jak urwane zdanie - a te strony sa produktem, nie notatka.
+    """
+    if len(nazwy) == 1:
+        return nazwy[0]
+    return ", ".join(nazwy[:-1]) + " and " + nazwy[-1]
+
+
+def zbuduj_indeks(wpisy, aktualizacja, nieobjete=()):
     w = [
         "---",
         'title: "Self-hosted apps after the SMTP AUTH shutdown"',
@@ -187,11 +198,13 @@ def zbuduj_indeks(wpisy, aktualizacja):
         "",
         "## What is not here",
         "",
-        "Netdata, Jellyfin, Paperless-ngx, Portainer, changedetection.io and "
-        "Wiki.js are all in the same position and are not covered yet. They "
-        "are missing because nobody has read their documentation carefully "
-        "enough to name the settings without guessing, not because they do "
-        "not fit.",
+        (przecinki([n["name"] for n in nieobjete]) +
+         " are all in the same position and are not covered yet. They "
+         "are missing because nobody has read their documentation carefully "
+         "enough to name the settings without guessing, not because they do "
+         "not fit.") if nieobjete else
+        "Every application measured as a candidate now has a page. Tell us "
+        "which one you run and it goes on the list.",
         "",
         "[Tell us which one you run](https://github.com/msgwing/ZeroSMTP/"
         "issues/new/choose) and it moves up the list.",
@@ -271,7 +284,11 @@ def main():
         KATALOG / f"{w['slug']}.md": zbuduj(w, dane["updated"], tytuly[w["slug"]])
         for w in wpisy
     }
-    wyjscia[INDEKS] = zbuduj_indeks(wpisy, dane["updated"])
+    # Lista "czego tu nie ma" musi odejmowac to, co juz jest. Wpisana na sztywno
+    # wymienila Paperless-ngx jako brakujacy akapit pod tabela, w ktorej stal.
+    objete = {w["slug"] for w in wpisy}
+    nieobjete = [n for n in dane.get("not_covered", []) if n["slug"] not in objete]
+    wyjscia[INDEKS] = zbuduj_indeks(wpisy, dane["updated"], nieobjete)
 
     # Bramka postawiona po tym, jak pierwszy przebieg wypuscil cztery
     # odnosniki do ERROR-MESSAGES.md z katalogu docs/apps/, gdzie tego pliku


### PR DESCRIPTION
Adding Paperless-ngx yesterday left `SELF-HOSTED.md` **saying two things at once**:

- the table linked to `apps/paperless-ngx.md`
- the paragraph underneath named Paperless-ngx among the applications *"not covered yet"*

Both came from the same generator — which built the table **from data** and the list of gaps **from a hardcoded sentence**.

## Same failure as the December 2026 one, smaller

A claim written once and then left to be overtaken. It is also the kind an assistant reading the page **cannot resolve**: the two statements are equally confident and adjacent, so there is no way to tell which is stale.

## The fix

The gap list now comes from `data/apps.json` with covered slugs subtracted, so it **cannot name something that has a page**. When the list empties it says so rather than printing an empty sentence.

Also joins names with *"and"* before the last — *"Portainer, changedetection.io, Wiki.js are all in the same position"* reads as a sentence that was cut off, and these pages are the product rather than a note to ourselves.

Edge cases checked: one name, two names, and none.