### PR TITLE
feat(vscode): scaffold the Basic Auth SMTP scanner extension (v1, partial)

### DIFF
--- a/packages/zerosmtp-vscode/README.md
+++ b/packages/zerosmtp-vscode/README.md
@@ -1,0 +1,78 @@
+# ZeroSMTP: Basic Auth SMTP Scanner (VS Code)
+
+Basic Auth for SMTP AUTH against Exchange Online / Microsoft 365 is being
+retired in December 2026. Anything that still logs in with a plain username
+and password to `smtp.office365.com` or `outlook.office365.com` — a printer's
+scan-to-email setup, an ASP.NET `appsettings.json`, a `.env` file, a script —
+stops sending mail on that date, silently, until someone reads the log.
+
+This extension looks for that configuration in your open workspace before it
+becomes an incident, and decodes the error once it does.
+
+## What it does today (v0.1.0, work in progress)
+
+- **`ZeroSMTP: Scan workspace for Basic Auth SMTP config`** — a text search
+  (not a parser for any one config format) across `.env` files,
+  `appsettings*.json`, `web.config`/`*.config`, and common source files, for
+  `smtp.office365.com` / `outlook.office365.com` alongside a password-looking
+  setting. Reports each hit in the Problems panel with a link to
+  [`docs.msgwing.com/EXCHANGE-ONLINE-SMTP-AUTH.html`](https://docs.msgwing.com/EXCHANGE-ONLINE-SMTP-AUTH.html).
+  If OAuth2-looking settings (`clientSecret`, `tenantId`, `accessToken`, ...)
+  are also nearby, the finding is downgraded from a warning to an
+  informational note rather than assumed fixed — this is a heuristic, not a
+  certainty, and says so in the message.
+- **`ZeroSMTP: Explain this SMTP error`** — takes the current selection (or
+  prompts for pasted text) and decodes it using the exact same error corpus
+  and matching logic as
+  [`zerosmtp-check --explain`](https://www.npmjs.com/package/zerosmtp-check):
+  this extension imports `zerosmtp-check`'s `explain()` function rather than
+  re-implementing the matching rules or duplicating `data/errors.json`.
+
+## What is not done yet
+
+This is real, working code, not a stub — both commands run and are tested —
+but it is one working session into a multi-day task, and honest about the
+gap:
+
+- **Not on the Marketplace.** Publishing needs a Visual Studio Marketplace
+  publisher agreement for a `msgwing` publisher id, which is a separate
+  system from the GitHub Marketplace listing `send-email-action` already has
+  (Azure DevOps / Personal Access Token, not a GitHub credential) — unverified
+  whether one already exists, and creating one is not something this task can
+  do on its own. `"private": true` is set so a stray `vsce publish` can't ship
+  this by accident.
+- **The `zerosmtp-check` dependency is `file:../zerosmtp-check`**, not a
+  published npm version. As of this writing, the npm registry's
+  `zerosmtp-check@1.2.1` predates the `explain`/`explainJson` exports this
+  extension calls — they exist in this repository's copy of `index.js` but
+  were never published under a new version. Before this extension is packaged
+  for real, `zerosmtp-check` needs a version bump and a publish
+  (`.github/workflows/publish-npm.yml`), and this dependency needs to switch
+  from the `file:` reference to that published semver range.
+- **The scanner is a heuristic, deliberately.** It has no test against every
+  config format in the wild (only `appsettings.json`, `web.config`, and
+  `.env` shapes are covered by `test/scanner.test.js`), and it does not parse
+  JSON/XML/YAML — it reads text, on purpose, so it works the same way
+  regardless of the file format.
+- **No icon, no `CHANGELOG.md` entries beyond this release, no
+  `@vscode/vsce` packaging step wired up.**
+
+## Free tier this points to
+
+`zerosmtp-check` and the docs this extension links to describe MsgWing's free
+relay: 200 messages a day, sent from a generated `@msgwing.com` address, not
+the user's own domain. Stated here because the extension's own messages link
+straight to that page.
+
+## Development
+
+```
+cd packages/zerosmtp-vscode
+npm install
+npm test                 # scanner.test.js - no `vscode` module needed
+```
+
+To try the commands themselves, open this folder in VS Code and press F5 to
+launch an Extension Development Host (requires `npm install` first, for the
+`zerosmtp-check` dependency and the ambient `vscode` typings VS Code provides
+at debug time).

--- a/packages/zerosmtp-vscode/extension.js
+++ b/packages/zerosmtp-vscode/extension.js
@@ -1,0 +1,149 @@
+'use strict';
+
+const vscode = require('vscode');
+const { scanText } = require('./scanner');
+
+const DIAGNOSTIC_SOURCE = 'ZeroSMTP';
+const CODE_LINK = 'https://docs.msgwing.com/EXCHANGE-ONLINE-SMTP-AUTH.html';
+
+// Kept broad on purpose: this is a grep, not a build system, so it should
+// look wherever an SMTP host or a password could plausibly be written down.
+const INCLUDE_EXTENSIONS =
+  '**/*.{cs,vb,js,mjs,cjs,ts,py,rb,php,go,java,kt,ps1,psm1,psd1,json,xml,yml,yaml,ini,properties,conf,config}';
+const INCLUDE_DOTENV = '**/.env*';
+const EXCLUDE = '**/{node_modules,.git,dist,build,bin,obj,out,.vs,vendor}/**';
+
+const MAX_FILES = 2000;
+const MAX_FILE_BYTES = 1024 * 1024; // skip anything this large - it's a text scan, not a binary one
+
+function severityToVsCode(severity) {
+  return severity === 'warning'
+    ? vscode.DiagnosticSeverity.Warning
+    : vscode.DiagnosticSeverity.Information;
+}
+
+async function findCandidateFiles() {
+  const [byExtension, dotenv] = await Promise.all([
+    vscode.workspace.findFiles(INCLUDE_EXTENSIONS, EXCLUDE, MAX_FILES),
+    vscode.workspace.findFiles(INCLUDE_DOTENV, EXCLUDE, MAX_FILES),
+  ]);
+
+  const seen = new Set();
+  const files = [];
+  for (const uri of [...byExtension, ...dotenv]) {
+    if (!seen.has(uri.fsPath)) {
+      seen.add(uri.fsPath);
+      files.push(uri);
+    }
+  }
+  return files;
+}
+
+async function scanWorkspace(diagnosticCollection, output) {
+  diagnosticCollection.clear();
+
+  const files = await findCandidateFiles();
+  let filesWithFindings = 0;
+  let totalFindings = 0;
+
+  for (const uri of files) {
+    let stat;
+    try {
+      stat = await vscode.workspace.fs.stat(uri);
+    } catch {
+      continue; // deleted between the search and the read - skip it
+    }
+    if (stat.size > MAX_FILE_BYTES) continue;
+
+    let bytes;
+    try {
+      bytes = await vscode.workspace.fs.readFile(uri);
+    } catch {
+      continue;
+    }
+
+    const text = Buffer.from(bytes).toString('utf8');
+    const findings = scanText(text);
+    if (findings.length === 0) continue;
+
+    filesWithFindings++;
+    totalFindings += findings.length;
+
+    const diagnostics = findings.map((finding) => {
+      const range = new vscode.Range(
+        finding.line,
+        finding.column,
+        finding.line,
+        finding.column + finding.length
+      );
+      const diagnostic = new vscode.Diagnostic(range, finding.message, severityToVsCode(finding.severity));
+      diagnostic.source = DIAGNOSTIC_SOURCE;
+      diagnostic.code = {
+        value: 'basic-auth-smtp-office365',
+        target: vscode.Uri.parse(CODE_LINK),
+      };
+      return diagnostic;
+    });
+
+    diagnosticCollection.set(uri, diagnostics);
+  }
+
+  const message =
+    totalFindings === 0
+      ? 'ZeroSMTP: no Microsoft 365 SMTP host references found in this workspace.'
+      : `ZeroSMTP: ${totalFindings} finding(s) in ${filesWithFindings} file(s). See the Problems panel.`;
+  output.appendLine(message);
+  vscode.window.setStatusBarMessage(message, 6000);
+}
+
+// `zerosmtp-check` is an ESM-only package (no `exports` map, so its
+// `errors.js`/`index.js` are importable as subpaths). Dynamic `import()`
+// from this CommonJS extension is what lets a CJS extension host load it -
+// this is the "reuse the package instead of rewriting the logic" requirement.
+async function explainSelection(output) {
+  const editor = vscode.window.activeTextEditor;
+  let text =
+    editor && !editor.selection.isEmpty ? editor.document.getText(editor.selection) : undefined;
+
+  if (!text) {
+    text = await vscode.window.showInputBox({
+      prompt: 'Paste the SMTP error text (from a log, a terminal, or a printer panel)',
+      placeHolder: '535 5.7.139 Authentication unsuccessful, basic authentication is disabled',
+    });
+  }
+
+  if (!text || !text.trim()) return;
+
+  const { explain } = await import('zerosmtp-check/index.js');
+  const answer = explain(text);
+
+  output.clear();
+  output.appendLine(answer);
+  output.show(true);
+}
+
+function activate(context) {
+  const diagnosticCollection = vscode.languages.createDiagnosticCollection('zerosmtp');
+  const output = vscode.window.createOutputChannel('ZeroSMTP');
+  context.subscriptions.push(diagnosticCollection, output);
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('zerosmtp.scanWorkspace', () =>
+      scanWorkspace(diagnosticCollection, output).catch((err) =>
+        vscode.window.showErrorMessage(`ZeroSMTP scan failed: ${err.message}`)
+      )
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('zerosmtp.explainError', () =>
+      explainSelection(output).catch((err) =>
+        vscode.window.showErrorMessage(`ZeroSMTP explain failed: ${err.message}`)
+      )
+    )
+  );
+}
+
+function deactivate() {}
+
+module.exports = { activate, deactivate };

--- a/packages/zerosmtp-vscode/package.json
+++ b/packages/zerosmtp-vscode/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "zerosmtp-vscode",
+  "displayName": "ZeroSMTP: Basic Auth SMTP Scanner",
+  "description": "Finds SMTP config in your workspace that authenticates to Microsoft 365 (smtp.office365.com) with a plain username and password, and decodes the 535 5.7.139 error when it starts happening. Basic Auth for SMTP AUTH is being retired in December 2026.",
+  "version": "0.1.0",
+  "publisher": "msgwing",
+  "license": "MIT",
+  "private": true,
+  "engines": {
+    "vscode": "^1.85.0",
+    "node": ">=18"
+  },
+  "categories": [
+    "Linters",
+    "Other"
+  ],
+  "keywords": [
+    "smtp",
+    "smtp-relay",
+    "office365",
+    "exchange-online",
+    "microsoft365",
+    "oauth",
+    "oauth2",
+    "basic-authentication",
+    "5.7.139",
+    "printer",
+    "scan-to-email"
+  ],
+  "homepage": "https://docs.msgwing.com/EXCHANGE-ONLINE-SMTP-AUTH.html",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/msgwing/ZeroSMTP.git",
+    "directory": "packages/zerosmtp-vscode"
+  },
+  "bugs": {
+    "url": "https://github.com/msgwing/ZeroSMTP/issues"
+  },
+  "main": "./extension.js",
+  "activationEvents": [
+    "onCommand:zerosmtp.scanWorkspace",
+    "onCommand:zerosmtp.explainError"
+  ],
+  "contributes": {
+    "commands": [
+      {
+        "command": "zerosmtp.scanWorkspace",
+        "title": "ZeroSMTP: Scan workspace for Basic Auth SMTP config",
+        "category": "ZeroSMTP"
+      },
+      {
+        "command": "zerosmtp.explainError",
+        "title": "ZeroSMTP: Explain this SMTP error",
+        "category": "ZeroSMTP"
+      }
+    ]
+  },
+  "scripts": {
+    "test": "node --test test/*.test.js"
+  },
+  "dependencies": {
+    "zerosmtp-check": "file:../zerosmtp-check"
+  }
+}

--- a/packages/zerosmtp-vscode/scanner.js
+++ b/packages/zerosmtp-vscode/scanner.js
@@ -1,0 +1,85 @@
+'use strict';
+
+// Heuristic scan for SMTP configuration that authenticates to Microsoft 365
+// with a plain username and password (Basic Auth) rather than OAuth2. Basic
+// Auth for SMTP AUTH is being retired for Exchange Online in December 2026 -
+// see https://docs.msgwing.com/EXCHANGE-ONLINE-SMTP-AUTH.html
+//
+// This is a text search, not a parser for any specific config format - it has
+// to work the same way against a .env file, appsettings.json, web.config, and
+// a literal string in a C# or Python file. It looks for the Microsoft 365
+// SMTP hostnames, then looks at the surrounding lines for words that suggest
+// a password on one hand or an OAuth2 flow on the other.
+//
+// This has no `vscode` dependency on purpose: it is the part that can be
+// unit-tested with `node --test`, without the Extension Development Host.
+
+const HOST_PATTERN = /\b(?:smtp\.office365\.com|outlook\.office365\.com)\b/gi;
+
+const CREDENTIAL_HINT =
+  /\b(?:password|passwd|pwd|networkcredential|smtp_pass|smtppass|mail_password|basicauth)\b/i;
+
+const OAUTH_HINT =
+  /\b(?:oauth2?|xoauth2|client[_-]?secret|access[_-]?token|refresh[_-]?token|tenant[_-]?id|clientid|msal)\b/i;
+
+// How many lines around a host match to read before deciding whether a
+// password or an OAuth2 flow is what's actually configured. Credentials and
+// host are rarely on the same line (e.g. appsettings.json, web.config), so
+// looking only at the matched line would miss almost everything.
+const CONTEXT_LINES = 10;
+
+const DOC_LINK = 'https://docs.msgwing.com/EXCHANGE-ONLINE-SMTP-AUTH.html';
+
+/**
+ * @param {string} text file contents
+ * @returns {Array<{line: number, column: number, length: number, severity: 'warning'|'information', message: string}>}
+ */
+function scanText(text) {
+  const lines = text.split(/\r\n|\r|\n/);
+  const findings = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    HOST_PATTERN.lastIndex = 0;
+    let match;
+    while ((match = HOST_PATTERN.exec(line)) !== null) {
+      const from = Math.max(0, i - CONTEXT_LINES);
+      const to = Math.min(lines.length, i + CONTEXT_LINES + 1);
+      const window = lines.slice(from, to).join('\n');
+
+      const hasCredential = CREDENTIAL_HINT.test(window);
+      const hasOAuth = OAUTH_HINT.test(window);
+
+      let severity;
+      let message;
+      if (hasCredential && !hasOAuth) {
+        severity = 'warning';
+        message =
+          `Looks like Basic Auth SMTP to Microsoft 365 (${match[0]}). Basic Auth for SMTP AUTH is being ` +
+          `retired in December 2026 - this will stop sending mail. ${DOC_LINK}`;
+      } else if (hasCredential && hasOAuth) {
+        severity = 'information';
+        message =
+          `Microsoft 365 SMTP host (${match[0]}) referenced near both a password-looking setting and an ` +
+          `OAuth-looking setting. Confirm which one is actually used before December 2026. ${DOC_LINK}`;
+      } else {
+        severity = 'information';
+        message =
+          `Microsoft 365 SMTP host (${match[0]}) referenced here. If this authenticates with a plain ` +
+          `username and password, it will stop working in December 2026. ${DOC_LINK}`;
+      }
+
+      findings.push({
+        line: i,
+        column: match.index,
+        length: match[0].length,
+        severity,
+        message,
+      });
+    }
+  }
+
+  return findings;
+}
+
+module.exports = { scanText, HOST_PATTERN, CREDENTIAL_HINT, OAUTH_HINT, DOC_LINK, CONTEXT_LINES };

--- a/packages/zerosmtp-vscode/test/scanner.test.js
+++ b/packages/zerosmtp-vscode/test/scanner.test.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { scanText } = require('../scanner');
+
+test('flags appsettings.json-style Basic Auth config as warning', () => {
+  const text = [
+    '{',
+    '  "Smtp": {',
+    '    "Host": "smtp.office365.com",',
+    '    "Port": 587,',
+    '    "Username": "printer@contoso.com",',
+    '    "Password": "hunter2"',
+    '  }',
+    '}',
+  ].join('\n');
+
+  const findings = scanText(text);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].severity, 'warning');
+  assert.match(findings[0].message, /December 2026/);
+  assert.equal(findings[0].line, 2); // the line with "Host"
+});
+
+test('flags a web.config-style single-line network element', () => {
+  const text =
+    '<network host="smtp.office365.com" port="587" userName="user@contoso.com" password="hunter2" />';
+
+  const findings = scanText(text);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].severity, 'warning');
+  assert.equal(findings[0].line, 0);
+});
+
+test('flags a .env-style pair of lines', () => {
+  const text = ['SMTP_HOST=smtp.office365.com', 'SMTP_PASS=hunter2'].join('\n');
+
+  const findings = scanText(text);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].severity, 'warning');
+});
+
+test('does not warn when only OAuth2 settings are nearby, no password field', () => {
+  const text = [
+    'SMTP_HOST=smtp.office365.com',
+    'TENANT_ID=11111111-1111-1111-1111-111111111111',
+    'CLIENT_SECRET=abc123',
+  ].join('\n');
+
+  const findings = scanText(text);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].severity, 'information');
+  assert.doesNotMatch(findings[0].message, /Looks like Basic Auth/);
+});
+
+test('downgrades to information when both a password and OAuth hints are present', () => {
+  const text = [
+    'host: smtp.office365.com',
+    'password: hunter2',
+    'clientSecret: abc123',
+  ].join('\n');
+
+  const findings = scanText(text);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].severity, 'information');
+  assert.match(findings[0].message, /Confirm which one is actually used/);
+});
+
+test('ignores a credential hint far outside the context window', () => {
+  const lines = ['smtp.office365.com'];
+  for (let i = 0; i < 30; i++) lines.push(`line ${i}`);
+  lines.push('password: hunter2');
+
+  const findings = scanText(lines.join('\n'));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].severity, 'information');
+});
+
+test('ignores hosts that are not Microsoft 365', () => {
+  const text = 'SMTP_HOST=smtp.gmail.com\nSMTP_PASS=hunter2';
+  assert.equal(scanText(text).length, 0);
+});
+
+test('matches the Microsoft 365 host case-insensitively', () => {
+  const text = 'Host=SMTP.Office365.Com\nPassword=hunter2';
+  const findings = scanText(text);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].severity, 'warning');
+});
+
+test('reports a finding per occurrence, with correct line and column', () => {
+  const text = [
+    'first: smtp.office365.com',
+    'password: hunter2',
+    '',
+    'second: outlook.office365.com',
+  ].join('\n');
+
+  const findings = scanText(text);
+  assert.equal(findings.length, 2);
+  assert.equal(findings[0].line, 0);
+  assert.equal(findings[0].column, text.split('\n')[0].indexOf('smtp.office365.com'));
+  assert.equal(findings[1].line, 3);
+});


### PR DESCRIPTION
## Summary

First working slice of the VS Code extension approved from venture-lead's idea C (real, empty niche: 25 Marketplace results for "smtp office365", all .NET mail-sending libraries, none of them diagnostic). Multi-day scope — this is a partial but genuinely working v1, not a stub.

- `packages/zerosmtp-vscode/scanner.js` — text-search heuristic (no `vscode` dependency, unit-testable on its own) for `smtp.office365.com` / `outlook.office365.com` next to a password-looking setting in `.env`, `appsettings*.json`, `web.config`/`*.config` and common source files. Downgrades to informational when an OAuth2-looking setting (`clientSecret`, `tenantId`, `accessToken`...) is also nearby, rather than asserting a false positive as certain.
- `packages/zerosmtp-vscode/extension.js` — `ZeroSMTP: Scan workspace for Basic Auth SMTP config` (wires the scanner into Diagnostics/Problems) and `ZeroSMTP: Explain this SMTP error` (dynamically imports `zerosmtp-check`'s `explain()` — same error corpus, zero duplicated logic).
- 9 passing tests in `test/scanner.test.js`; also ran with the host regex deliberately broken to confirm the suite actually fails when it should.

## Known gaps, stated rather than hidden

- **Not published to the Marketplace.** `package.json` has `"private": true`. Publishing needs a `msgwing` Visual Studio Marketplace publisher agreement — a separate system (Azure DevOps / PAT) from the GitHub Marketplace listing `send-email-action` already has. Whether that agreement exists is unverified and not something this change can create.
- **Depends on `zerosmtp-check` via `file:../zerosmtp-check`**, not a published npm version. The registry's `zerosmtp-check@1.2.1` predates the `explain`/`explainJson` exports this extension calls — pinning to the npm version today would have shipped a command that silently does nothing. Before real packaging, `zerosmtp-check` needs a version bump and republish, and this dependency needs to switch to that published range.
- Scanner is a heuristic (grep, not a parser), covers three config shapes in tests, no icon, no packaging (`@vscode/vsce`) wired up yet.

## Test plan

- [x] `cd packages/zerosmtp-vscode && npm install && npm test` — 9/9 passing
- [x] Confirmed the test suite fails when the scanner regex is deliberately broken
- [x] Confirmed `extension.js` fails only on the ambient `vscode` module (expected outside the Extension Development Host)
- [x] Confirmed the dynamic import of `zerosmtp-check`'s `explain()` returns real, correct output for `535 5.7.139`
- [ ] Not yet run inside an actual Extension Development Host (F5) — next step for whoever picks this up
