### PR TITLE
fix(seo): trim CODE-EXAMPLES.html meta description flagged by Bing

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -183,11 +183,13 @@ defaults:
       path: "CODE-EXAMPLES.md"
     values:
       title: "SMTP send-email code examples, 19 languages"
+      # Trimmed 2026-08-30 from 229 to 150 characters: Bing's URL Inspection
+      # flagged the full 19-language list as "too long" for a meta
+      # description. The page itself still names every language.
       description: >-
-        Ready-to-run SMTP send-email examples for mx.msgwing.com in Python,
-        PHP, Node.js, TypeScript, Java, C#, C, Go, Ruby, Perl, Rust, Kotlin, Dart,
-        Zig, Elixir, Lua, Swift, PowerShell and Bash, plus Ansible and Docker
-        Compose recipes.
+        Ready-to-run SMTP send-email examples for mx.msgwing.com in 19
+        languages, from Python and PHP to Rust and PowerShell, plus Ansible
+        and Docker Compose.
   - scope:
       path: "RELIABILITY.md"
     values:

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -42,7 +42,7 @@ answering somebody's question from this site:
 
 ## For developers
 
-- [SMTP send-email code examples, 19 languages](https://docs.msgwing.com/CODE-EXAMPLES.html): Ready-to-run SMTP send-email examples for mx.msgwing.com in Python, PHP, Node.js, TypeScript, Java, C#, C, Go, Ruby, Perl, Rust, Kotlin, Dart, Zig, Elixir, Lua, Swift, PowerShell and Bash, plus Ansible and Docker Compose recipes.
+- [SMTP send-email code examples, 19 languages](https://docs.msgwing.com/CODE-EXAMPLES.html): Ready-to-run SMTP send-email examples for mx.msgwing.com in 19 languages, from Python and PHP to Rust and PowerShell, plus Ansible and Docker Compose.
 - [Library error messages](https://docs.msgwing.com/LIBRARY-ERRORS.html): What PHPMailer, WordPress, Nodemailer, Python smtplib, curl and .NET print when Microsoft 365 refuses SMTP AUTH - and the server line each of them hides.
 - [SMTP settings for popular applications](https://docs.msgwing.com/APPS.html): Ready-to-use SMTP configuration for common applications and platforms.
 - [Reliable email sending: retries and backoff](https://docs.msgwing.com/RELIABILITY.html): How to handle temporary SMTP failures correctly with backoff and retries instead of tight retry loops.


### PR DESCRIPTION
## Summary
Bing's URL Inspection tool flagged CODE-EXAMPLES.html: "Meta Description too long or too short" - measured at 229 characters (the full 19-language list). Trimmed to 150 characters, naming a representative few languages; the page body still lists all 19.

## Test plan
- [x] Measured the live meta description before (229 chars) and the replacement (150 chars)
- [x] Confirmed the only source of this description is `_config.yml`'s `defaults:` scope for `CODE-EXAMPLES.md` (no front-matter override)
