### PR TITLE
feat(ci): nothing was watching the pull requests we send to other people

### DIFF
--- a/.github/workflows/ready-for-approval.yml
+++ b/.github/workflows/ready-for-approval.yml
@@ -406,3 +406,94 @@ jobs:
             }
 
             core.info(`oznaczonych jako zrobione-a-otwarte: ${oznaczonych}`);
+
+  # Wnioski wyslane do cudzych repozytoriow, ktorych nikt nie pilnuje.
+  #
+  # 2026-08-29 ten brak wyprodukowal dwie pomylki w jednej godzinie. Zgloszenie
+  # #216 zostalo zamkniete jako "nie kwalifikujemy sie", podczas gdy wniosek do
+  # tej listy byl otwarty od szesciu dni. Godzine wczesniej o maly wlos nie
+  # powstal drugi wniosek do `linsa-io`, bo zgloszenie nie wiedzialo o
+  # pierwszym.
+  #
+  # Wpisy w katalogach sa zmierzonym kanalem tego projektu: free-for.dev daje
+  # 20 unikalnych odwiedzajacych na 14 dni, a wszystkie nasze pozycje w
+  # wyszukiwarce GitHuba razem - 18. Niepilnowana kolejka wnioskow to
+  # niepilnowany kanal.
+  wnioski-na-zewnatrz:
+    if: github.event_name != 'issues'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const owner = context.repo.owner, repo = context.repo.repo;
+            const PROG_DNI = 21;
+
+            const wnioski = (await github.rest.search.issuesAndPullRequests({
+              q: `is:pr is:open author:${owner} -repo:${owner}/${repo}`,
+              per_page: 50,
+            })).data.items;
+
+            if (!wnioski.length) {
+              core.info('brak otwartych wnioskow na zewnatrz');
+              return;
+            }
+
+            // Zgloszenia sledzace, po numerze wniosku w tresci lub komentarzu.
+            const zgloszenia = (await github.rest.issues.listForRepo({
+              owner, repo, state: 'all', labels: 'listing', per_page: 100,
+            })).data;
+
+            const dzis = Date.now();
+            const stare = [], sieroty = [], zamkniete = [];
+
+            for (const w of wnioski) {
+              const gdzie = w.repository_url.split('/').slice(-2).join('/');
+              const dni = Math.floor((dzis - new Date(w.created_at)) / 86400000);
+              const opis = `${gdzie}#${w.number} (${dni} dni)`;
+
+              // Ktore zgloszenie sledzi ten wniosek?
+              const sledzi = zgloszenia.filter((z) =>
+                (z.body || '').includes(gdzie) || (z.title || '').includes(gdzie));
+
+              if (!sledzi.length) { sieroty.push(opis); continue; }
+              // To jest przypadek, ktory kosztowal nas dzis pomylke: wniosek
+              // otwarty, a zgloszenie zamkniete jako zalatwione albo odrzucone.
+              if (sledzi.every((z) => z.state === 'closed')) {
+                zamkniete.push(`${opis} - a zgloszenie #${sledzi[0].number} jest zamkniete`);
+              }
+              if (dni >= PROG_DNI) stare.push(opis);
+            }
+
+            core.info(`otwartych wnioskow: ${wnioski.length}`);
+            for (const z of zamkniete) core.warning(`sprzecznosc: ${z}`);
+            for (const s of sieroty) core.notice(`bez zgloszenia sledzacego: ${s}`);
+            for (const s of stare) core.notice(`bez odpowiedzi >= ${PROG_DNI} dni: ${s}`);
+
+            // Zamkniete zgloszenie przy otwartym wniosku jest sprzecznoscia,
+            // nie przypomnieniem - dlatego tylko ono zaklada zgloszenie.
+            if (!zamkniete.length) return;
+
+            const TYTUL = 'Wniosek otwarty, zgloszenie zamkniete';
+            const istnieje = (await github.rest.issues.listForRepo({
+              owner, repo, state: 'open', per_page: 100,
+            })).data.find((i) => i.title === TYTUL);
+            if (istnieje) {
+              core.info(`juz zgloszone: #${istnieje.number}`);
+              return;
+            }
+
+            await github.rest.issues.create({
+              owner, repo, title: TYTUL,
+              body: [
+                'Te wnioski sa otwarte w cudzych repozytoriach, a zgloszenia,',
+                'ktore je sledza, sa u nas zamkniete:', '',
+                ...zamkniete.map((z) => `- ${z}`), '',
+                'Jedno z dwojga jest nieprawda. Albo wniosek trzeba wycofac,',
+                'albo zgloszenie otworzyc z powrotem - i to drugie zdarzylo sie',
+                '2026-08-29, gdy #216 zamknieto jako "nie kwalifikujemy sie",',
+                'a wniosek do tej samej listy czekal otwarty od szesciu dni.',
+              ].join('\n'),
+            });


### PR DESCRIPTION
**Two mistakes in one hour today, both from the same gap.**

#216 was closed as *"we do not qualify"* while a pull request to that exact list had been open for **six days** — adding `zerosmtp-check` to their command-line tools section, not to the `Email Clients` section the radar matched and I read. An hour earlier a second pull request to `linsa-io` was one command from being opened, because the tracking issue did not know the first existed.

## Why this is a channel problem, not tidiness

`free-for.dev` sends **20** unique visitors in 14 days. Every position this project holds in GitHub's own search sends **18**, combined. An unwatched submission queue is an unwatched channel.

## What it reports, and what it escalates

| case | action |
|---|---|
| PR open in someone else's repo, **tracking issue closed** | **opens an issue** — one of the two is wrong |
| PR with no tracking issue at all | notice |
| no response for 21 days | notice |

Only the contradiction raises an issue, because that is the case that cost us today.

## Run against live data before committing — it found four things nobody knew about

| pull request | age | state |
|---|---|---|
| `sdras/awesome-actions#882` | **27 days** | no tracking issue |
| `jonathandion/awesome-emails#122` | **26 days** | no tracking issue |
| `LlamaGenAI/awesome-free-saas#104` | 17 days | issue #203 **closed** |
| `Mindbaz/awesome-opensource-email#43` | 7 days | issue #208 **closed** |

## The first test run was wrong in a believable way

It reported **all seven as orphans and zero contradictions**. The issue list had come back empty because the subprocess read crashed on cp1250 decoding — so every match failed, and the failure looked exactly like a finding.

A check that cannot read its own inputs reports absence, and absence is precisely what this one exists to report.