### PR TITLE
fix(metrics): "not published" was wrong about a package that is published

### DIFF
--- a/tools/metrics.py
+++ b/tools/metrics.py
@@ -84,7 +84,16 @@ def npm(pakiet):
         # publikacji od braku odpowiedzi.
         kod = getattr(e, "code", None)
         if kod == 404:
-            return None, "jeszcze nieopublikowany"
+            # 404 z API pobran nie rozstrzyga. Nowy pakiet jest w rejestrze
+            # od razu, a licznik pobran rusza dopiero po dobie - wiec o zywym
+            # pakiecie miernik mowilby "nieopublikowany", co jest falszem
+            # i trafiloby do odczytu celu 4.
+            try:
+                with urllib.request.urlopen(
+                        f"https://registry.npmjs.org/{pakiet}", timeout=20):
+                    return None, "opublikowany, licznik pobran jeszcze milczy"
+            except Exception:
+                return None, "nieopublikowany"
         return None, f"nie odczytano ({type(e).__name__})"
 
     dni = [x["downloads"] for x in d.get("downloads", [])]


### PR DESCRIPTION
`zerosmtp-mcp@1.0.0` went to npm today and the metric reported it as **"jeszcze nieopublikowany"**.

Both halves of that were readable and only one was true: the **registry has it**, npm's **download API has nothing yet**, and a new package takes about a day before the counter starts.

## Why this is not cosmetic

**Goal 4** — the AI channel, measured by `zerosmtp-mcp` installs, because nobody runs an MCP server except to plug it into an assistant — is read off this line.

A metric that calls a live package unpublished puts a false premise into **exactly the decision it exists to inform**. That is the failure this company has already paid for twice: `traffic/clones`, and the npm weekly total earlier today.

## The fix

A 404 from the downloads API now asks the registry before concluding anything, and reports which of the two it is:

| situation | line |
|---|---|
| in the registry, counter silent | `opublikowany, licznik pobran jeszcze milczy` |
| genuinely absent | `nieopublikowany` |

Verified against the live package — it now reads the first.