### PR TITLE
fix(mcp): server.json fails registry schema validation

### DIFF
--- a/packages/zerosmtp-mcp/server.json
+++ b/packages/zerosmtp-mcp/server.json
@@ -1,10 +1,11 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.msgwing/zerosmtp",
-  "description": "MCP server for the Microsoft 365 SMTP AUTH shutdown: identify an error string, check whether a device has OAuth firmware, and test whether port 587 is reachable from this machine.",
+  "description": "MCP server for the Microsoft 365 SMTP AUTH shutdown: error lookup, device OAuth, port 587 test.",
   "repository": {
     "url": "https://github.com/msgwing/ZeroSMTP",
-    "source": "github"
+    "source": "github",
+    "subfolder": "packages/zerosmtp-mcp"
   },
   "version": "1.0.1",
   "packages": [


### PR DESCRIPTION
## Summary
- `description` in `packages/zerosmtp-mcp/server.json` was 179 chars; the registry schema (`https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`) caps `ServerDetail.description` at 100. Shortened to 95.
- `repository` had no `subfolder`, though the package lives at `packages/zerosmtp-mcp/` inside this monorepo — the registry's own docs give this exact monorepo case as the worked example for `subfolder`.

## Validation
- `ajv-cli validate` against the declared schema: fails before, passes after (verified by the agent that found this while checking whether `zerosmtp-mcp` was ready to be pointed at from outside the repo).

Found while verifying `zerosmtp-mcp@1.0.1` end-to-end ahead of any external directory/registry submission — submitting the pre-fix file would have failed official registry validation outright.