### PR TITLE
feat(cli): explain Xerox fault code 027-779

### DIFF
--- a/packages/zerosmtp-check/errors.js
+++ b/packages/zerosmtp-check/errors.js
@@ -162,5 +162,10 @@ export const DEVICE_CODES = {
     "vendor": "Kyocera",
     "note": "Kyocera MFPs report an SMTP AUTH refusal as send error 1102 (also shown as 0x1102). It looks like a hardware fault and is not one - the device is being refused by the mail server.",
     "kind": "auth-refused"
+  },
+  "027-779": {
+    "vendor": "Xerox",
+    "note": "Xerox WorkCentre 7328/7335/7345/7346 devices report fault code 027-779 when SMTP authentication fails. Check the Scan to E-mail login and SMTP server settings before treating it as a hardware fault.",
+    "kind": "auth-refused"
   }
 };

--- a/tools/build-cli-errors.py
+++ b/tools/build-cli-errors.py
@@ -43,6 +43,14 @@ KODY_URZADZEN = {
                 "not one - the device is being refused by the mail server.",
         "kind": "auth-refused",
     },
+    "027-779": {
+        "vendor": "Xerox",
+        "note": "Xerox WorkCentre 7328/7335/7345/7346 devices report fault "
+                "code 027-779 when SMTP authentication fails. Check the Scan "
+                "to E-mail login and SMTP server settings before treating it "
+                "as a hardware fault.",
+        "kind": "auth-refused",
+    },
 }
 
 


### PR DESCRIPTION
## Summary

- add Xerox fault code `027-779` to the CLI device-code corpus
- identify it as an SMTP authentication refusal for WorkCentre 7328/7335/7345/7346 devices
- regenerate the dependency-free `zerosmtp-check` error module without changing `data/errors.json` or the generic matcher

## Source

Xerox documents this as **Fault Code 027-779: SMTP Authentication Failed** in [KB0238716](https://www.support.xerox.com/en-us/article/en/1815767.html).

## Validation

- `/opt/homebrew/bin/python3.12 tools/build-cli-errors.py`
- `/opt/homebrew/bin/python3.12 tools/build-cli-errors.py --check`
- `/opt/homebrew/bin/python3.12 -m py_compile tools/build-cli-errors.py`
- `node --test packages/zerosmtp-check/test/zerosmtp-check.test.js` (28 passed)
- `node packages/zerosmtp-check/index.js --explain 027-779`
- `git diff --check`

Addresses #265.

## AI assistance

Codex was used to inspect the existing device-code precedent, apply the focused entry, run validation, and prepare this PR. I reviewed the generated diff and CLI output.
