### PR TITLE
ci: last comment not ours is a gate now, not a rule (#265)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -355,6 +355,24 @@ jobs:
       - name: Type-check TypeScript example
         run: npm run typecheck
 
+  # Logika decydujaca, czy ostatni komentarz na jakims otwartym watku jest
+  # nasz - uzywana przez `czeka-czlowiek` i `zalegle-zewnetrzne` w
+  # ready-for-approval.yml. Wydzielona i testowana tutaj zamiast wewnatrz
+  # YAML, bo #265 pokazal, jak drogo kosztuje logika, ktorej nikt nie
+  # przetestowal na przypadku, ktory ma ja wywolac - patrz
+  # tools/unanswered-external.test.js, ktory zawiera dokladnie te dane.
+  unanswered-external:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+      - name: "Ostatni komentarz nie nasz: bramka i test na przypadku #265"
+        run: node --test tools/unanswered-external.test.js
+
   zerosmtp-mcp:
     needs: changes
     if: needs.changes.outputs.code == 'true'

--- a/.github/workflows/ready-for-approval.yml
+++ b/.github/workflows/ready-for-approval.yml
@@ -166,73 +166,247 @@ jobs:
   #
   # Przypisanie wlasciciela jest tu calym mechanizmem: GitHub wysyla list
   # tylko do przypisanego. Etykieta pilnuje, zeby zrobic to raz.
+  #
+  # NAPRAWIONE 2026-08-30, patrz #265. Ta kontrola pytala dotad "czy AUTOR
+  # ZGLOSZENIA jest czlowiekiem z zewnatrz, i czy KIEDYKOLWIEK odpowiedzielismy
+  # gdziekolwiek w watku". #265 zostalo otwarte przez wlasciciela (`msgwing`),
+  # wiec nie przechodzilo nawet pierwszego warunku - mimo ze ostatni komentarz,
+  # od prawdziwego czlowieka z zewnatrz (`k4its1t`, association: none), czekal
+  # SZESC DNI bez odpowiedzi. Znalezione przypadkiem, przy okazji zupelnie
+  # innego zadania - dokladnie taka cisza mogla trwac w nieskonczonosc.
+  #
+  # Wlasciwe pytanie: kto napisal OSTATNIA rzecz w watku, niezaleznie od tego,
+  # kto go otworzyl i czy odpowiadalismy wczesniej. Logika jest w
+  # `tools/unanswered-external.js`, testowana na prawdziwych danych #265 w
+  # `tools/unanswered-external.test.js` - wydzielona z YAML zeby dalo sie ja
+  # przetestowac raz, zamiast ufac skladni sklejonej w kroku workflow.
   czeka-czlowiek:
     if: github.event_name != 'issues'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
       pull-requests: write
     steps:
+      - uses: actions/checkout@v7
       - uses: actions/github-script@v9
         with:
           script: |
+            const { ocenWatek } = await import(
+              `${process.env.GITHUB_WORKSPACE}/tools/unanswered-external.js`);
+
             const owner = context.repo.owner, repo = context.repo.repo;
             const PROG_H = 4;
             const ETYKIETA = 'czeka-czlowiek';
+            const ACK = 'Ten komentarz zostal dodany automatycznie';
             const granica = Date.now() - PROG_H * 3600 * 1000;
 
             const watki = (await github.rest.issues.listForRepo({
               owner, repo, state: 'open', per_page: 100, sort: 'created',
             })).data;
 
-            let oznaczonych = 0;
+            let oznaczonych = 0, odznaczonych = 0;
             for (const w of watki) {
-              const autor = w.user && w.user.login;
-              // Nasze wlasne zgloszenia i boty nie sa "czlowiekiem z zewnatrz".
-              if (!autor || autor === owner) continue;
-              if (w.user.type === 'Bot' || /\[bot\]$/.test(autor)) continue;
-              if ((w.labels || []).some(l => l.name === ETYKIETA)) continue;
-              if (new Date(w.created_at).getTime() > granica) continue;
-
-              // Czy ktokolwiek z naszej strony juz sie odezwal?
               const kom = (await github.rest.issues.listComments({
                 owner, repo, issue_number: w.number, per_page: 100,
               })).data;
-              let odpowiedziano = kom.some(k => k.user && k.user.login === owner);
 
-              if (!odpowiedziano && w.pull_request) {
-                const rec = (await github.rest.pulls.listReviews({
+              let rec = [];
+              if (w.pull_request) {
+                rec = (await github.rest.pulls.listReviews({
                   owner, repo, pull_number: w.number, per_page: 100,
                 })).data;
-                odpowiedziano = rec.some(r => r.user && r.user.login === owner);
               }
-              if (odpowiedziano) continue;
 
-              const godzin = Math.round((Date.now() - new Date(w.created_at).getTime()) / 3600000);
+              const { czeka, ostatniZewnetrzny, jujAcked } =
+                ocenWatek(w, kom, rec, owner, ACK);
+              const maEtykiete = (w.labels || []).some(l => l.name === ETYKIETA);
+
+              if (!czeka) {
+                // Ostatnie slowo jest teraz nasze - jesli bylo oznaczone
+                // wczesniej, przestalo to byc prawda i etykieta ma to
+                // odzwierciedlac, zeby liczyla sie do biezacego stanu, a nie
+                // do historii.
+                if (maEtykiete) {
+                  await github.rest.issues.removeLabel({
+                    owner, repo, issue_number: w.number, name: ETYKIETA,
+                  });
+                  core.notice('Zdjeto etykiete #' + w.number + ' - odpowiedziano.');
+                  odznaczonych++;
+                }
+                continue;
+              }
+
+              if (new Date(ostatniZewnetrzny.at).getTime() > granica) continue;
+
+              if (!maEtykiete) {
+                try {
+                  await github.rest.issues.createLabel({
+                    owner, repo, name: ETYKIETA, color: 'D93F0B',
+                    description: 'Ostatni komentarz jest od kogos z zewnatrz - czeka na nasza odpowiedz.',
+                  });
+                } catch (e) { /* juz istnieje */ }
+                await github.rest.issues.addLabels({
+                  owner, repo, issue_number: w.number, labels: [ETYKIETA],
+                });
+                await github.rest.issues.addAssignees({
+                  owner, repo, issue_number: w.number, assignees: [owner],
+                });
+              }
+
+              // Juz raz potwierdzone dla tego samego ostatniego komentarza -
+              // nie dublowac "dziekujemy" przy kazdym przebiegu co dwie godziny.
+              if (jujAcked) continue;
+
+              const godzin = Math.round(
+                (Date.now() - new Date(ostatniZewnetrzny.at).getTime()) / 3600000);
               const NL = String.fromCharCode(10);
 
-              await github.rest.issues.addLabels({
-                owner, repo, issue_number: w.number, labels: [ETYKIETA],
-              });
-              await github.rest.issues.addAssignees({
-                owner, repo, issue_number: w.number, assignees: [owner],
-              });
               await github.rest.issues.createComment({
                 owner, repo, issue_number: w.number,
                 body: [
-                  '@' + autor + ' - dziekujemy, widzimy to i odpowiemy.',
+                  '@' + ostatniZewnetrzny.autor + ' - dziekujemy, widzimy to i odpowiemy.',
                   '',
-                  'Ten komentarz zostal dodany automatycznie po ' + godzin
+                  ACK + ' po ' + godzin
                     + ' godzinach bez odpowiedzi z naszej strony. Nie zastepuje',
                   'odpowiedzi - jest po to, zeby watek nie utknal niezauwazony.',
                 ].join(NL),
               });
-              core.notice('Oznaczono #' + w.number + ' od @' + autor + ' - czeka ' + godzin + 'h');
+              core.notice('Oznaczono #' + w.number + ' od @' + ostatniZewnetrzny.autor + ' - czeka ' + godzin + 'h');
               oznaczonych++;
             }
 
-            if (oznaczonych === 0) {
-              core.info('Nikt z zewnatrz nie czeka dluzej niz ' + PROG_H + 'h.');
+            if (oznaczonych === 0 && odznaczonych === 0) {
+              core.info('Nikt z zewnatrz nie czeka dluzej niz ' + PROG_H + 'h, nic sie nie zmienilo.');
+            }
+
+  # `czeka-czlowiek` powyzej powiadamia natychmiast (4h) o pojedynczym watku.
+  # To jest druga polowa zadania wlasciciela z 2026-08-30: jeden zbiorczy
+  # widok, zeby nie trzeba bylo pamietac o przegladaniu 17 osobnych zgloszen,
+  # i eskalacja dla tych, ktore mimo powiadomienia stoja dluzej niz cykl
+  # pracy (3 dni) - dokladnie tak dlugo stalo #265, zanim ktos je znalazl.
+  #
+  # Jedna, samoaktualizujaca sie pozycja - ten sam wzorzec co dashboard
+  # kolejki CI w jobie `waiting` ponizej: tytul jest markerem, wiec kolejny
+  # przebieg edytuje te sama pozycje zamiast mnozyc zgloszenia, i zamyka ja
+  # sama, gdy kolejka jest pusta.
+  zalegle-zewnetrzne:
+    if: github.event_name != 'issues'
+    needs: czeka-czlowiek
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const { ocenWatek } = await import(
+              `${process.env.GITHUB_WORKSPACE}/tools/unanswered-external.js`);
+
+            const owner = context.repo.owner, repo = context.repo.repo;
+            const ETYKIETA = 'czeka-czlowiek';
+            const ACK = 'Ten komentarz zostal dodany automatycznie';
+            const PROG_DNI = 3;
+            const granica = Date.now() - PROG_DNI * 86400_000;
+            const TYTUL = 'Zewnetrzne komentarze bez odpowiedzi';
+            const ZALEGLE = 'stan:zalegle';
+            const NL = String.fromCharCode(10);
+            const TICK = String.fromCharCode(96);
+
+            // `czeka-czlowiek` juz odfiltrowal - kazdy wpis tutaj naprawde
+            // ma ostatnie slowo od kogos z zewnatrz. Wiek liczymy jednak z
+            // TEGO SAMEGO zrodla co tamten job (data ostatniego zewnetrznego
+            // komentarza), a nie z `updated_at` zgloszenia - `updated_at`
+            // zmienia sie przy kazdym dodaniu/zdjeciu etykiety, wiec sam nic
+            // nie mowi o tym, jak dawno ktos naprawde napisal.
+            const watki = (await github.rest.issues.listForRepo({
+              owner, repo, state: 'open', labels: ETYKIETA, per_page: 100,
+            })).data;
+
+            const ocenione = [];
+            for (const w of watki) {
+              const kom = (await github.rest.issues.listComments({
+                owner, repo, issue_number: w.number, per_page: 100,
+              })).data;
+              let rec = [];
+              if (w.pull_request) {
+                rec = (await github.rest.pulls.listReviews({
+                  owner, repo, pull_number: w.number, per_page: 100,
+                })).data;
+              }
+              const wynik = ocenWatek(w, kom, rec, owner, ACK);
+              if (wynik.czeka) ocenione.push({ w, ostatni: wynik.ostatniZewnetrzny });
+            }
+
+            let dotknietych = 0;
+            for (const { w, ostatni } of ocenione) {
+              if (new Date(ostatni.at).getTime() > granica) continue;
+              if ((w.labels || []).some(l => l.name === ZALEGLE)) continue;
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: w.number, labels: [ZALEGLE],
+              });
+              dotknietych++;
+            }
+            if (dotknietych) core.notice(dotknietych + ' watek(ow) przekroczylo ' + PROG_DNI + ' dni - oznaczone ' + ZALEGLE + '.');
+
+            const dashboard = (await github.rest.issues.listForRepo({
+              owner, repo, state: 'open', labels: ZALEGLE, per_page: 100,
+            })).data.filter(i => i.title === TYTUL);
+
+            if (!ocenione.length) {
+              for (const i of dashboard) {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: i.number,
+                  body: 'Kolejka pusta - kazdy zewnetrzny komentarz ma odpowiedz. Zamykam.',
+                });
+                await github.rest.issues.update({
+                  owner, repo, issue_number: i.number, state: 'closed',
+                });
+              }
+              core.info('Zaden otwarty watek nie czeka na zewnetrznego czlowieka.');
+              return;
+            }
+
+            const wiekDni = (at) =>
+              Math.floor((Date.now() - new Date(at).getTime()) / 86400_000);
+            const posortowane = [...ocenione].sort(
+              (a, b) => new Date(a.ostatni.at) - new Date(b.ostatni.at));
+
+            const wiersze = posortowane.slice(0, 20).map(
+              ({ w, ostatni }) => '| ' + wiekDni(ostatni.at) + ' dni | #' + w.number +
+                   ' | @' + ostatni.autor + ' | ' +
+                   TICK + (w.title || '').replace(/\|/g, '\\|').slice(0, 50) + TICK + ' |');
+
+            const body = [
+              '**' + ocenione.length + ' otwarty(ch) watek(ow), gdzie ostatnie slowo nie jest nasze.**',
+              '',
+              'Zbudowane po tym, jak #265 czekalo 6 dni bez odpowiedzi na konkretne',
+              'pytanie techniczne - otwarte przez wlasciciela, wiec dotychczasowy',
+              'nadzor patrzacy na autora zgloszenia go nie widzial. Ta lista patrzy',
+              'na autora OSTATNIEGO komentarza, nie na to, kto otworzyl watek.',
+              '',
+              'Watki starsze niz ' + PROG_DNI + ' dni dostaja dodatkowo etykiete `' + ZALEGLE + '`.',
+              '',
+              '| Czeka | Watek | Kto czeka | Tytul |',
+              '|---|---|---|---|',
+              ...wiersze,
+              '',
+              '_To zgloszenie zamknie sie samo, gdy kazdy watek dostanie odpowiedz._',
+            ].join(NL);
+
+            if (dashboard.length) {
+              await github.rest.issues.update({
+                owner, repo, issue_number: dashboard[0].number, body,
+              });
+              core.notice('Zaktualizowano #' + dashboard[0].number);
+            } else {
+              const issue = await github.rest.issues.create({
+                owner, repo, title: TYTUL, body, labels: [ZALEGLE],
+              });
+              core.notice('Utworzono ' + issue.data.html_url);
             }
 
   waiting:

--- a/tools/unanswered-external.js
+++ b/tools/unanswered-external.js
@@ -1,0 +1,72 @@
+// Decyduje, czy watek (issue albo PR) czeka teraz na PRAWDZIWA odpowiedz
+// kogos z naszej strony (`owner` = login wlasciciela repo, ktorym dziala caly
+// zespol). Wydzielone z .github/workflows/ready-for-approval.yml, zeby dalo
+// sie to przetestowac raz (`tools/unanswered-external.test.js`), zamiast
+// ufac logice sklejonej wewnatrz YAML.
+//
+// Mechanika naprawiona 2026-08-30, patrz #265: stara wersja pytala
+// "czy AUTOR ZGLOSZENIA jest czlowiekiem z zewnatrz, i czy KIEDYKOLWIEK
+// odpowiedzielismy gdziekolwiek w tym watku". #265 zostalo otwarte przez
+// wlasciciela (`msgwing`), wiec nie przechodzilo nawet pierwszego warunku -
+// mimo ze ostatni komentarz, od prawdziwego czlowieka z zewnatrz
+// (`k4its1t`, authorAssociation: NONE), czekal 6 dni bez odpowiedzi.
+//
+// Wlasciwe pytanie brzmi: kto napisal OSTATNIA rzecz w tym watku - my, czy
+// ktos z zewnatrz - niezaleznie od tego, kto go otworzyl i czy odpowiadalismy
+// wczesniej.
+
+export function jestZewnetrzny(login, typ, owner) {
+  if (!login) return false;
+  if (login === owner) return false;
+  if (typ === 'Bot') return false;
+  if (/\[bot\]$/.test(login)) return false;
+  return true;
+}
+
+/**
+ * @param {{number:number, user:{login:string,type:string}, created_at:string, pull_request?:object}} watek
+ * @param {Array<{user:{login:string,type:string}, created_at:string, body:string}>} komentarze
+ * @param {Array<{user:{login:string,type:string}, submitted_at:string}>} recenzje - tylko PR-y; puste dla issue
+ * @param {string} owner - login wlasciciela repo
+ * @param {string} ackMarker - fragment tekstu wlasnego automatycznego
+ *   potwierdzenia; taki komentarz nie liczy sie jako prawdziwa odpowiedz,
+ *   zeby watek nie zostal cichaczem uznany za zalatwiony przez wlasny bot
+ * @returns {{czeka:boolean, ostatniZewnetrzny:({at:string,autor:string}|null), ostatniNasz:(string|null), jujAcked:boolean}}
+ */
+export function ocenWatek(watek, komentarze, recenzje, owner, ackMarker) {
+  let ostatniZewnetrzny = jestZewnetrzny(
+    watek.user && watek.user.login, watek.user && watek.user.type, owner)
+    ? { at: watek.created_at, autor: watek.user.login }
+    : null;
+  let ostatniNasz = null;
+  let ostatniAck = null;
+
+  for (const k of komentarze || []) {
+    const login = k.user && k.user.login;
+    const typ = k.user && k.user.type;
+    if (login === owner) {
+      if (!ostatniNasz || k.created_at > ostatniNasz) ostatniNasz = k.created_at;
+    } else if (jestZewnetrzny(login, typ, owner)) {
+      if (!ostatniZewnetrzny || k.created_at > ostatniZewnetrzny.at) {
+        ostatniZewnetrzny = { at: k.created_at, autor: login };
+      }
+    } else if ((typ === 'Bot' || /\[bot\]$/.test(login)) &&
+               (k.body || '').includes(ackMarker)) {
+      if (!ostatniAck || k.created_at > ostatniAck) ostatniAck = k.created_at;
+    }
+  }
+
+  // Recenzja PR-a (zatwierdzenie, prosba o zmiany, komentarz recenzyjny) jest
+  // odpowiedzia tak samo jak zwykly komentarz - GitHub liczy je osobno.
+  for (const r of recenzje || []) {
+    if (r.user && r.user.login === owner && r.submitted_at) {
+      if (!ostatniNasz || r.submitted_at > ostatniNasz) ostatniNasz = r.submitted_at;
+    }
+  }
+
+  const czeka = !!ostatniZewnetrzny &&
+    (!ostatniNasz || ostatniZewnetrzny.at > ostatniNasz);
+  const jujAcked = czeka && !!ostatniAck && ostatniAck > ostatniZewnetrzny.at;
+
+  return { czeka, ostatniZewnetrzny, ostatniNasz, jujAcked };
+}

--- a/tools/unanswered-external.test.js
+++ b/tools/unanswered-external.test.js
@@ -1,0 +1,137 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ocenWatek, jestZewnetrzny } from './unanswered-external.js';
+
+const OWNER = 'msgwing';
+const ACK = 'Ten komentarz zostal dodany automatycznie';
+
+// Dane ponizej sa prawdziwe - pobrane z `gh issue view 265 --json ...` w dniu
+// naprawy. To jest retrospektywny test wymagany przy tej zmianie: gdyby ta
+// bramka istniala wczesniej, czy zlapalaby #265?
+
+test('#265 retrospektywnie: stan sprzed odpowiedzi wlasciciela - MUSI zostac zlapane', () => {
+  const watek = {
+    number: 265,
+    user: { login: 'msgwing', type: 'User' },     // zgloszenie otworzyl WLASCICIEL
+    created_at: '2026-08-23T12:33:41Z',
+  };
+  const komentarze = [
+    { user: { login: 'k4its1t', type: 'User' }, created_at: '2026-08-24T09:57:16Z', body: '...' },
+    { user: { login: 'k4its1t', type: 'User' }, created_at: '2026-08-24T09:59:37Z', body: '...' },
+    // Zero komentarzy od wlasciciela w tym oknie - dokladnie stan trwajacy
+    // od 2026-08-24 09:59 do 2026-08-30 15:39 (szesc dni).
+  ];
+
+  const wynik = ocenWatek(watek, komentarze, [], OWNER, ACK);
+
+  assert.equal(
+    wynik.czeka, true,
+    'Stara logika ("czy autor ZGLOSZENIA jest z zewnatrz") przegapila #265 ' +
+    'przez 6 dni, bo zgloszenie otworzyl wlasciciel. Ta bramka patrzy na ' +
+    'OSTATNI komentarz, nie na autora zgloszenia.');
+  assert.equal(wynik.ostatniZewnetrzny.autor, 'k4its1t');
+});
+
+test('#265 retrospektywnie: po prawdziwej odpowiedzi wlasciciela - rozwiazane', () => {
+  const watek = {
+    number: 265,
+    user: { login: 'msgwing', type: 'User' },
+    created_at: '2026-08-23T12:33:41Z',
+  };
+  const komentarze = [
+    { user: { login: 'k4its1t', type: 'User' }, created_at: '2026-08-24T09:57:16Z', body: '...' },
+    { user: { login: 'k4its1t', type: 'User' }, created_at: '2026-08-24T09:59:37Z', body: '...' },
+    { user: { login: 'msgwing', type: 'User' }, created_at: '2026-08-30T15:39:14Z', body: '...' },
+  ];
+
+  const wynik = ocenWatek(watek, komentarze, [], OWNER, ACK);
+
+  assert.equal(wynik.czeka, false, 'ostatni komentarz jest teraz nasz - nic nie czeka');
+});
+
+test('zepsute celowo: druga wiadomosc po naszej JEDYNEJ odpowiedzi - stara logika ("czy KIEDYKOLWIEK odpowiedzielismy") mylila sie tutaj tak samo jak w #265', () => {
+  const watek = {
+    number: 999,
+    user: { login: 'ktos-z-zewnatrz', type: 'User' },
+    created_at: '2026-08-01T00:00:00Z',
+  };
+  const komentarze = [
+    { user: { login: OWNER, type: 'User' }, created_at: '2026-08-01T01:00:00Z', body: 'odpowiedz' },
+    { user: { login: 'ktos-z-zewnatrz', type: 'User' }, created_at: '2026-08-10T00:00:00Z', body: 'a co z tym drugim pytaniem?' },
+  ];
+
+  const wynik = ocenWatek(watek, komentarze, [], OWNER, ACK);
+
+  assert.equal(
+    wynik.czeka, true,
+    'druga wiadomosc, zadana po naszej jedynej odpowiedzi, zostaje bez ' +
+    'odpowiedzi - "odpowiedzielismy kiedykolwiek" nie jest tym samym co ' +
+    '"odpowiedzielismy na to ostatnie".');
+});
+
+test('wlasny automatyczny komentarz potwierdzajacy nie liczy sie jako odpowiedz, ale nie dubluje sie', () => {
+  const watek = {
+    number: 1,
+    user: { login: 'ktos-z-zewnatrz', type: 'User' },
+    created_at: '2026-08-01T00:00:00Z',
+  };
+  const komentarze = [
+    {
+      user: { login: 'github-actions[bot]', type: 'Bot' },
+      created_at: '2026-08-01T05:00:00Z',
+      body: ACK + ' po 4 godzinach bez odpowiedzi z naszej strony.',
+    },
+  ];
+
+  const wynik = ocenWatek(watek, komentarze, [], OWNER, ACK);
+
+  assert.equal(wynik.czeka, true, 'potwierdzenie to nie odpowiedz - watek nadal czeka na prawdziwa');
+  assert.equal(wynik.jujAcked, true, 'ale juz raz potwierdzone - nie trzeba dublowac komentarza');
+});
+
+test('bot niebedacy naszym potwierdzeniem (np. dependabot) nie liczy sie ani jako odpowiedz, ani jako czlowiek z zewnatrz', () => {
+  const watek = {
+    number: 2,
+    user: { login: OWNER, type: 'User' },
+    created_at: '2026-08-01T00:00:00Z',
+  };
+  const komentarze = [
+    { user: { login: 'dependabot[bot]', type: 'Bot' }, created_at: '2026-08-02T00:00:00Z', body: 'Superseded by #3.' },
+  ];
+
+  const wynik = ocenWatek(watek, komentarze, [], OWNER, ACK);
+
+  assert.equal(wynik.czeka, false, 'zaden prawdziwy czlowiek z zewnatrz nic tu nie napisal');
+});
+
+test('recenzja PR-a (bez zwyklego komentarza) liczy sie jako nasza odpowiedz', () => {
+  const watek = {
+    number: 3,
+    user: { login: 'kontrybutor', type: 'User' },
+    created_at: '2026-08-01T00:00:00Z',
+    pull_request: {},
+  };
+  const recenzje = [{ user: { login: OWNER, type: 'User' }, submitted_at: '2026-08-01T06:00:00Z' }];
+
+  const wynik = ocenWatek(watek, [], recenzje, OWNER, ACK);
+
+  assert.equal(wynik.czeka, false);
+});
+
+test('jestZewnetrzny odrzuca wlasciciela i boty, przyjmuje prawdziwych ludzi', () => {
+  assert.equal(jestZewnetrzny(OWNER, 'User', OWNER), false);
+  assert.equal(jestZewnetrzny('cos[bot]', 'User', OWNER), false);
+  assert.equal(jestZewnetrzny('ktos', 'Bot', OWNER), false);
+  assert.equal(jestZewnetrzny('k4its1t', 'User', OWNER), true);
+});
+
+test('brak jakiejkolwiek aktywnosci od zewnetrznego czlowieka - nic nie czeka', () => {
+  const watek = {
+    number: 4,
+    user: { login: OWNER, type: 'User' },
+    created_at: '2026-08-01T00:00:00Z',
+  };
+  const wynik = ocenWatek(watek, [], [], OWNER, ACK);
+  assert.equal(wynik.czeka, false);
+});


### PR DESCRIPTION
## Dlaczego

`czeka-czlowiek` w `ready-for-approval.yml` mial byc dokladnie tym mechanizmem, ktory zlapie #265 - i nie zlapal, przez dwa bledy naraz:

1. Sprawdzal **autora zgloszenia**, nie autora ostatniego komentarza. #265 otworzyl wlasciciel (`msgwing`), wiec watek nigdy nie przechodzil pierwszego warunku - mimo ze ostatni komentarz, od prawdziwego czlowieka z zewnatrz (`k4its1t`, `authorAssociation: NONE`), czekal 6 dni.
2. Sprawdzal, czy wlasciciel **kiedykolwiek** skomentowal w watku, nie czy jego komentarz jest **ostatni**. Odpowiedz raz nie zamyka sprawy, jesli po niej przyszlo kolejne pytanie.

Zbudowana teraz bramka pyta o wlasciwa rzecz: kto napisal ostatnia rzecz w watku, niezaleznie od tego, kto go otworzyl.

## Co sie zmienilo

- **`tools/unanswered-external.js`** - logika wydzielona z YAML (funkcja `ocenWatek`), zeby dalo sie ja przetestowac raz zamiast ufac skladni sklejonej w kroku workflow.
- **`tools/unanswered-external.test.js`** - `node --test`, w tym retrospektywny test na prawdziwych danych #265 (przed i po odpowiedzi wlasciciela) i jeden przypadek celowo zepsuty (druga wiadomosc po naszej jedynej odpowiedzi - stara logika mylila sie tu identycznie jak w #265).
- **`.github/workflows/lint.yml`** - nowy job `unanswered-external` uruchamia ten test na kazdym pushu/PR. Bramka niesprawdzona nie liczy sie jako wykonana.
- **`.github/workflows/ready-for-approval.yml`**:
  - `czeka-czlowiek` naprawiony: uzywa `ocenWatek`, sciaga etykiete gdy watek zostanie naprawde odpowiedziany (zeby stan etykiety odzwierciedlal biezaca prawde, nie historie), i tworzy etykiete `czeka-czlowiek` jesli jeszcze nie istnieje (nie istniala w repo - sprawdzone, dopisana rowniez recznie na czas review).
  - Nowy job **`zalegle-zewnetrzne`**: zbiorczy, samoaktualizujacy sie dashboard (ten sam wzorzec co kolejka CI w jobie `waiting`) listujacy kazdy watek aktualnie czekajacy na nas, posortowany po wieku ostatniego zewnetrznego komentarza, z eskalacja do `stan:zalegle` po 3 dniach.

## Test na przypadku, ktory ma to wywolac (nie tylko czyste repo)

```
$ node --test tools/unanswered-external.test.js
✔ #265 retrospektywnie: stan sprzed odpowiedzi wlasciciela - MUSI zostac zlapane
✔ #265 retrospektywnie: po prawdziwej odpowiedzi wlasciciela - rozwiazane
✔ zepsute celowo: druga wiadomosc po naszej JEDYNEJ odpowiedzi - stara logika mylila sie tutaj tak samo jak w #265
✔ wlasny automatyczny komentarz potwierdzajacy nie liczy sie jako odpowiedz, ale nie dubluje sie
✔ bot niebedacy naszym potwierdzeniem (np. dependabot) nie liczy sie ani jako odpowiedz, ani jako czlowiek z zewnatrz
✔ recenzja PR-a (bez zwyklego komentarza) liczy sie jako nasza odpowiedz
✔ jestZewnetrzny odrzuca wlasciciela i boty, przyjmuje prawdziwych ludzi
✔ brak jakiejkolwiek aktywnosci od zewnetrznego czlowieka - nic nie czeka
ℹ tests 8, pass 8, fail 0
```

Odtworzona rowniez STARA logika (poza commitem, wylacznie do dowodu) i uruchomiona na tych samych dwoch przypadkach:

```
#265 (przed odpowiedzia wlasciciela): stara logika -> czeka=false (powod: "autor zgloszenia nie jest z zewnatrz")
przypadek zepsuty (druga wiadomosc po naszej jedynej odpowiedzi): stara logika -> czeka=false (powod: "wlasciciel skomentowal kiedykolwiek")
```

Obie POTWIERDZONE jako przegapione przez stara logike, zlapane przez nowa.

## Retrospektywny test na obecnym stanie repo

Przegladniete wszystkich **17 aktualnie otwartych issues** przez `ocenWatek`:

- **#265** - `ok` (rozwiazane, ostatni komentarz jest juz od `msgwing`, 2026-08-30T15:39).
- **#361** - **`CZEKA`** - `Mohitingale13` odpowiedzial 2026-08-30T11:56 z konkretna, merytoryczna walidacja (10/10 testow, zweryfikowany certyfikat), zgloszenie otworzyl `msgwing`. Zywy, biezacy przypadek dokladnie tej samej klasy co #265 - ta bramka zlapie go sama, bez czekania na kolejny przypadek.
- pozostale 15 - `ok`, bez falszywych trafien.

## Sprawdzone

- `python .github/check-workflows.py` - czysto.
- `python tools/check-control-chars.py` - czysto (239 plikow).
- `python -c "import yaml; yaml.safe_load(...)"` - workflow parsuje sie poprawnie, nowy job jest na liscie.
- Etykieta `czeka-czlowiek` nie istniala w repo (`gh label list` - 45 etykiet, zadna pasujaca) - dopisana proaktywnie (`gh label create`) i tworzona defensywnie przez workflow, ten sam wzorzec co `issue-labeler.yml`.

Nie mergowane samodzielnie.
