### PR TITLE
chore(vscode): use the published zerosmtp-check@1.3.0 instead of file:

### DIFF
--- a/packages/zerosmtp-check/package.json
+++ b/packages/zerosmtp-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zerosmtp-check",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Check whether outbound SMTP works from this machine, and say what an SMTP error actually means. TCP, STARTTLS/implicit TLS, certificates and AUTH against any host, plus --explain for the refusal your log, library or printer panel printed. No credentials, no mail sent, no dependencies.",
   "type": "module",
   "bin": {

--- a/packages/zerosmtp-vscode/README.md
+++ b/packages/zerosmtp-vscode/README.md
@@ -41,14 +41,9 @@ gap:
   whether one already exists, and creating one is not something this task can
   do on its own. `"private": true` is set so a stray `vsce publish` can't ship
   this by accident.
-- **The `zerosmtp-check` dependency is `file:../zerosmtp-check`**, not a
-  published npm version. As of this writing, the npm registry's
-  `zerosmtp-check@1.2.1` predates the `explain`/`explainJson` exports this
-  extension calls — they exist in this repository's copy of `index.js` but
-  were never published under a new version. Before this extension is packaged
-  for real, `zerosmtp-check` needs a version bump and a publish
-  (`.github/workflows/publish-npm.yml`), and this dependency needs to switch
-  from the `file:` reference to that published semver range.
+- ~~The `zerosmtp-check` dependency is `file:../zerosmtp-check`~~ — resolved
+  2026-08-30: `zerosmtp-check@1.3.0` (with `explain`/`explainJson` exported)
+  is now published, and the dependency is a real semver range (`^1.3.0`).
 - **The scanner is a heuristic, deliberately.** It has no test against every
   config format in the wild (only `appsettings.json`, `web.config`, and
   `.env` shapes are covered by `test/scanner.test.js`), and it does not parse

--- a/packages/zerosmtp-vscode/package.json
+++ b/packages/zerosmtp-vscode/package.json
@@ -59,6 +59,6 @@
     "test": "node --test test/*.test.js"
   },
   "dependencies": {
-    "zerosmtp-check": "file:../zerosmtp-check"
+    "zerosmtp-check": "^1.3.0"
   }
 }


### PR DESCRIPTION
## Summary
Follow-up to #386/#387: `zerosmtp-check@1.3.0` is now live on npm with `explain`/`explainJson` actually exported, so the VS Code extension's `file:../zerosmtp-check` workaround is no longer needed. Switched to `^1.3.0`.

## Test plan
- [x] Fresh `npm install` (no node_modules/lockfile carried over) resolves `zerosmtp-check@1.3.0` from the real registry, not a local path
- [x] `node --test test/scanner.test.js` - 9/9 pass against the real dependency
- [x] Ran the extension's exact `import('zerosmtp-check/index.js')` call directly and confirmed `explain()` is callable and returns the expected text
- [x] `python tools/check-control-chars.py` - clean
