### PR TITLE
docs(mcp): say what the product is on the surface an AI-assistant user reads

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -102,6 +102,12 @@ jobs:
         run: python tools/build-readme-toc.py --check
       - name: action.yml is publishable to the Marketplace
         run: python tools/check-action.py
+      # Same failure mode as the line above, on a different form. The MCP
+      # registry schema caps description at 100 characters and says so nowhere
+      # a person reads; the field shipped at 179 and was invalid against the
+      # schema it names itself.
+      - name: server.json is publishable to the MCP registry
+        run: python tools/check-mcp-server.py
       # A workflow file GitHub cannot parse fails at startup with no job and
       # no log, so it stays invisible until somebody notices a run named after
       # a file path instead of a workflow. Two files sat like that for twelve

--- a/packages/zerosmtp-mcp/README.md
+++ b/packages/zerosmtp-mcp/README.md
@@ -1,10 +1,16 @@
 # zerosmtp-mcp
 
-An MCP server for the Microsoft 365 SMTP AUTH shutdown. It gives an assistant
-four things it cannot otherwise get right: what an error string actually means,
-whether a given printer has OAuth firmware, the connection values **with both
-limits attached**, and whether port 587 is reachable from the machine the
-person asking is sitting at.
+ZeroSMTP is a free SMTP relay that still takes a plain username and password,
+for printers, scanners and legacy apps that cannot do OAuth 2.0. Mail leaves
+from a generated `@msgwing.com` address rather than your own domain, and the
+cap is 200 messages a day. There is no paid tier, so those two limits are the
+whole of the catch.
+
+This is that relay as an MCP server. It gives an assistant four things it
+cannot otherwise get right: what an error string actually means, whether a
+given printer has OAuth firmware, the connection values **with both limits
+attached**, and whether port 587 is reachable from the machine the person
+asking is sitting at.
 
 That last one is the reason this exists. An assistant can read documentation.
 It cannot open a socket from somebody else's network, and "is 587 blocked
@@ -54,8 +60,8 @@ claude mcp add zerosmtp -- npx -y zerosmtp-mcp
 
 ## The limits it will always tell you
 
-Mail leaves from a generated `@msgwing.com` address, never your own domain,
-and the cap is 200 messages a day with no paid tier that lifts it.
+The two named at the top - a generated `@msgwing.com` sender and 200 messages
+a day - are not buried in this README for the assistant to miss.
 
 `relay_settings` returns both without being asked, because a recommendation
 that omits either is one you would regret: fine for a scan-to-email button,

--- a/packages/zerosmtp-mcp/package.json
+++ b/packages/zerosmtp-mcp/package.json
@@ -1,8 +1,8 @@
 {
   "name": "zerosmtp-mcp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "mcpName": "io.github.msgwing/zerosmtp",
-  "description": "MCP server for the Microsoft 365 SMTP AUTH shutdown: identify an error string, check whether a device has OAuth firmware, and test whether port 587 is reachable from this machine.",
+  "description": "A free SMTP relay that still takes a username and password, for devices that cannot do OAuth 2.0 - as an MCP server. Your assistant gets the connection settings with both limits attached, plus SMTP error lookup, per-vendor OAuth firmware status, and a real port 587 test from this machine.",
   "keywords": [
     "mcp",
     "model-context-protocol",

--- a/packages/zerosmtp-mcp/server.json
+++ b/packages/zerosmtp-mcp/server.json
@@ -1,18 +1,18 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.msgwing/zerosmtp",
-  "description": "MCP server for the Microsoft 365 SMTP AUTH shutdown: error lookup, device OAuth, port 587 test.",
+  "description": "A free SMTP relay that still takes a username and password, for devices that cannot do OAuth 2.0.",
   "repository": {
     "url": "https://github.com/msgwing/ZeroSMTP",
     "source": "github",
     "subfolder": "packages/zerosmtp-mcp"
   },
-  "version": "1.0.1",
+  "version": "1.0.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "zerosmtp-mcp",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "transport": {
         "type": "stdio"
       }

--- a/tools/check-facts.py
+++ b/tools/check-facts.py
@@ -39,6 +39,15 @@ OBSZAR = [
     (KORZEN / "docs" / "devices", "*.md"),
     (KORZEN / "tools", "*.py"),
     (KORZEN, "README.md"),
+    # Added 2026-08-31. The package READMEs are shipped to npm and rendered on
+    # the npm page, and zerosmtp-mcp's is what somebody browsing a directory of
+    # MCP servers reads before deciding in seconds whether to add it. They state
+    # the daily cap and the sender address like every other page here, but they
+    # sat outside this check - so the one surface an AI assistant reads on our
+    # behalf was the one surface allowed to contradict the rest.
+    (KORZEN / "packages" / "zerosmtp-mcp", "README.md"),
+    (KORZEN / "packages" / "zerosmtp-check", "README.md"),
+    (KORZEN / "packages" / "zerosmtp-vscode", "README.md"),
 ]
 
 # Ten plik z definicji zawiera kazdy sprzeczny zwrot, i tools/check-facts.py

--- a/tools/check-mcp-server.py
+++ b/tools/check-mcp-server.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Validate packages/zerosmtp-mcp/server.json against what the MCP registry enforces.
+
+Same class of failure as tools/check-action.py, found the same way. The registry
+schema this file names in its own `$schema` caps `description` at 100 characters.
+Nothing said so anywhere a person would read: on 2026-08-31 the field was 179
+characters and had been since the package was published, so the entry was invalid
+against the schema it declared and nobody would have found out until the registry
+refused it.
+
+The length is only half of it. server.json and package.json carry a description
+each, and npm shows one while the registry shows the other. When they drift, the
+project describes itself two different ways on the two surfaces an AI-assistant
+user actually sees - which is the thing this repository already refuses to do for
+its documentation pages via tools/check-facts.py.
+
+So both are checked here, where it costs nothing to find out.
+
+    python tools/check-mcp-server.py
+"""
+
+import json
+import pathlib
+import sys
+
+KORZEN = pathlib.Path(__file__).resolve().parent.parent
+PAKIET = KORZEN / "packages" / "zerosmtp-mcp"
+SERWER = PAKIET / "server.json"
+NPM = PAKIET / "package.json"
+
+# static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json,
+# definitions.ServerDetail.properties.description: {"maxLength": 100}.
+# Read off the schema on 2026-08-31, not guessed.
+MAX_OPISU = 100
+
+# The one sentence, in the words the reader already uses. A description that
+# lists only the tools describes a diagnostic library and hides the offer -
+# which is what both files did until 2026-08-31.
+SLOWA_OFERTY = ("relay", "password")
+
+
+def main() -> int:
+    for p in (SERWER, NPM):
+        if not p.exists():
+            print(f"{p.relative_to(KORZEN)} is missing", file=sys.stderr)
+            return 1
+
+    serwer = json.loads(SERWER.read_text(encoding="utf-8"))
+    npm = json.loads(NPM.read_text(encoding="utf-8"))
+    bledy = []
+
+    opis = serwer.get("description", "")
+    if not opis:
+        bledy.append("description: missing")
+    elif len(opis) > MAX_OPISU:
+        bledy.append(
+            f"description: {len(opis)} characters, and the registry schema caps it "
+            f"at {MAX_OPISU}. Trim it here rather than finding out at the registry.")
+
+    # A version in server.json that npm does not have is an entry pointing at
+    # nothing. Both places in server.json name it, and both have to agree.
+    wersje = {
+        "server.json version": serwer.get("version"),
+        "package.json version": npm.get("version"),
+    }
+    for i, p in enumerate(serwer.get("packages") or []):
+        wersje[f"server.json packages[{i}].version"] = p.get("version")
+    if len(set(wersje.values())) > 1:
+        bledy.append("version: " + ", ".join(f"{k}={v!r}" for k, v in wersje.items())
+                     + " - these must all be the same version")
+
+    if serwer.get("name") != npm.get("mcpName"):
+        bledy.append(f"name: server.json {serwer.get('name')!r} but package.json "
+                     f"mcpName {npm.get('mcpName')!r}")
+
+    # Both descriptions are read by a person deciding in seconds whether to add
+    # this to their config. Neither may describe only the tools.
+    for etykieta, tekst in (("server.json", opis), ("package.json", npm.get("description", ""))):
+        brak = [w for w in SLOWA_OFERTY if w not in tekst.lower()]
+        if brak:
+            bledy.append(
+                f"{etykieta} description: says nothing about {' or '.join(brak)}. "
+                f"A reader on a directory shelf learns there are tools and never "
+                f"learns there is a free relay behind them.")
+
+    if bledy:
+        for b in bledy:
+            print(f"::error file=packages/zerosmtp-mcp/server.json::{b}", file=sys.stderr)
+        return 1
+
+    print(f"server.json is publishable - description {len(opis)}/{MAX_OPISU} "
+          f"characters, version {serwer.get('version')}, and both descriptions "
+          f"name the relay")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What was wrong

`zerosmtp-mcp` went onto a 93,592-star shelf this week. Neither description a
reader sees there ever said what ZeroSMTP is.

`server.json` and `package.json` both carried a list of tools:

> MCP server for the Microsoft 365 SMTP AUTH shutdown: error lookup, device
> OAuth, port 587 test.

Three of the four tools, and the one that names the offer - `relay_settings` -
is the one that got dropped. Measured on the shipped strings: `relay` appears
0 times, `password` 0 times, `free` 0 times. Somebody deciding in five seconds
whether to add this to their config learned there is a lookup service, and
never learned there is a free relay behind it.

The README was better - it was written for this reader, not copy-pasted from
the printer pages - but it opened the same way, and put the offer and its two
limits in section six.

This is not a different claim that needs reconciling. It is a **missing** one,
which on a five-second surface is worse.

## What changed

Both descriptions and the README now open with the one sentence this project
already uses everywhere else, in the reader's own words:

> A free SMTP relay that still takes a username and password, for devices that
> cannot do OAuth 2.0.

97 characters, which matters - see below. The npm description carries the same
claim with the detail that reader wants: what the assistant actually gets,
including `relay_settings` and both limits. The README states the cap and the
generated sender in the same breath as the offer instead of six sections later.

Nothing here is a new promise. Same sentence, different detail.

## Two gates, because unchecked copy drifts back

**`tools/check-mcp-server.py`** (new). The MCP registry schema caps
`description` at 100 characters, and that number is written down nowhere a
person would read it - same class of failure as the Marketplace's 125-character
cap that `tools/check-action.py` exists for. The field shipped at **179
characters**, invalid against the schema `server.json` names in its own
`$schema`. #394 trimmed the length while this was being written; this makes it
impossible to regress, and also checks that the version agrees across all three
places that state it and that neither description hides the relay.

**`tools/check-facts.py`** now covers the three `packages/*/README.md`. They
ship to npm, they state the daily cap and the sender address like every other
page, and they sat outside the consistency gate. The one surface an AI
assistant reads on our behalf was the one surface allowed to contradict the
rest of the site.

## What proves it is correct rather than merely different

Every check below was run by breaking the input first, per the rule that a gate
which only fires on bad input is unproven until it has seen bad input.

- **The cap is real, not assumed.** Read off the live schema:
  `definitions.ServerDetail.properties.description.maxLength = 100`. The old
  179-character file fails `jsonschema.validate` with *"is too long"*; the new
  one validates clean against the same downloaded schema.
- **The gate's boundary matches the schema exactly.** 99 accepted, 100
  accepted, 101 refused.
- **The gate is not blind.** Seven deliberate breakages, all refused: the
  original 179-char string, a version drift in `server.json`, a drift in only
  the nested `packages[0].version`, an `mcpName` mismatch, a tools-only
  description in each file. The first attempt at this test was itself wrong -
  it built a 98-character string and the gate passed it correctly - which is
  why the boundary was then tested directly.
- **`check-facts.py` really sees the new files.** A contradicting claim was
  planted in each of the three package READMEs in turn; all three were refused
  with file and line. Green before and after.
- **The package still works.** `npm test` - 10 passed, 0 failed, including
  *"relay_settings zawsze podaje oba limity"*. `npm pack --dry-run` builds
  1.0.2, 6 files.
- **No line-ending damage.** `git show --numstat --format= HEAD` on the commit,
  not the worktree: 13/7 on the README, 3/3 on `server.json`. Two other package
  READMEs picked up CRLF churn during the break-tests and were restored before
  staging rather than swept in.

## Needs a dispatch, not a merge

Version is bumped to 1.0.2 so the copy is publishable, but the npm page keeps
showing the old description until someone runs `publish-npm.yml` for
`zerosmtp-mcp`. That workflow is manual by design and publishing is the owner's
decision, so this PR does not attempt it.

Nothing was posted to any repository this project does not own.
