### PR TITLE
chore(seo): remove dead HowTo structured data (Google retired it in 2023)

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -132,7 +132,6 @@ defaults:
         Fix scan-to-email after Microsoft 365 disables Basic auth. Per-brand
         SMTP settings for Ricoh, Canon, Xerox, HP, Kyocera, Konica Minolta,
         Sharp and more.
-      schema: printers-howto
       widget: printers
   - scope:
       path: "TROUBLESHOOTING.md"

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -139,41 +139,6 @@
       ]
     }
     </script>
-    {% elsif page.schema == "printers-howto" %}
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "HowTo",
-      "name": "Configure a network printer to send scan-to-email through ZeroSMTP",
-      "description": "Set up scan-to-email on a network printer or multifunction device using a free SMTP relay that still accepts plain username and password authentication.",
-      "supply": [
-        { "@type": "HowToSupply", "name": "A free ZeroSMTP account (msgwing.com)" },
-        { "@type": "HowToSupply", "name": "Network access to the printer's web admin interface" }
-      ],
-      "step": [
-        {
-          "@type": "HowToStep",
-          "name": "Get credentials",
-          "text": "Register a free account at msgwing.com and activate it, then copy the randomly generated @msgwing.com username and password."
-        },
-        {
-          "@type": "HowToStep",
-          "name": "Enter the connection settings",
-          "text": "In the printer's SMTP or outgoing-email settings, enter server mx.msgwing.com, port 587 with STARTTLS (or 465 with SSL/TLS), enable authentication, and enter the @msgwing.com username and password."
-        },
-        {
-          "@type": "HowToStep",
-          "name": "Find the setting in your printer's menu",
-          "text": "The exact menu path varies by brand: HP, Canon, Ricoh, Kyocera, Xerox, Konica Minolta, Sharp, Brother, Epson and Lexmark are each documented with their vendor's own current instructions."
-        },
-        {
-          "@type": "HowToStep",
-          "name": "Send a test scan-to-email",
-          "text": "Send a test scan to your own inbox. If it fails, check the printer's event log for an authentication or TLS error and re-verify the connection settings."
-        }
-      ]
-    }
-    </script>
     {% elsif page.schema == "dataset" %}
     {%- comment -%}
       The compatibility list and the error corpus are the only things here that


### PR DESCRIPTION
## Summary
Removed the `HowTo` JSON-LD structured data on `PRINTERS.html`. Verified today against Google's own current documentation: the HowTo rich result was fully retired in September 2023 - "no longer shown in search results, on both desktop and mobile devices", for any site, regardless of markup correctness. This block has produced nothing since before this project existed.

`FAQPage` (used on `FAQ.html`) is untouched: it's not deprecated, only restricted (also since September 2023) to government/health sites for the visual rich result - the markup still has value for general structured-data understanding at zero maintenance cost, so it stays.

## Test plan
- [x] Confirmed via Google's own docs (`developers.google.com/search/docs/appearance/structured-data/how-to`) that this feature is fully retired, not just narrowed
- [x] Checked the Liquid `{% if %}/{% elsif %}/{% endif %}` chain in `docs/_layouts/default.html` stays well-formed after removal (faq -> dataset -> reference)
- [x] Grepped the repo for any other reference to `printers-howto` - none outside this diff
