### PR TITLE
ci: a change that cannot be undone by a later commit carries a verdict

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,6 +58,40 @@ jobs:
             echo "code=false" >> "$GITHUB_OUTPUT"
           fi
 
+  # Six pull requests reached main on 2026-08-31 and 2026-09-01 with zero
+  # reviews between them - among them a fork PR from an outsider, a new CI
+  # job, and a version bump that leads to a permanent npm publish. Merges land
+  # on `--squash --auto`, so checks were the only gate, and no check asked
+  # whether anybody had decided anything.
+  #
+  # This does not require a review on every pull request; that would stall a
+  # repository that merges on checks by design, and most of what ships here is
+  # a page a later commit can correct. It refuses a named list instead - the
+  # changes whose cost, when they are wrong, is not paid by a later commit.
+  # Replayed against those six: it catches five, each by a different class,
+  # and lets #396 through, which is the one that was purely reversible.
+  #
+  # Same SHA pair the `changes` job uses, for the same reason: for a
+  # pull_request event github.sha is the merge commit, so fetch-depth 2 has
+  # both sides.
+  board-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+      - name: A change in a reviewed class carries a board verdict
+        env:
+          BAZA_SHA: ${{ github.event.pull_request.base.sha }}
+          GLOWA_SHA: ${{ github.sha }}
+          TRESC_PR: ${{ github.event.pull_request.body }}
+          Z_FORKA: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        run: python tools/check-board-review.py
+
   device-table:
     runs-on: ubuntu-latest
     steps:
@@ -401,6 +435,25 @@ jobs:
           node-version: '22'
       - name: "Ostatni komentarz nie nasz: bramka i test na przypadku #265"
         run: node --test tools/unanswered-external.test.js
+
+  # Logika bramki "etat mial spojrzec i nie spojrzal" - uzywana przez job
+  # `etat-nie-spojrzal` w ready-for-approval.yml. Wydzielona i testowana tutaj
+  # z tego samego powodu co powyzsza: 2026-09-01 szesc scalonych PR-ow mialo
+  # zero recenzji i zauwazyl to wlasciciel, a nie zaden przyrzad. Bramka,
+  # ktorej nikt nie przetestowal na przypadku majacym ja wywolac, jest
+  # ozdoba - patrz tools/seat-obligations.test.js, ktory zawiera dane tych
+  # szesciu PR-ow.
+  seat-obligations:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+      - name: "Etat nie spojrzal: bramka i test na szesciu PR-ach z 2026-09-01"
+        run: node --test tools/seat-obligations.test.js
 
   zerosmtp-mcp:
     needs: changes

--- a/tools/check-board-review.py
+++ b/tools/check-board-review.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Refuse a pull request in a reviewed class that carries no board verdict.
+
+Why this exists, 2026-09-01. Six pull requests reached `main` on 2026-08-31
+and 2026-09-01 - #390, #394, #396, #397, #399, #405 - and every one of them
+returned `0` from:
+
+    gh api repos/msgwing/ZeroSMTP/pulls/<n>/reviews
+
+Among them: a pull request from a fork by somebody outside this project, a new
+CI job, two new gates, a version bump that leads to a permanent npm publish,
+and a page about a 56,410-star project whose central claim rested on one line
+of somebody else's C#. Merges land on `--squash --auto`, so checks are the only
+gate, and no check asked whether anybody had decided anything.
+
+Requiring a review on every pull request is the wrong repair: this repository
+merges on checks by design, and most of what ships is a docs page a later
+commit can correct in minutes. So this refuses a narrow, named list instead -
+changes whose cost, when they are wrong, is not paid by a later commit.
+
+    python tools/check-board-review.py
+
+What it cannot do, said plainly rather than discovered later: every agent here
+authenticates with the same account, so nothing stops an author writing their
+own BOARD line. This gate does not prove a review happened. It makes the
+absence of one a red check and a permanent line in the pull request body,
+which is what `auditor` reads and what the six did not have.
+"""
+
+import fnmatch
+import os
+import re
+import subprocess
+import sys
+
+# Each entry: the class, why it is in the class, and the paths that name it.
+# A path is here only if being wrong about it costs more than a follow-up
+# commit. Everything not matched merges on checks, which is the default and
+# is meant to stay the default.
+KLASY = [
+    ("irreversible outside this repository",
+     "A published npm version cannot be unpublished and a registry entry cannot "
+     "be recalled. The decision is made here or it is not made.",
+     ["packages/*/package.json", "packages/*/server.json", "action.yml"]),
+
+    ("the merge path itself",
+     "A weakened or deleted check is invisible until the day it would have "
+     "caught something.",
+     [".github/workflows/*", ".github/check-workflows.py"]),
+
+    ("a claim about somebody else's product",
+     "A wrong port or a wrong field name sends a stranger's mail nowhere, and "
+     "the page is the reason they trusted us. These are read off the vendor's "
+     "own source or they are not written.",
+     ["data/apps.json", "data/devices.json", "data/clients.json",
+      "data/platforms.json", "docs/ALTERNATIVES.md"]),
+]
+
+WERDYKTY = ("MERGE WITH FOLLOW-UP", "MERGE", "REJECT", "ESCALATE")
+WERDYKT = re.compile(r"^BOARD:\s*(" + "|".join(re.escape(w) for w in WERDYKTY) +
+                     r")\s*[-\u2014]\s*\S.*$", re.M)
+DOWOD = re.compile(r"^EVIDENCE:\s*\S.*$", re.M)
+
+
+def zmienione(baza: str, glowa: str):
+    wynik = subprocess.run(["git", "diff", "--name-only", baza, glowa],
+                           capture_output=True, text=True, check=True)
+    return [w for w in wynik.stdout.splitlines() if w]
+
+
+def dopasowane(pliki):
+    trafienia = []
+    for nazwa, powod, wzorce in KLASY:
+        p = sorted({f for f in pliki for w in wzorce if fnmatch.fnmatch(f, w)})
+        if p:
+            trafienia.append((nazwa, powod, p))
+    return trafienia
+
+
+def main() -> int:
+    baza = os.environ.get("BAZA_SHA", "")
+    glowa = os.environ.get("GLOWA_SHA", "HEAD")
+    tresc = os.environ.get("TRESC_PR", "")
+    fork = os.environ.get("Z_FORKA", "") == "true"
+
+    if not baza:
+        print("Not a pull request - nothing to decide.")
+        return 0
+
+    pliki = zmienione(baza, glowa)
+    trafienia = dopasowane(pliki)
+    if fork:
+        trafienia.append((
+            "a pull request from a fork",
+            "The author cannot read this project's doctrine, so the only place "
+            "its conventions get applied is the review. #390 shipped correct "
+            "code and left the site without the page the CLI now references.",
+            [f"head repository is not msgwing/ZeroSMTP"]))
+
+    if not trafienia:
+        print(f"{len(pliki)} changed file(s), none in a reviewed class - "
+              f"checks are the gate here, as intended.")
+        return 0
+
+    ma_werdykt = bool(WERDYKT.search(tresc))
+    ma_dowod = bool(DOWOD.search(tresc))
+    if ma_werdykt and ma_dowod:
+        print("Board verdict present:")
+        print("  " + WERDYKT.search(tresc).group(0).strip())
+        print("  " + DOWOD.search(tresc).group(0).strip())
+        return 0
+
+    print("::error::This pull request is in a class that does not merge on "
+          "checks alone, and its body carries no board verdict.", file=sys.stderr)
+    for nazwa, powod, p in trafienia:
+        print(f"\n  {nazwa}", file=sys.stderr)
+        print(f"    {powod}", file=sys.stderr)
+        for f in p:
+            print(f"    - {f}", file=sys.stderr)
+    print("\n  Add two lines to the pull request body. change-board writes "
+          "them after answering the four questions in "
+          ".claude/agents/change-board.md:", file=sys.stderr)
+    print("\n    BOARD: MERGE - <what it earns>", file=sys.stderr)
+    print("    EVIDENCE: <the command that was run, and what it printed>",
+          file=sys.stderr)
+    if not ma_werdykt:
+        print(f"\n  No line matched BOARD: <{' | '.join(WERDYKTY)}> - <reason>.",
+              file=sys.stderr)
+    if not ma_dowod:
+        print("  No line matched EVIDENCE: <what was run>. A verdict with "
+              "nothing behind it is the thing this gate exists to stop.",
+              file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
BOARD: MERGE - the absence of a decision becomes a red check instead of nothing
EVIDENCE: 10 cases run against real commits, 6 of them refusals; replay of the six merges catches 5 by 5 different classes and passes #396

## The measurement

```
$ for n in 390 394 396 397 399 405; do
    gh api repos/msgwing/ZeroSMTP/pulls/$n/reviews --jq 'length'; done
0 0 0 0 0 0
```

Six pull requests on `main` in two days, zero reviews. Among them a fork PR
from somebody outside this project, a new CI job, two new gates, and a version
bump that leads to a permanent npm publish.

## What this deliberately does not do

It does not require a review on every pull request. `enforce_admins` is on,
zero reviews are required, and `--auto` is how work lands here - that is a
design decision that makes a small team fast, and reversing it would stall a
repository where most of what ships is a page a later commit corrects in
minutes.

## What it does

Refuses four named classes unless the body carries `BOARD:` and `EVIDENCE:`
lines. The classes are not "important things"; they are **changes whose cost,
when they are wrong, is not paid by a later commit**:

| class | why it is in the list |
|---|---|
| `packages/*/package.json`, `packages/*/server.json`, `action.yml` | a published npm version cannot be unpublished |
| `.github/workflows/*`, `.github/check-workflows.py` | a weakened check is invisible until the day it would have caught something |
| `data/apps.json`, `data/devices.json`, `data/clients.json`, `data/platforms.json`, `docs/ALTERNATIVES.md` | a wrong port sends a stranger's mail nowhere, and the page is why they trusted us |
| head repository is a fork | the author cannot read this project's doctrine; the review is the only place its conventions get applied |

Everything else merges on checks, unchanged.

## Replayed against the six

```
#390 rc=1 a pull request from a fork
#394 rc=1 irreversible outside this repository
#396 rc=0 none
#397 rc=1 irreversible outside this repository
#399 rc=1 a claim about somebody else's product
#405 rc=1 the merge path itself
```

Five caught, each by a different class. #396 passes - it is the one whose
entire diff a later commit could correct, which is what the list is for.

## Tested by breaking it, not by reading it

Ten cases, six of them refusals (`CLAUDE.md` mechanic 10 - a gate only ever
run on good input has not been tested):

```
OK rc=0 not a pull request
OK rc=0 docs+generator only (#396)
OK rc=1 workflow, empty body (#406)
OK rc=0 workflow, full verdict
OK rc=1 workflow, verdict no evidence
OK rc=1 workflow, evidence no verdict
OK rc=1 apps.json, empty body (#399)
OK rc=1 package.json bump (#397)
OK rc=1 fork, docs only, no verdict
OK rc=0 fork, docs only, verdict
niezgodnosci: 0
```

This pull request touches `.github/workflows/`, so it is in class two and
carries its own verdict at the top - which is the seventh live case.

## Two limits, stated here rather than discovered later

1. **It cannot prove a review happened.** Every agent authenticates as the
   same account, so an author can write their own `BOARD:` line. What it
   converts is "nobody decided" from invisible into a red check and a
   permanent, greppable line in the body.
2. **It cannot block until it is a required context.** Measured: #334 and
   #342 merged with a red `submit-nuget`, because `--auto` waits only on
   required checks and `required_status_checks.contexts` is eleven language
   linters. That is #407, and this gate is inert until it lands.

`python .github/check-workflows.py` and `python tools/check-control-chars.py`
both clean.
