### PR TITLE
docs: replace unmeasurable deliverability claims with checkable facts

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -243,34 +243,38 @@ sonstige kommerzielle Zwecke verarbeitet.
 
 ## Sicherheit und Zustellbarkeit
 
-**✓ Verbesserte Domain-Reputation**: Die Reputation der Domain msgwing.com wurde
-verbessert, strenge Anti-Spam-Maßnahmen sind in Kraft. Alle Spam-Konten wurden
-gesperrt und entfernt, damit die Zustellbarkeit für rechtmäßige Nutzer optimal
-bleibt.
+**Was wir tun:**
+- SPF, DKIM und DMARC (`p=reject`) sind für `msgwing.com` korrekt ausgerichtet
+  — prüfen Sie es selbst: `dig txt msgwing.com`, `dig txt _dmarc.msgwing.com`.
+- Konten, die den Relay missbrauchen, werden aktiv entfernt (siehe
+  [FAQ](docs/FAQ.md#why-is-zerosmtp-free-whats-the-catch)).
+- Der Versand ist pro Konto ratenbegrenzt, damit die Reputation der
+  gemeinsamen Domain für alle gut bleibt (siehe
+  [Versandlimits](docs/TROUBLESHOOTING.md#sending-limits-rate-limiting)).
 
-### Domain-Reputation selbst prüfen
+**Was wir nicht versprechen:** eine gemeinsame Domain bedeutet ein
+gemeinsames Risiko. Kein einzelnes Konto kontrolliert die Reputation des
+gesamten Pools — anders als bei einer eigenen Domain, wo nur Sie sie
+beschädigen können. Muss die Post von Ihrer eigenen Domain kommen, ist
+ZeroSMTP das falsche Werkzeug — siehe
+[Alternativen](docs/ALTERNATIVES.md).
 
-Sie möchten die Reputation von msgwing.com nachprüfen? Das können Sie selbst
-über [mail-tester.com](https://mail-tester.com/) tun:
+**Was wir nicht offenlegen, und warum:** siehe
+[SECURITY.md](SECURITY.md#infrastructure-and-third-party-integration-inquiries).
+
+### Selbst nachprüfen
+
+Glauben Sie uns nicht einfach — testen Sie es mit
+[mail-tester.com](https://mail-tester.com/):
 
 1. Legen Sie auf [msgwing.com](https://msgwing.com) ein kostenloses SMTP-Konto an
 2. Verwenden Sie unser PowerShell-Testskript: [SendEmailTest_mail-tester.com.ps1](SendEmailTest_mail-tester.com.ps1)
 3. Lassen Sie sich auf mail-tester.com eine zufällige Adresse erzeugen und senden Sie eine Testnachricht von Ihrer @msgwing.com-Adresse
 4. Sehen Sie sich die Bewertung und die ausführliche Analyse an
 
-**✓ Sicherheitsverbesserungen**: Wir haben den Dienst msgwing.com umfassend
-abgesichert — darunter verbesserte Authentifizierungsverfahren, erweiterte
-Missbrauchsüberwachung und gehärtete Infrastruktur.
-
 ---
 
 Bei Fragen erreichen Sie uns unter: abuse@msgwing.com
-
-Gute Zustellbarkeit • Zufälliges Konto mit guter Reputation • Keine Kosten •
-Volle Privatsphäre • Funktioniert mit allem
-
-Fangen Sie noch heute an zu versenden — vollständig kostenlos und ohne
-versteckte Regeln!
 
 Die Registrierung finden Sie unter: https://msgwing.com
 

--- a/README.md
+++ b/README.md
@@ -341,26 +341,35 @@ We respect your privacy - your data is not processed for any marketing or commer
 
 ## Security & Deliverability
 
-**✓ Domain Reputation Enhanced**: The msgwing.com domain reputation has been improved, with strict anti-spam measures enforced. All spam accounts have been blocked and removed to ensure optimal email deliverability for legitimate users.
+**What we do:**
+- SPF, DKIM and DMARC (`p=reject`) are aligned on `msgwing.com` — check it
+  yourself: `dig txt msgwing.com`, `dig txt _dmarc.msgwing.com`.
+- Accounts that abuse the relay are actively removed (see
+  [FAQ](docs/FAQ.md#why-is-zerosmtp-free-whats-the-catch)).
+- Sending is rate-limited per account to keep the shared domain's reputation
+  good for everyone (see
+  [sending limits](docs/TROUBLESHOOTING.md#sending-limits-rate-limiting)).
 
-### Verify Your Domain Reputation
+**What we don't promise:** a shared domain means shared risk. No single
+account controls the reputation of the whole pool, unlike your own domain,
+where you're the only one who can damage it. If mail must come from your own
+domain, ZeroSMTP is the wrong tool — see [Alternatives](docs/ALTERNATIVES.md).
 
-Interested in checking the reputation of msgwing.com? You can test this yourself using [mail-tester.com](https://mail-tester.com/):
+**What we don't disclose, and why:** see
+[SECURITY.md](SECURITY.md#infrastructure-and-third-party-integration-inquiries).
+
+### Test it yourself
+
+Don't take our word for it — check with [mail-tester.com](https://mail-tester.com/):
 
 1. Create a free SMTP account at [msgwing.com](https://msgwing.com)
 2. Use our PowerShell test script: [SendEmailTest_mail-tester.com.ps1](SendEmailTest_mail-tester.com.ps1)
 3. Generate a random email at mail-tester.com and send a test message from your @msgwing.com address
-4. Check the reputation score and detailed analysis
-
-**✓ Security Improvements**: We have implemented comprehensive security enhancements to the msgwing.com service, including improved authentication protocols, enhanced abuse monitoring, and strengthened infrastructure security measures.
+4. Read the score and the detailed analysis
 
 ---
 
 If you have any questions, feel free to contact us: abuse@msgwing.com
-
-Great deliverability • Random high-reputation account • No costs • Full privacy • Works with everything
-
-Start sending emails today - completely free and with no hidden rules!
 
 Registration is available at: https://msgwing.com
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -243,26 +243,37 @@ Dbamy o Twoją prywatność - Twoje dane nie są przetwarzane w żadnych celach 
 
 ## Bezpieczeństwo i Dostarczalność
 
-**✓ Poprawa Reputacji Domeny**: Reputacja domeny msgwing.com została znacznie poprawiona, a wszystkie konta spamowe zostały zablokowane i usunięte. Gwarantujemy optymalną dostarczalność dla wszystkich legytymnych użytkowników.
+**Co robimy:**
+- SPF, DKIM i DMARC (`p=reject`) są skonfigurowane spójnie na `msgwing.com` —
+  sprawdź sam: `dig txt msgwing.com`, `dig txt _dmarc.msgwing.com`.
+- Konta nadużywające relay są aktywnie usuwane (zobacz
+  [FAQ](docs/FAQ.md#why-is-zerosmtp-free-whats-the-catch)).
+- Wysyłka jest limitowana per konto, żeby reputacja współdzielonej domeny
+  pozostała dobra dla wszystkich (zobacz
+  [limity wysyłki](docs/TROUBLESHOOTING.md#sending-limits-rate-limiting)).
 
-### Sprawdź Reputację Domeny Samodzielnie
+**Czego nie obiecujemy:** współdzielona domena to współdzielone ryzyko.
+Żadne pojedyncze konto nie kontroluje reputacji całej puli — inaczej niż przy
+własnej domenie, gdzie tylko Ty możesz ją zepsuć. Jeśli poczta musi wychodzić
+z Twojej własnej domeny, ZeroSMTP jest złym wyborem — zobacz
+[Alternatywy](docs/ALTERNATIVES.md).
 
-Chcesz zweryfikować reputację msgwing.com? Możesz to zrobić samodzielnie za pomocą [mail-tester.com](https://mail-tester.com/):
+**Czego nie ujawniamy i dlaczego:** zobacz
+[SECURITY.md](SECURITY.md#infrastructure-and-third-party-integration-inquiries).
+
+### Sprawdź to sam
+
+Nie musisz wierzyć nam na słowo — zweryfikuj to za pomocą
+[mail-tester.com](https://mail-tester.com/):
 
 1. Utwórz darmowe konto SMTP na stronie [msgwing.com](https://msgwing.com)
 2. Użyj naszego skryptu PowerShell: [SendEmailTest_mail-tester.com.ps1](SendEmailTest_mail-tester.com.ps1)
 3. Wygeneruj losowy email na mail-tester.com i wyślij wiadomość testową z Twojego adresu @msgwing.com
-4. Sprawdź wynik reputacji i szczegółową analizę
-
-**✓ Poprawki Bezpieczeństwa**: Wdrożyliśmy kompleksowe ulepszeń bezpieczeństwa usługi msgwing.com, w tym ulepszony protokół autoryzacji, wzmocnione monitorowanie nadużyć i ulepszony bezpieczeństwo infrastruktury.
+4. Sprawdź wynik i szczegółową analizę
 
 ---
 
 Jeśli masz pytania, napisz do nas: abuse@msgwing.com
-
-Dobra dostarczalność • Losowa reputacja konta • Zero kosztów • Pełna prywatność • Działa z wszystkim
-
-Zacznij wysyłać maile już dziś - całkowicie za darmo i bez żadnych ukrytych zasad!
 
 Rejestracja odbywa się na stronie: https://msgwing.com
 

--- a/docs/ALTERNATIVES.md
+++ b/docs/ALTERNATIVES.md
@@ -20,7 +20,7 @@ part is standard. What differs is what happens *before* you can use them.
 | **Time to first email** | ~2 minutes | Minutes to 48 hours (DNS propagation) |
 | **DNS records to configure** | None | SPF + DKIM (and DMARC, recommended) |
 | **Sends from your own domain** | ❌ shared `@msgwing.com` address | ✅ once verified |
-| **Sender reputation** | Managed for you — shared domain, actively monitored for abuse | Yours to build and protect — a fresh domain/IP has no reputation yet, and one bad list wrecks it |
+| **Sender reputation** | Shared — actively monitored for abuse, but no single account controls the whole pool's reputation | Yours alone to build and protect — a fresh domain/IP has no reputation yet, but you're the only one who can wreck it |
 | **Free tier** | 200/day, permanent | 100/month to 12,000/month — [the numbers are below](#what-the-free-tiers-actually-allow) |
 | **Credit card required** | No | Usually no |
 | **Best fit** | Printers, NAS units, scripts, legacy devices — anything that just needs mail to leave, from anyone | Apps and products sending under your own brand |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1339,7 +1339,7 @@ part is standard. What differs is what happens *before* you can use them.
 | **Time to first email** | ~2 minutes | Minutes to 48 hours (DNS propagation) |
 | **DNS records to configure** | None | SPF + DKIM (and DMARC, recommended) |
 | **Sends from your own domain** | ❌ shared `@msgwing.com` address | ✅ once verified |
-| **Sender reputation** | Managed for you — shared domain, actively monitored for abuse | Yours to build and protect — a fresh domain/IP has no reputation yet, and one bad list wrecks it |
+| **Sender reputation** | Shared — actively monitored for abuse, but no single account controls the whole pool's reputation | Yours alone to build and protect — a fresh domain/IP has no reputation yet, but you're the only one who can wreck it |
 | **Free tier** | 200/day, permanent | 100/month to 12,000/month — [the numbers are below](#what-the-free-tiers-actually-allow) |
 | **Credit card required** | No | Usually no |
 | **Best fit** | Printers, NAS units, scripts, legacy devices — anything that just needs mail to leave, from anyone | Apps and products sending under your own brand |


### PR DESCRIPTION
## Summary

The "Security & Deliverability" section claimed things nobody measures:
"Domain Reputation Enhanced", "Security Improvements... comprehensive...
strengthened", "Great deliverability", "Random high-reputation account".
Replaced with three claims that are checkable today, in every place this
section is stated (README.md, README.pl.md, README.de.md):

- **SPF, DKIM and DMARC aligned on `msgwing.com`.** Verified against live
  DNS before writing it, not assumed:
  - `dig txt msgwing.com` → `v=spf1 mx ip4:77.55.193.153 -all`
  - `dig txt _dmarc.msgwing.com` → `v=DMARC1; p=reject`
  - DKIM signing was already documented (`docs/PRIVACY.md`,
    `docs/TROUBLESHOOTING.md`: "Mail leaving the relay is DKIM-signed").
- **Abuse accounts are actively removed** — wording matched to
  `docs/FAQ.md`'s existing phrasing, not restated differently.
- **Sending is rate-limited per account** — wording matched to
  `docs/FAQ.md` and `docs/TROUBLESHOOTING.md#sending-limits-rate-limiting`.

Added what the old copy never said: a shared domain is shared risk — no
single account controls the whole pool's reputation, unlike an owner's own
domain. `docs/ALTERNATIVES.md:23` framed "Managed for you" as a pure
upside with no such caveat; reworded so both pages describe the same
trade-off the same way, per the "consistency is the job" rule this role
runs on.

Also added a link to `SECURITY.md#infrastructure-and-third-party-integration-inquiries`
for what's deliberately not disclosed, instead of leaving the reader to
wonder — content unchanged there, only linked.

## Scope note

The task named README.md and docs/ALTERNATIVES.md. I also updated
README.pl.md and README.de.md: they carried the identical vague claims
word-for-word, and leaving them untouched would have recreated the exact
"two surfaces, two claims" inconsistency this change exists to remove.

## Test plan

- [x] `dig txt msgwing.com` / `dig txt _dmarc.msgwing.com` run and output
      matches what's now claimed in the copy (see above).
- [x] Grepped all four files for the removed phrases
      ("Domain Reputation", "Great deliverability", "Random
      high-reputation", and their PL/DE equivalents) — zero matches left.
- [x] Confirmed no new number or limit was introduced that isn't already
      stated elsewhere (FAQ.md, TROUBLESHOOTING.md) — only linked, not
      duplicated with different wording.
- [ ] Reviewer: confirm the FAQ/SECURITY.md anchors resolve on the
      rendered GitHub page.
