### PR TITLE
fix(seo): stop error-page titles truncating on a trailing preposition

### DIFF
--- a/docs/errors/5-7-12-sender-was-not-authenticated-by-organization.md
+++ b/docs/errors/5-7-12-sender-was-not-authenticated-by-organization.md
@@ -1,5 +1,5 @@
 ---
-title: "5.7.12 Sender was not authenticated by"
+title: "5.7.12 Sender was not authenticated"
 description: "What 5.7.12 Sender was not authenticated by organization means, whether it can still be turned back on, and what to do if it cannot."
 ---
 

--- a/docs/errors/5-7-233-tenant-daily-limit-external-recipients.md
+++ b/docs/errors/5-7-233-tenant-daily-limit-external-recipients.md
@@ -1,5 +1,5 @@
 ---
-title: "5.7.233 Tenant exceeded its daily limit for"
+title: "5.7.233 Tenant exceeded its daily limit"
 description: "What 5.7.233 Tenant exceeded its daily limit for sending email to external recipients means, whether it can still be turned back on, and what to do if it cannot."
 ---
 

--- a/docs/errors/5-7-236-tenant-daily-limit-per-recipient.md
+++ b/docs/errors/5-7-236-tenant-daily-limit-per-recipient.md
@@ -1,5 +1,5 @@
 ---
-title: "5.7.236 Tenant has exceeded its daily limit for"
+title: "5.7.236 Tenant has exceeded its daily limit"
 description: "What 5.7.236 Tenant has exceeded its daily limit for sending email means, whether it can still be turned back on, and what to do if it cannot."
 ---
 

--- a/docs/errors/5-7-367-remote-server-returned-not-permitted-to-relay.md
+++ b/docs/errors/5-7-367-remote-server-returned-not-permitted-to-relay.md
@@ -1,5 +1,5 @@
 ---
-title: "5.7.367 Remote server returned not permitted to"
+title: "5.7.367 Remote server returned not permitted"
 description: "What 5.7.367 Remote server returned not permitted to relay means, whether it can still be turned back on, and what to do if it cannot."
 ---
 

--- a/docs/errors/535-5-7-57-client-was-not-authenticated-to-send-anonymous-mail.md
+++ b/docs/errors/535-5-7-57-client-was-not-authenticated-to-send-anonymous-mail.md
@@ -1,5 +1,5 @@
 ---
-title: "535 5.7.57 SMTP; Client was not authenticated to"
+title: "535 5.7.57 SMTP; Client was not authenticated"
 description: "What 535 5.7.57 SMTP; Client was not authenticated to send anonymous mail means, whether it can still be turned back on, and what to do if it cannot."
 ---
 

--- a/tools/build-error-pages.py
+++ b/tools/build-error-pages.py
@@ -70,6 +70,10 @@ def tytul(wpis, wyrozniki=None):
     skrocony = None
     while slowa:
         slowa.pop()
+        # To samo obciecie co w galezi kolizji: slowo funkcyjne na koncu
+        # czyta sie jak urwane zdanie - "Sender was not authenticated by".
+        while slowa and slowa[-1].lower() in SPOJNIKI:
+            slowa.pop()
         kandydat = f"{wpis['code']} {' '.join(slowa)}"
         if slowa and len(kandydat) <= LIMIT_TYTULU:
             skrocony = kandydat


### PR DESCRIPTION
## Summary
- `tools/build-error-pages.py` generates the `<title>` front matter for `docs/errors/*.md` from `data/errors.json`, shortening the code+message to fit a 48-char SEO budget by popping trailing words.
- The collision-handling branch already stripped a trailing stopword (`is/was/for/the/by/to/...`) so a shortened title never ends on a function word - but the first-pass (non-collision) branch did not have that check, so 5 of 17 titles ended mid-sentence: `Sender was not authenticated by`, `Client was not authenticated to`, `Client does not have` (unaffected, see below), `Remote server returned not permitted to`.
- These are the exact `<title>` tags Google shows in search results for these pages.

## Fix
Apply the same trailing-stopword strip to the first-pass loop. 4-line change to the generator; regenerated the 5 affected pages.

## Verification
- `python tools/build-error-pages.py --check` passes (was failing before the fix was applied and pages regenerated).
- Only the 5 broken titles changed; `git diff docs/ERROR-MESSAGES.md` is empty (that index uses the full, unshortened code+message, not the shortened title, so it was never affected).
- No new title collisions: `--check` includes the duplicate-title gate and it passed.

Before → after:
- `5.7.12 Sender was not authenticated by` → `5.7.12 Sender was not authenticated`
- `5.7.233 Tenant exceeded its daily limit for` → `5.7.233 Tenant exceeded its daily limit`
- `5.7.236 Tenant has exceeded its daily limit for` → `5.7.236 Tenant has exceeded its daily limit`
- `5.7.367 Remote server returned not permitted to` → `5.7.367 Remote server returned not permitted`
- `535 5.7.57 SMTP; Client was not authenticated to` → `535 5.7.57 SMTP; Client was not authenticated`

## Test plan
- [x] `python tools/build-error-pages.py --check` green
- [x] CI `lint.yml` runs this same check
