### PR TITLE
chore(zerosmtp-check): bump to 1.3.0 - explain/explainJson need publishing

### DIFF
--- a/packages/zerosmtp-check/package.json
+++ b/packages/zerosmtp-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zerosmtp-check",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Check whether outbound SMTP works from this machine, and say what an SMTP error actually means. TCP, STARTTLS/implicit TLS, certificates and AUTH against any host, plus --explain for the refusal your log, library or printer panel printed. No credentials, no mail sent, no dependencies.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
`zerosmtp-check` on npm is still 1.2.1 (published 2026-08-22 17:58), but `explain()`/`explainJson()` were exported as public API four days later in #300 (2026-08-26), along with a 25-test suite. Anyone running `npx zerosmtp-check` from npm today doesn't have this - found while building the VS Code extension (#385), which had to depend on `file:../zerosmtp-check` specifically because of this gap.

Version bump only (1.2.1 -> 1.3.0, minor since it's a new exported API surface). Not triggering the actual npm publish myself - `.github/workflows/publish-npm.yml`'s own comment states plainly "publishing is the owner's decision" and a published version is permanent. Filing a do-akceptacji issue with exact dispatch instructions.

## Test plan
- [x] `npm test` in `packages/zerosmtp-check` - 25/25 pass
- [x] `python tools/check-control-chars.py` - clean
- [x] Confirmed no other file references the old version number
