### PR TITLE
ci: build Jekyll on every PR/push, not only on deploy to main

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -111,6 +111,29 @@ jobs:
       - name: Workflow files parse, and carry no control characters
         run: python .github/check-workflows.py
 
+  # Found 2026-08-30, during review of #366: pages-deploy.yml only builds
+  # Jekyll on push to main, so a broken Liquid template (an unclosed
+  # {% if %}/{% elsif %}, a bad include) in a pull request passes every other
+  # check here and only breaks once it has already reached production. That
+  # PR was verified by hand (grepping the if/elsif/endif chain) instead of by
+  # a gate - which worked once, but doesn't scale to every future change in
+  # docs/_layouts/ or docs/_config.yml. This job runs the same build
+  # pages-deploy.yml runs, without the deploy steps, on every push and PR.
+  jekyll-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # jekyll-last-modified-at needs real per-file git log, same reason pages-deploy.yml uses it
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+          working-directory: docs
+      - name: Build with Jekyll
+        working-directory: docs
+        run: bundle exec jekyll build --destination _site --config _config.yml,_config_actions.yml
+
   bash:
     needs: changes
     if: needs.changes.outputs.code == 'true'

--- a/packages/zerosmtp-check/package.json
+++ b/packages/zerosmtp-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zerosmtp-check",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Check whether outbound SMTP works from this machine, and say what an SMTP error actually means. TCP, STARTTLS/implicit TLS, certificates and AUTH against any host, plus --explain for the refusal your log, library or printer panel printed. No credentials, no mail sent, no dependencies.",
   "type": "module",
   "bin": {

--- a/packages/zerosmtp-vscode/README.md
+++ b/packages/zerosmtp-vscode/README.md
@@ -41,14 +41,9 @@ gap:
   whether one already exists, and creating one is not something this task can
   do on its own. `"private": true` is set so a stray `vsce publish` can't ship
   this by accident.
-- **The `zerosmtp-check` dependency is `file:../zerosmtp-check`**, not a
-  published npm version. As of this writing, the npm registry's
-  `zerosmtp-check@1.2.1` predates the `explain`/`explainJson` exports this
-  extension calls — they exist in this repository's copy of `index.js` but
-  were never published under a new version. Before this extension is packaged
-  for real, `zerosmtp-check` needs a version bump and a publish
-  (`.github/workflows/publish-npm.yml`), and this dependency needs to switch
-  from the `file:` reference to that published semver range.
+- ~~The `zerosmtp-check` dependency is `file:../zerosmtp-check`~~ — resolved
+  2026-08-30: `zerosmtp-check@1.3.0` (with `explain`/`explainJson` exported)
+  is now published, and the dependency is a real semver range (`^1.3.0`).
 - **The scanner is a heuristic, deliberately.** It has no test against every
   config format in the wild (only `appsettings.json`, `web.config`, and
   `.env` shapes are covered by `test/scanner.test.js`), and it does not parse

--- a/packages/zerosmtp-vscode/package.json
+++ b/packages/zerosmtp-vscode/package.json
@@ -59,6 +59,6 @@
     "test": "node --test test/*.test.js"
   },
   "dependencies": {
-    "zerosmtp-check": "file:../zerosmtp-check"
+    "zerosmtp-check": "^1.3.0"
   }
 }


### PR DESCRIPTION
## Summary
Closes #367. `pages-deploy.yml` only builds Jekyll on push to `main`, so a broken Liquid template in a PR passes every other check and only breaks after it's already on production - exactly what was verified by hand (not by a gate) during #366's review. New `jekyll-build` job in `lint.yml` runs the same build on every push/PR, without the deploy steps.

## Test plan
- [x] `python .github/check-workflows.py` - clean
- [ ] This PR's own CI run is the real test (no Ruby available locally) - the new `jekyll-build` job must go green here
