### PR TITLE
feat(docs): three ways in, above a table of twenty

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -251,11 +251,6 @@ defaults:
         How ZeroSMTP compares to SMTP2GO, Brevo and MailerSend: no DNS
         setup vs. sending from your own verified domain.
 
-# Jekyll skips dot-prefixed paths, so RFC 9116 needs this line or
-# .well-known/security.txt is never published.
-include:
-  - ".well-known"
-
 exclude:
   - assets/*.py
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -388,6 +388,35 @@
       }
       .site-header nav a:hover { color:var(--ink); border-bottom-color:var(--accent); }
 
+      /* Trzy drogi wejscia. Tabela "Start here" ma dwadziescia wierszy i jest
+         kompletna - to jej zaleta i jej wada. Serwisant, administrator i
+         programista musza ja przeczytac, zeby znalezc swoj jeden wiersz.
+         Karty nie zastepuja tabeli, tylko staja nad nia: nazywaja role, kazda
+         prowadzi w trzy miejsca, reszta zostaje nizej dla wszystkich innych. */
+      .paths { display:grid; gap:14px; margin:1.6rem 0 2rem;
+        grid-template-columns:repeat(auto-fit,minmax(min(100%,240px),1fr)); }
+      .path {
+        display:flex; flex-direction:column; padding:16px 18px;
+        border:1px solid var(--line); border-left:4px solid var(--accent);
+        border-radius:10px; background:var(--panel);
+      }
+      .path:hover { border-color:var(--line-strong); border-left-color:var(--accent); }
+      .path h3 {
+        margin:0 0 .2rem; font-size:1rem; font-weight:700; color:var(--ink);
+        border:0; padding:0;
+      }
+      .path p { margin:0 0 .7rem; font-size:.84rem; color:var(--muted); }
+      .path ul { list-style:none; margin:auto 0 0; padding:0; }
+      .path li { margin:0; padding:.22rem 0; font-size:.88rem; }
+      .path li + li { border-top:1px dashed var(--line); }
+      .path a { color:var(--link); font-weight:600; text-decoration:none; }
+      .path a:hover { text-decoration:underline; }
+      .path .kto {
+        font-family:var(--mono); font-size:.64rem; letter-spacing:.12em;
+        text-transform:uppercase; color:var(--accent); font-weight:700;
+        margin-bottom:.35rem;
+      }
+
       /* ---------- live relay status ---------- */
       .relay-status {
         display:inline-flex; align-items:center; gap:.45rem;

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,41 @@ tool and [the alternatives page](ALTERNATIVES.md) says which one is right.
 
 ## Start here
 
+<div class="paths">
+  <div class="path">
+    <span class="kto">Serwis i drukarki</span>
+    <h3>A printer or scanner stopped emailing</h3>
+    <p>Scan-to-email died, the panel shows an authentication error, or the device refuses the certificate.</p>
+    <ul>
+      <li><a href="PRINTERS.html">Setup by brand</a> — Canon, Epson, Brother, HP, Ricoh, Kyocera, Xerox</li>
+      <li><a href="DEVICE-COMPATIBILITY.html">Does my model have OAuth firmware?</a></li>
+      <li><a href="PRINTER-CERTIFICATE-ERROR.html">It will not trust the certificate</a></li>
+    </ul>
+  </div>
+  <div class="path">
+    <span class="kto">Administracja</span>
+    <h3>You run the servers this breaks</h3>
+    <p>Find out what else in the environment sends mail with a password before December finds it for you.</p>
+    <ul>
+      <li><a href="AFFECTED-SYSTEMS.html">What breaks, and when</a></li>
+      <li><a href="WINDOWS-SERVER.html">Windows Server / IIS</a> · <a href="LINUX.html">Linux</a></li>
+      <li><a href="SELF-HOSTED.html">Gitea, Vaultwarden, Immich, Authelia, Paperless</a></li>
+    </ul>
+  </div>
+  <div class="path">
+    <span class="kto">Programowanie</span>
+    <h3>Your code or app cannot send</h3>
+    <p>The library printed a summary of the error rather than the error. Start from the string you actually have.</p>
+    <ul>
+      <li><a href="LIBRARY-ERRORS.html">What your library said vs. what the server said</a></li>
+      <li><a href="CODE-EXAMPLES.html">21 runnable examples, 19 languages</a></li>
+      <li><a href="WORDPRESS.html">WordPress and WooCommerce</a></li>
+    </ul>
+  </div>
+</div>
+
+Everything else is in the table further down — these three cover most of it.
+
 **If you have an error in front of you right now, skip the table:**
 
 ```bash

--- a/docs/security-txt.md
+++ b/docs/security-txt.md
@@ -1,3 +1,7 @@
+---
+permalink: /.well-known/security.txt
+layout: null
+---
 # Security contact information for msgwing.com and docs.msgwing.com
 # https://www.rfc-editor.org/rfc/rfc9116
 


### PR DESCRIPTION
The `Start here` table is complete, and that is both its strength and its problem: **twenty rows of "if you…"**, and a printer technician, a sysadmin and a developer each have to read all of it to find their one line.

## Three cards, one per audience named

| card | leads to |
|---|---|
| **A printer or scanner stopped emailing** | setup by brand · OAuth firmware list · certificate refusal |
| **You run the servers this breaks** | what breaks and when · Windows / Linux · self-hosted apps |
| **Your code cannot send** | what your library said vs. the server · 21 runnable examples · WordPress |

**The table stays.** The other seventeen rows are real and somebody needs each of them. The cards are a shortcut past it, not a replacement.

## Theme tokens only

No colour literal anywhere in the component, so it follows the reader's light or dark setting rather than assuming one.

That is not taste. **Near-white text on a hardcoded near-white box is the bug this site shipped earlier today**, and `check-theme-colors.py` now refuses it — this component was written against that gate.

## Links checked, not assumed

Every target verified against the file it points at before committing. `SELF-HOSTED`, `LIBRARY-ERRORS` and `WORDPRESS` are all new enough this week that assuming they exist would have been careless.