### PR TITLE
fix(docs): security.txt 404'd at the address it calls canonical

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -251,11 +251,6 @@ defaults:
         How ZeroSMTP compares to SMTP2GO, Brevo and MailerSend: no DNS
         setup vs. sending from your own verified domain.
 
-# Jekyll skips dot-prefixed paths, so RFC 9116 needs this line or
-# .well-known/security.txt is never published.
-include:
-  - ".well-known"
-
 exclude:
   - assets/*.py
 

--- a/docs/security-txt.md
+++ b/docs/security-txt.md
@@ -1,3 +1,7 @@
+---
+permalink: /.well-known/security.txt
+layout: null
+---
 # Security contact information for msgwing.com and docs.msgwing.com
 # https://www.rfc-editor.org/rfc/rfc9116
 


### PR DESCRIPTION
The file was in the repository, `include: [".well-known"]` was in `_config.yml`, and Pages built successfully after the commit.

**The URL still returned 404** — checked three times, cache-busted, and against the `github.io` host as well.

Jekyll on GitHub Pages does not publish a dot-prefixed directory even when `include` names it. That include was written on the assumption it would, and **never verified after deploying** — which is how a file that declares itself canonical at an address ends up not being there.

A page with `permalink: /.well-known/security.txt` sidesteps the question entirely: Jekyll generates it at that path regardless of what the source file is called.

`include` is removed rather than left in as decoration for something that did not work.