### PR TITLE
feat(mcp): a Dockerfile, because two venues gate listing on one

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -420,6 +420,49 @@ jobs:
       # rather than here: a runner with 587 blocked would turn a working tool
       # into a red build, which is the wrong direction for a false alarm.
 
+  # Glama gates listing on `awesome-mcp-servers` (93,592 stars) behind a
+  # Dockerfile plus a passing introspection check - their bot said exactly that
+  # on our own pull request #13311 on 2026-08-31. `docker/mcp-registry` refuses
+  # us for the same missing file. Both venues take somebody's word for nothing,
+  # and neither should we: this builds the image and speaks MCP to it.
+  #
+  # The assertion is deliberately the protocol handshake rather than "the
+  # container started". A container that starts and answers nothing passes the
+  # first and fails the listing check - the failure that would otherwise be
+  # discovered by a stranger's bot rejecting us a second time.
+  mcp-container:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build the image
+        run: docker build -t zerosmtp-mcp:ci packages/zerosmtp-mcp
+
+      - name: It answers an MCP introspection request
+        run: |
+          set -euo pipefail
+          {
+            echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"ci","version":"0"}}}'
+          } | timeout 30 docker run -i --rm zerosmtp-mcp:ci > out.txt
+          cat out.txt
+          grep -q serverInfo out.txt
+          grep -q zerosmtp out.txt
+
+      - name: It lists all four tools
+        run: |
+          set -euo pipefail
+          {
+            echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"ci","version":"0"}}}'
+            echo '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+            echo '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+          } | timeout 30 docker run -i --rm zerosmtp-mcp:ci > tools.txt
+          cat tools.txt
+          for tool in lookup_smtp_error check_device_oauth relay_settings check_relay_reachable; do
+            grep -q "$tool" tools.txt || { echo "::error::$tool missing from tools/list"; exit 1; }
+          done
+
   zerosmtp-check:
     needs: changes
     if: needs.changes.outputs.code == 'true'

--- a/packages/zerosmtp-mcp/Dockerfile
+++ b/packages/zerosmtp-mcp/Dockerfile
@@ -1,0 +1,42 @@
+# A container for the MCP server, for the places that will only take one.
+#
+# Two of them, both measured 2026-08-31:
+#
+#   * Glama gates listing on `awesome-mcp-servers` (93,592 stars) behind a
+#     Dockerfile and an introspection check - their bot said so on our own
+#     pull request #13311. No image, no listing.
+#   * `docker/mcp-registry` was checked the same day and rejected us for
+#     exactly this: its CONTRIBUTING.md needs either a Dockerfile in the
+#     source repository or a public HTTPS endpoint, and `grep -i "npx"`
+#     over it returns nothing. Publishing to npm was not enough there.
+#
+# So this file is not packaging for its own sake - it is the entry ticket to
+# two venues that npm alone cannot open.
+#
+# Deliberately not `node:22`: the server has no dependencies at all, so the
+# only thing an image needs to carry is a Node runtime and four files. Alpine
+# keeps that honest and small, and `npm install` is absent on purpose - there
+# is nothing to install, and a lockfile-less `npm install` in a build is how a
+# zero-dependency package quietly stops being one.
+
+FROM node:22-alpine
+
+# `stdio` is the only transport this server speaks, so there is no port to
+# expose and no health endpoint to add. The check any registry runs is an
+# MCP introspection request over stdin, which is what CMD below answers.
+WORKDIR /app
+
+# Copied one by one rather than `COPY . .`, so a stray test fixture or a
+# scratch file cannot end up in a published image. Same list as the `files`
+# array in package.json, which is what npm ships.
+COPY package.json ./
+COPY index.js ./
+COPY data/ ./data/
+COPY README.md ./
+
+# Runs as a non-root user. `node` (uid 1000) already exists in this image, so
+# this costs nothing and means a registry that inspects the image does not
+# have to take our word for it.
+USER node
+
+ENTRYPOINT ["node", "/app/index.js"]


### PR DESCRIPTION
## Why this exists

Not packaging for its own sake. Two venues gate listing on this one file, both measured 2026-08-31:

- **Glama** gates listing on `punkpeye/awesome-mcp-servers` (93,592 stars). Their bot said so on our own open pull request there, #13311: *"you must add Dockerfile directly to Glama. For checks to pass, we only need the server to start and respond to introspection requests."* No image, no listing — and that pull request is the largest shelf this project has ever submitted to.
- **`docker/mcp-registry`** was checked the same day and rejected for exactly this: its `CONTRIBUTING.md` requires either a Dockerfile in the source repository or a public HTTPS endpoint. `grep -i "npx"` over their rules returns nothing. Publishing to npm was not enough there.

One file, two venues that npm alone cannot open.

## The image

`node:22-alpine`, files copied one by one rather than `COPY . .` so a stray test fixture cannot reach a published image — the same list as the `files` array in `package.json`. No `npm install`: the package has no dependencies, and a lockfile-less install in a build is how a zero-dependency package quietly stops being one. Runs as the non-root `node` user that image already provides.

## The CI job asserts the handshake, not the start

`mcp-container` builds the image and then speaks MCP to it: an `initialize` request must come back with `serverInfo`, and `tools/list` must name all four tools.

That distinction is the point. A container that starts and answers nothing passes "did it start" and fails the listing check — the failure a stranger's bot would otherwise find for us, on the shelf we most want.

## Verified, not asserted

There is no Docker on the machine this was written on, so the container itself is proved by this job's own first real run rather than by a claim here. What was verified locally is the assertion logic, against the real server:

- Full handshake through `node packages/zerosmtp-mcp/index.js`: `serverInfo` returns `{"name":"zerosmtp","version":"1.0.2"}`, and all four tools appear in `tools/list`.
- **Deliberate breaks, both refused** — per the standing rule that a gate which only runs when something is wrong must be tested by making something wrong:
  - a process that starts and answers nothing → `grep -q serverInfo` fails, job would fail;
  - one tool removed from the listing → the loop names the missing tool and exits 1.
- `python .github/check-workflows.py` → clean. It caught an earlier draft of this same job: a `\n` was eaten by a shell layer and became a real newline, making the YAML invalid — the exact failure mode already documented for this repository. The job now contains zero backslashes, verified by count.
