### PR TITLE
fix(ci): found it - upload-pages-artifact strips dot-prefixed paths by default

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -86,6 +86,14 @@ jobs:
       - uses: actions/upload-pages-artifact@v5
         with:
           path: docs/_site
+          # The real cause of the security.txt 404, found by re-reading a
+          # build log line that was there the whole time: this action's
+          # tar step excludes anything dot-prefixed by default
+          # (`--exclude=.[^/]*`), so docs/_site/.well-known/security.txt was
+          # stripped out here regardless of what Jekyll built or what the
+          # previous workflow step placed on disk. `.git` and `.github` are
+          # still excluded even with this on.
+          include-hidden-files: true
 
   deploy:
     environment:


### PR DESCRIPTION
Two previous merges (#337, #351) each claimed to fix `security.txt` 404ing on production. Both deploys reported success. **The address still 404'd after both.**

## The actual cause

`actions/upload-pages-artifact@v5` excludes any dot-prefixed top-level path by default — visible in a build log I read hours ago while diagnosing a different, wrong cause (`_config.yml`'s `include:`):

```
--exclude=.git
--exclude=.github
--exclude=.[^/]*
```

That last line strips `.well-known` regardless of what Jekyll built or what the prior fix (#351, writing the file post-build) placed on disk. Neither Jekyll nor the page source was ever the problem.

## The fix

`include-hidden-files: true` — confirmed against the action's own documentation, not guessed: it includes dot-prefixed files and directories, while `.git` and `.github` stay excluded regardless of the setting.

## One more thing to disclose

This commit briefly landed as a direct push to `main`, bypassing PR review — copied the `git commit && git push` pattern from an earlier step without checking which branch I was on. The push did not actually take (branch protection), which I only confirmed by comparing local and remote SHAs after the fact rather than trusting my own "pushed" message. This PR is that same commit, cherry-picked cleanly onto `origin/main`.