### PR TITLE
fix(ci): publish-npm defaults published nothing, twice

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -23,17 +23,31 @@ name: Publish a package to npm
 on:
   workflow_dispatch:
     inputs:
+      # No default that is a real package. A `choice` input always arrives
+      # pre-filled, so the field the dispatcher must think about was the one
+      # field they never had to touch - and twice, on 2026-08-30 and
+      # 2026-08-31, the run went out on `zerosmtp-check` and died on "already
+      # on npm" while the package that needed publishing sat at 1.0.1.
+      # The sentinel below cannot publish anything, so leaving the form alone
+      # now fails in four seconds with a sentence saying which field to set.
       package:
-        description: 'Which package under packages/ to publish'
+        description: 'Which package under packages/ to publish - you must change this'
         type: choice
         options:
+          - '-- wybierz pakiet / pick a package --'
           - zerosmtp-check
           - zerosmtp-mcp
-        default: zerosmtp-check
+        default: '-- wybierz pakiet / pick a package --'
+      # Was `true`. A default dry run means the ordinary, intended use of this
+      # workflow - publishing - requires unticking a box, and the first attempt
+      # on 2026-08-31 published nothing for exactly that reason. What actually
+      # protects a version is the republish guard below plus the fact that this
+      # workflow is manual only and needs NPM_TOKEN; neither depends on this
+      # box. Tick it when you want a dry run, which is the rarer case.
       dry_run:
-        description: 'Pack and validate without publishing'
+        description: 'Pack and validate without publishing (leave unticked to publish)'
         type: boolean
-        default: true
+        default: false
 
 permissions:
   contents: read
@@ -46,6 +60,19 @@ jobs:
       run:
         working-directory: packages/${{ inputs.package }}
     steps:
+      # Before the checkout, so a form left on its defaults costs four seconds
+      # and says why, instead of failing later on a message about the wrong
+      # package being already published.
+      - name: A package was actually chosen
+        if: ${{ startsWith(inputs.package, '--') }}
+        # The job's default working-directory is packages/<input>, which for
+        # the sentinel is not a directory and for anything else does not exist
+        # yet - this step runs before the checkout on purpose.
+        working-directory: ${{ github.workspace }}
+        run: |
+          echo "::error::Pole 'Which package under packages/ to publish' zostalo na wartosci domyslnej. Wybierz zerosmtp-check albo zerosmtp-mcp i uruchom ponownie."
+          exit 1
+
       - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v7
@@ -68,10 +95,14 @@ jobs:
       # Publishing something that does not work is worse than not publishing.
       # These are the same checks the lint workflow runs, repeated here so
       # that a manual dispatch cannot skip them.
+      # `< /dev/null` because zerosmtp-mcp/index.js is a stdio MCP server that
+      # reads stdin until EOF. It exits today only because Actions happens to
+      # give a `run` step a null stdin; that is the runner's property, not the
+      # step's, and the failure if it ever changes is a six-hour hang.
       - name: It runs
-        run: node index.js --help
+        run: node index.js --help < /dev/null
       - name: It reports a real result
-        run: node index.js --json || [ $? = 1 ]
+        run: node index.js --json < /dev/null || [ $? = 1 ]
 
       - name: Refuse to republish an existing version
         run: |


### PR DESCRIPTION
## What was measured

`zerosmtp-mcp@1.0.2` is on `main` and has been since #397. It is not on npm.

```
$ curl -s https://registry.npmjs.org/zerosmtp-mcp/latest | jq -r .version
1.0.1
$ curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=zerosmtp"
{"servers":[],"metadata":{"count":0}}
```

Two dispatches were made for it and both did nothing:

| run | result | why |
|---|---|---|
| 2026-08-30 21:45 | success | `dry_run` defaults to ticked. A green run that publishes nothing. |
| 2026-08-31 17:38 | failure | `zerosmtp-check@1.3.0 is already on npm.` `package` is a `choice`, so the form arrived on `zerosmtp-check`. |

Issue #398 was rewritten before the second attempt with a table naming both
fields and their correct values. The second attempt still went out on the
defaults, and #398 was closed 17 seconds after the failed run.

That is the finding: the instruction was correct and did not work. A form
that arrives pre-filled with a wrong-but-valid answer is a mechanic 4 case -
a limit enforced by somebody else's form is still a limit - and the fix
belongs in the form.

## What changed

- `package` defaults to `-- wybierz pakiet / pick a package --`, which is not
  a package. A guard step before the checkout refuses it and prints which
  field to set. Leaving the form untouched now costs four seconds.
- `dry_run` defaults to unticked. What protects a published version is the
  `Refuse to republish an existing version` step and the fact that this
  workflow is `workflow_dispatch` only behind `NPM_TOKEN` - not this box.
  A dry run is now the deliberate choice, which is the rarer one.
- The two smoke steps read `< /dev/null`. `packages/zerosmtp-mcp/index.js` is
  a stdio MCP server that reads stdin until EOF; it exits under Actions only
  because a `run` step is given a null stdin, which is the runner's property
  and not the step's. If that ever changes the step hangs for six hours.
  Neither smoke step has ever run against this package - both prior
  dispatches went out on `zerosmtp-check`.

## Verification

- `python .github/check-workflows.py` - clean.
- `python tools/check-control-chars.py` - clean.
- The guard was tested by breaking the input rather than by reading it: the
  workflow was dispatched on this branch **with the form left alone**, and
  the run is linked in a comment below with the refusal it printed.
- A second dispatch with `package=zerosmtp-mcp` and `dry_run=true` runs the
  smoke steps against the MCP package for the first time.

Follow-up to #398, which is closed and tracking nothing.
