### PR TITLE
ci: a seat whose trigger fired and left no trace is now detectable

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -402,6 +402,25 @@ jobs:
       - name: "Ostatni komentarz nie nasz: bramka i test na przypadku #265"
         run: node --test tools/unanswered-external.test.js
 
+  # Logika bramki "etat mial spojrzec i nie spojrzal" - uzywana przez job
+  # `etat-nie-spojrzal` w ready-for-approval.yml. Wydzielona i testowana tutaj
+  # z tego samego powodu co powyzsza: 2026-09-01 szesc scalonych PR-ow mialo
+  # zero recenzji i zauwazyl to wlasciciel, a nie zaden przyrzad. Bramka,
+  # ktorej nikt nie przetestowal na przypadku majacym ja wywolac, jest
+  # ozdoba - patrz tools/seat-obligations.test.js, ktory zawiera dane tych
+  # szesciu PR-ow.
+  seat-obligations:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+      - name: "Etat nie spojrzal: bramka i test na szesciu PR-ach z 2026-09-01"
+        run: node --test tools/seat-obligations.test.js
+
   zerosmtp-mcp:
     needs: changes
     if: needs.changes.outputs.code == 'true'

--- a/.github/workflows/ready-for-approval.yml
+++ b/.github/workflows/ready-for-approval.yml
@@ -671,3 +671,205 @@ jobs:
                 'a wniosek do tej samej listy czekal otwarty od szesciu dni.',
               ].join('\n'),
             });
+
+  # ETAT, KTORY MIAL SPOJRZEC, I NIE SPOJRZAL.
+  #
+  # 2026-09-01, wlasciciel: "nie chce w firmie nigdy takich sytuacji, ze ktos
+  # na cos nie spojrzal!!!! gdzie jest HR????". Tego dnia szesc scalonych
+  # PR-ow - #390, #394, #396, #397, #399, #405 - zwrocilo `0` z
+  # `pulls/<n>/reviews`. Wsrod nich PR od czlowieka z zewnatrz uruchamiany na
+  # naszych runnerach, nowy job CI i dwie nowe bramki.
+  #
+  # Szerszy pomiar tego samego dnia: z ostatnich 60 PR-ow dokladnie JEDEN ma
+  # jakikolwiek obiekt recenzji (#331), i jest on od
+  # `github-advanced-security[bot]`. Zero recenzji od czlowieka, kiedykolwiek.
+  # Nie bylo wiec regresu - nadzoru nigdy nie bylo.
+  #
+  # DLACZEGO BRAMKA, A NIE REGULA: regula "change-board recenzuje kazda zmiane"
+  # juz istniala, w pierwszym zdaniu opisu tamtego etatu, i nie wystrzelila ani
+  # razu. Ten projekt ma na to zapisane doswiadczenie - buduj bramke, nie pisz
+  # reguly.
+  #
+  # CZEGO TA BRAMKA NIE ROBI: nie blokuje scalenia. `enforce_admins` jest
+  # wlaczone a wymaganych recenzji jest zero, wiec `--auto` jest celowo droga,
+  # ktora praca lada; wymuszenie recenzji zatrzymaloby projekt. Ta bramka
+  # WYKRYWA i MELDUJE - jedna, samozamykajaca sie pozycja, ten sam wzorzec co
+  # `zalegle-zewnetrzne` powyzej.
+  #
+  # Logika jest w `tools/seat-obligations.js`, przetestowana na prawdziwych
+  # danych tych szesciu PR-ow w `tools/seat-obligations.test.js` i sprawdzona
+  # celowym zepsuciem pieciu porownan. W YAML zostaje samo pobieranie danych.
+  etat-nie-spojrzal:
+    if: github.event_name != 'issues'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const { raport, wymagaRecenzji, NIEOBSERWOWALNE, OBSADA_ETATOW,
+                    OBSADA_ODCZYT } = await import(
+              `${process.env.GITHUB_WORKSPACE}/tools/seat-obligations.js`);
+
+            const owner = context.repo.owner, repo = context.repo.repo;
+            const OKNO_DNI = 14;
+            // Prog wlaczenia bramki. Bez niego pierwszy przebieg zaklada
+            // kolejke na 99 pozycji - tyle scalonych PR-ow z ostatnich 14 dni
+            // nie ma zadnej recenzji - a scalonego PR-a nie da sie juz sensownie
+            // zrecenzowac, wiec taka kolejka NIGDY sie nie oprozni i nigdy sie
+            // nie zamknie. Zgloszenie, ktore zawsze jest otwarte, przestaje byc
+            // czytane. Historia melduje sie jako jedna liczba w tresci, praca
+            // jako wiersze.
+            const OD = '2026-09-02T00:00:00Z';
+            const TYTUL = 'Etat mial spojrzec i nie spojrzal';
+            const NL = String.fromCharCode(10);
+            const TICK = String.fromCharCode(96);
+
+            // Polityka nalezy do `change-board`, nie do tej bramki. Gdy jej
+            // nie ma, meldujemy wszystko - domysl w strone halasu, bo cisza
+            // jest trybem awarii, ktory to zbudowal.
+            let polityka = null;
+            const sciezka = `${process.env.GITHUB_WORKSPACE}/data/review-policy.json`;
+            if (fs.existsSync(sciezka)) {
+              try {
+                polityka = JSON.parse(fs.readFileSync(sciezka, 'utf8'));
+                core.info('Polityka recenzji wczytana od change-board.');
+              } catch (e) {
+                core.warning(`data/review-policy.json nie parsuje sie: ${e.message}`);
+              }
+            } else {
+              core.info('Brak data/review-policy.json - melduje kazdy scalony PR.');
+            }
+
+            const granica = new Date(Date.now() - OKNO_DNI * 86400000).toISOString();
+
+            const scalone = (await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'closed', sort: 'updated', direction: 'desc',
+              per_page: 100,
+            })).filter((p) => p.merged_at && p.merged_at >= granica);
+
+            // Stan wyjsciowy: ile z okna wypada przed progiem wlaczenia.
+            const historyczne = scalone.filter((p) => p.merged_at < OD).length;
+            const biezace = scalone.filter((p) => p.merged_at >= OD);
+
+            const obowiazki = [];
+            for (const p of biezace) {
+              const pr = {
+                autor: (p.user || {}).login,
+                etykiety: (p.labels || []).map((l) => l.name),
+              };
+              if (!wymagaRecenzji(pr, polityka, owner)) continue;
+
+              const recenzje = (await github.rest.pulls.listReviews({
+                owner, repo, pull_number: p.number, per_page: 100,
+              })).data;
+
+              obowiazki.push({
+                seat: 'change-board',
+                przedmiot: `#${p.number}`,
+                trigger: 'PR scalony',
+                tytul: p.title || '',
+                autor: pr.autor,
+                wyzwolonyAt: p.merged_at,
+                // Termin to moment scalenia: spojrzenie ma sens PRZED nim.
+                terminAt: p.merged_at,
+                akty: recenzje.map((r) => ({
+                  login: (r.user || {}).login,
+                  typ: (r.user || {}).type,
+                  at: r.submitted_at,
+                })),
+                owner,
+              });
+            }
+
+            const { zwloki, spoznione, poEtacie } = raport(obowiazki, Date.now());
+
+            core.info(`sprawdzonych scalonych PR-ow: ${obowiazki.length}`);
+            for (const s of spoznione) {
+              core.notice(`${s.przedmiot}: spojrzano, ale dopiero po scaleniu`);
+            }
+
+            const dashboard = (await github.rest.issues.listForRepo({
+              owner, repo, state: 'open', per_page: 100,
+            })).data.filter((i) => i.title === TYTUL);
+
+            if (!zwloki.length) {
+              for (const i of dashboard) {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: i.number,
+                  body: `Kazdy scalony PR z ostatnich ${OKNO_DNI} dni ma spojrzenie etatu. Zamykam.`,
+                });
+                await github.rest.issues.update({
+                  owner, repo, issue_number: i.number, state: 'closed',
+                });
+              }
+              core.info('Zaden etat nie przegapil swojego wyzwalacza.');
+              return;
+            }
+
+            const wiersze = zwloki.slice(0, 25).map((z) =>
+              `| ${z.przedmiot} | ${z.seat} | @${z.autor} | ${z.trigger} | ` +
+              TICK + (z.tytul || '').replace(/\|/g, '\\|').slice(0, 48) + TICK + ' |');
+
+            const podsumowanie = Object.entries(poEtacie)
+              .map(([s, n]) => `**${s}**: ${n}`).join(', ');
+
+            const body = [
+              `**${zwloki.length} przypadek(ow), gdzie wyzwalacz etatu zadzialal, a etat nie zostawil sladu.**`,
+              '',
+              `Wedlug etatu: ${podsumowanie}.`,
+              '',
+              'Ta lista nie jest zarzutem o jakosc pracy. Jest odpowiedzia na',
+              'pytanie, ktore 2026-09-01 musial zadac wlasciciel, bo zaden',
+              'przyrzad w tej firmie go nie zadawal: **czy etat, ktory MA',
+              'zdefiniowany wyzwalacz, faktycznie zadzialal, gdy ten wyzwalacz',
+              'wystrzelil.** Wlasnosc powierzchni byla mierzona; wykonanie nie.',
+              '',
+              '| Przedmiot | Etat | Autor | Wyzwalacz | Tytul |',
+              '|---|---|---|---|---|',
+              ...wiersze,
+              '',
+              '### Czego ta bramka NIE widzi',
+              '',
+              'Zapisane wprost, bo raport milczacy o wlasnym zasiegu klamie',
+              'przez pominiecie, a pomiaru niewykonanego nie wolno zapisac',
+              'jako zera.',
+              '',
+              `Stan wyjsciowy: **${historyczne}** PR-ow scalonych w tym oknie`,
+              `przed wlaczeniem bramki (${OD.slice(0, 10)}) nie ma zadnej recenzji.`,
+              'Nie sa wierszami wyzej, bo scalonego PR-a nie da sie juz',
+              'zrecenzowac - kolejka, ktorej nie da sie oproznic, przestaje byc',
+              'czytana. Ta liczba jest punktem odniesienia, nie zadaniem.',
+              '',
+              `Obsada liczy **${OBSADA_ETATOW} etatow** (odczyt ${OBSADA_ODCZYT}).`,
+              'Ta bramka karmi na razie **jedna** klase obowiazku - scalony PR',
+              'bez recenzji. Pozostale klasy sa w module zdefiniowane, ale',
+              '**niekarmione**, i cisza o nich nie znaczy "brak zwloki".',
+              '',
+              'Etaty, ktorych wyzwalacza API GitHuba w ogole nie pokazuje:',
+              '',
+              ...NIEOBSERWOWALNE.map((e) => `- ${TICK}${e.seat}${TICK} - ${e.powod}`),
+              '',
+              'Bramka nie blokuje scalenia i nie ma tego robic: wymaganych',
+              'recenzji jest zero celowo, a --auto jest droga, ktora praca',
+              'lada. Wykrywa i melduje.',
+              '',
+              '_To zgloszenie zamknie sie samo, gdy kolejka bedzie pusta._',
+            ].join(NL);
+
+            if (dashboard.length) {
+              await github.rest.issues.update({
+                owner, repo, issue_number: dashboard[0].number, body,
+              });
+              core.notice(`Zaktualizowano #${dashboard[0].number} - ${zwloki.length} w kolejce.`);
+            } else {
+              const issue = await github.rest.issues.create({
+                owner, repo, title: TYTUL, body, labels: ['raport'],
+              });
+              core.notice(`Utworzono ${issue.data.html_url}`);
+            }

--- a/tools/seat-obligations.js
+++ b/tools/seat-obligations.js
@@ -1,0 +1,163 @@
+// Wykrywa JEDNA rzecz: etat, ktorego wyzwalacz zadzialal, a ktory nie zostawil
+// po sobie zadnego sladu w API GitHuba.
+//
+// Powod, 2026-09-01. Wlasciciel: "nie chce w firmie nigdy takich sytuacji, ze
+// ktos na cos nie spojrzal". Tego dnia szesc scalonych PR-ow - #390, #394,
+// #396, #397, #399, #405 - zwrocilo `0` z `pulls/<n>/reviews`. Wsrod nich PR
+// od czlowieka z zewnatrz uruchamiany na naszych runnerach oraz dwie nowe
+// bramki. Etat `change-board`, ktorego plik mowi, ze "approves or rejects
+// changes on the owner's behalf", nie spojrzal na zaden z nich.
+//
+// Szerzej: z ostatnich 60 PR-ow tego repozytorium dokladnie JEDEN ma
+// jakikolwiek obiekt recenzji (#331), i jest on od
+// `github-advanced-security[bot]`. Zaden nie ma recenzji od czlowieka. Nie
+// bylo wiec regresu - bramka nigdy nie istniala.
+//
+// Czego ten modul NIE robi i dlaczego. Nie blokuje scalenia. `ci-engineer.md`
+// zapisuje, ze `enforce_admins` jest wlaczone a liczba wymaganych recenzji
+// wynosi zero, wiec `--auto` jest celowo droga, ktora praca lada. Wymuszenie
+// recenzji na kazdym PR zatrzymaloby projekt. Ta bramka WYKRYWA i MELDUJE.
+//
+// Dlaczego osobny plik, a nie skrypt w YAML: bramka sklejona w kroku workflow
+// nie da sie przetestowac, a bramka nieprzetestowana wywraca sie w dniu,
+// w ktorym jest potrzebna (patrz DOCTRINE, `UnboundLocalError` w generatorze
+// stron aplikacji). Testy sa w `tools/seat-obligations.test.js`.
+
+/**
+ * Czy ten akt jest naszym dzialaniem, czy tylko szumem.
+ *
+ * Caly zespol dziala jednym loginem (`owner`), wiec API nie potrafi
+ * przypisac aktu do konkretnego etatu - patrz NIEOBSERWOWALNE nizej. To,
+ * co API rozroznia, to CZY ktokolwiek z naszej strony w ogole cos zrobil.
+ *
+ * Bot sie nie liczy. Jedyna recenzja w historii tego repozytorium pochodzi
+ * od `github-advanced-security[bot]`; policzenie jej jako "etat spojrzal"
+ * zamienilaby te bramke w zielone swiatlo dla dokladnie tej sytuacji,
+ * ktora ma wykrywac.
+ */
+export function slad(akt, owner) {
+  if (!akt || !akt.login || !akt.at) return false;
+  // Jeden warunek zalatwia oba pytania i to nie jest skrot. Caly zespol
+  // dziala loginem wlasciciela, a KAZDA nasza automatyka pisze jako
+  // `github-actions[bot]` albo `github-advanced-security[bot]` - zaden bot
+  // nie ma tego loginu. Osobne straze na `typ === 'Bot'` i na sufiks `[bot]`
+  // zostaly tu napisane i USUNIETE po tym, jak celowe zepsucie pokazalo, ze
+  // sa nieosiagalne: test #331 przechodzil takze bez nich. Martwa straz jest
+  // gorsza niz jej brak, bo test obok niej wyglada na pokrycie, ktorym nie jest.
+  return akt.login === owner;
+}
+
+/**
+ * @param {{seat:string, przedmiot:string, trigger:string, wyzwolonyAt:string,
+ *          terminAt:string, akty:Array<{login:string,typ:string,at:string}>,
+ *          owner:string}} o
+ * @param {number} terazMs
+ * @returns {{zwloka:boolean, spozniony:boolean,
+ *            akt:({login:string,typ:string,at:string}|null), wiekH:number}}
+ */
+export function ocenObowiazek(o, terazMs) {
+  const nasze = (o.akty || []).filter((a) => slad(a, o.owner));
+  // Najwczesniejszy akt, nie najpozniejszy: pytanie brzmi "kiedy ktos
+  // pierwszy raz spojrzal", a nie "kiedy ostatni raz".
+  nasze.sort((a, b) => (a.at < b.at ? -1 : 1));
+  const akt = nasze.length ? nasze[0] : null;
+
+  const termin = new Date(o.terminAt).getTime();
+  const poTerminie = terazMs >= termin;
+
+  return {
+    zwloka: !akt && poTerminie,
+    spozniony: !!akt && new Date(akt.at).getTime() > termin,
+    akt,
+    wiekH: Math.max(0, Math.round((terazMs - termin) / 3600000)),
+  };
+}
+
+/**
+ * SZEW DLA `change-board`. Ta funkcja decyduje TYLKO o tym, czy dany PR w
+ * ogole podlega meldowaniu - o TRESC polityki (ktore klasy zmian maja isc
+ * przez recenzje) odpowiada `change-board` w swoim wlasnym pliku, nie ta
+ * bramka. Tutaj jest wylacznie mechanizm, ktory te polityke skonsumuje.
+ *
+ * Do czasu, az polityka zostanie opublikowana, `polityka` jest `null`
+ * i bramka melduje KAZDY scalony PR. To jest celowy domysl w strone
+ * halasu, nie ciszy: cisza jest dokladnie tym trybem awarii, ktory
+ * 2026-09-01 musial zauwazyc wlasciciel.
+ *
+ * CO `change-board` FAKTYCZNIE ZBUDOWAL, sprawdzone 2026-09-01 w tym samym
+ * drzewie: `tools/check-board-review.py`. Jego polityka to nie etykiety, tylko
+ * KLASY SCIEZEK (`packages/<pkg>/package.json`, `.github/workflows/`,
+ * `data/` ...), wymuszane PRZED scaleniem jako czerwona kontrola
+ * zadajaca linii `BOARD:` w tresci PR-a.
+ *
+ * Te globy NIE sa tu przepisane celowo. Dwie kopie tej samej listy rozjezdzaja
+ * sie, a wlascicielem TRESCI polityki jest tamten etat. Jesli zechce zawezic
+ * takze ten raport, publikuje swoje klasy jako `data/review-policy.json`
+ * i bramka je skonsumuje bez zmiany kodu:
+ *   { "etykiety": ["ci", "security"], "zewnetrzniZawsze": true }
+ *
+ * Te dwie bramki sie nie dubluja. Tamta pyta "czy autor NAPISAL, ze byla
+ * decyzja" - i sama zapisuje, ze linii `BOARD:` nikt nie broni przed
+ * wpisaniem jej sobie samemu. Ta pyta "czy w API ISTNIEJE obiekt recenzji" -
+ * tego w tresci PR-a napisac sie nie da. Tamta blokuje waska nazwana klase
+ * przed scaleniem; ta obserwuje wszystko i melduje po fakcie.
+ *
+ * @param {{autor:string, etykiety:string[]}} pr
+ * @param {{etykiety?:string[], zewnetrzniZawsze?:boolean}|null} polityka
+ * @param {string} owner
+ */
+export function wymagaRecenzji(pr, polityka, owner) {
+  if (!polityka) return true;
+  if (polityka.zewnetrzniZawsze !== false && pr.autor !== owner) return true;
+  const chciane = polityka.etykiety || [];
+  return (pr.etykiety || []).some((e) => chciane.includes(e));
+}
+
+/**
+ * @param {Array} obowiazki
+ * @param {number} terazMs
+ * @returns {{zwloki:Array, spoznione:Array, poEtacie:Object}}
+ */
+export function raport(obowiazki, terazMs) {
+  const zwloki = [], spoznione = [], poEtacie = {};
+  for (const o of obowiazki || []) {
+    const w = ocenObowiazek(o, terazMs);
+    if (w.zwloka) {
+      zwloki.push({ ...o, ...w });
+      poEtacie[o.seat] = (poEtacie[o.seat] || 0) + 1;
+    } else if (w.spozniony) {
+      spoznione.push({ ...o, ...w });
+    }
+  }
+  zwloki.sort((a, b) => b.wiekH - a.wiekH);
+  return { zwloki, spoznione, poEtacie };
+}
+
+// Zasieg tej bramki, spisany jawnie, bo DOCTRINE §5 zabrania wymyslania
+// przyrzadow, a pomiaru niewykonanego nie wolno zapisac jako zera. Ta lista
+// jest jedynym uczciwym sposobem, zeby raport nie udawal, ze cisza po stronie
+// pozostalych etatow znaczy "brak zwloki".
+//
+// Runner NIE MOZE policzyc etatow sam: `.claude/` jest w `.gitignore` tego
+// repozytorium (linia 6) i nie ma go w `git ls-files`. Obsada zyje w osobnym
+// repozytorium `msgwing/zerosmtp-team`. Stad liczba ponizej jest wpisana
+// recznie i ma date odczytu.
+export const OBSADA_ETATOW = 28;          // odczyt 2026-09-01, `ls .claude/agents/*.md`
+export const OBSADA_ODCZYT = '2026-09-01';
+
+/**
+ * Etaty, ktorych wyzwalacza ta bramka NIE widzi, z powodem. Powod jest
+ * zawsze jeden z dwoch: albo wyzwalacz nie jest zdarzeniem w API, albo akt
+ * etatu nie zostawia obiektu, ktory da sie odroznic od pracy kogokolwiek
+ * innego dzialajacego tym samym loginem.
+ */
+export const NIEOBSERWOWALNE = [
+  { seat: 'marketing-lead', powod: 'wyzwalacz to rozbieznosc w tekscie na kilku powierzchniach - nie zdarzenie' },
+  { seat: 'color-systems', powod: 'wyzwalacz to ocena wizualna; API nie ma pojecia "strona meczy"' },
+  { seat: 'strategy-director', powod: 'wyzwalacz to konflikt priorytetow, nie obiekt' },
+  { seat: 'competitive-intel', powod: 'wyzwalacz jest w cudzych repozytoriach, akt to wiedza a nie artefakt' },
+  { seat: 'auditor', powod: 'akt to sprostowanie w prozie, nieodrozninalne od zwyklego komentarza' },
+  { seat: 'trust-safety', powod: 'weto jest brakiem dzialania - bramka nie odroznia weta od przeoczenia' },
+  { seat: 'pentester', powod: 'akt bez znaleziska nie zostawia sladu' },
+  { seat: 'traffic-analyst', powod: 'zrodlo to API ruchu, nieczytelne tokenem workflow (403, sprawdzone dwa razy)' },
+];

--- a/tools/seat-obligations.test.js
+++ b/tools/seat-obligations.test.js
@@ -1,0 +1,171 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  slad, ocenObowiazek, raport, wymagaRecenzji, NIEOBSERWOWALNE,
+} from './seat-obligations.js';
+
+const OWNER = 'msgwing';
+const TERAZ = Date.parse('2026-09-01T19:00:00Z');
+
+// Dane ponizej sa prawdziwe - `gh api repos/msgwing/ZeroSMTP/pulls/<n>` oraz
+// `.../reviews` w dniu zbudowania tej bramki. To jest test retrospektywny,
+// ktorego ta firma wymaga przy kazdej bramce: gdyby istniala wczesniej, czy
+// zlapalaby zdarzenie, ktore ja wymusilo?
+
+const pr = (n, autor, mergedAt, akty = []) => ({
+  seat: 'change-board',
+  przedmiot: 'PR #' + n,
+  trigger: 'scalony',
+  wyzwolonyAt: mergedAt,
+  terminAt: mergedAt,
+  autor,
+  akty,
+  owner: OWNER,
+});
+
+const SZESC = [
+  pr(390, 'k4its1t', '2026-08-31T17:11:42Z'),
+  pr(394, 'msgwing', '2026-08-31T17:14:33Z'),
+  pr(396, 'msgwing', '2026-08-31T17:25:03Z'),
+  pr(397, 'msgwing', '2026-08-31T17:35:30Z'),
+  pr(399, 'msgwing', '2026-08-31T17:49:04Z'),
+  pr(405, 'msgwing', '2026-09-01T18:14:01Z'),
+];
+
+test('2026-09-01 retrospektywnie: szesc scalonych PR-ow, zero recenzji - MUSZA zostac zlapane', () => {
+  const { zwloki, poEtacie } = raport(SZESC, TERAZ);
+
+  assert.equal(zwloki.length, 6,
+    'To jest zdarzenie, ktore wymusilo ta bramke. Wlasciciel policzyl je ' +
+    'recznie, bo zaden przyrzad w tej firmie go nie widzial.');
+  assert.equal(poEtacie['change-board'], 6);
+  assert.deepEqual(zwloki.map((z) => z.przedmiot).sort(),
+    ['PR #390', 'PR #394', 'PR #396', 'PR #397', 'PR #399', 'PR #405']);
+});
+
+test('#390 od czlowieka z zewnatrz wazy tyle samo - bramka nie patrzy na autora', () => {
+  const { zwloki } = raport([SZESC[0]], TERAZ);
+  assert.equal(zwloki.length, 1);
+  assert.equal(zwloki[0].autor, 'k4its1t',
+    'PR z cudzego forka uruchamiany na naszych runnerach nie moze byc ' +
+    'traktowany lagodniej niz nasz wlasny.');
+});
+
+// Jedyna recenzja w calej historii tego repozytorium (60 sprawdzonych PR-ow)
+// jest od bota skanujacego kod. Policzenie jej jako "etat spojrzal" zamieniloby
+// te bramke w zielone swiatlo dla dokladnie tej ciszy, ktora ma wykrywac.
+//
+// Uczciwie o tym, co ten test sprawdza: wyklucza go warunek `login === owner`,
+// a nie zadna osobna straz na boty. Zostalo to ustalone celowym zepsuciem -
+// po usunieciu OBU straz na boty test dalej przechodzil, wiec straze byly
+// martwe i zostaly usuniete. Test zostaje jako test ZACHOWANIA (bot nie liczy
+// sie jako spojrzenie), nie jako dowod na istnienie mechanizmu.
+test('#331 retrospektywnie: recenzja od bota NIE jest spojrzeniem etatu', () => {
+  const o = pr(331, 'msgwing', '2026-08-29T17:13:09Z', [
+    { login: 'github-advanced-security[bot]', typ: 'Bot', at: '2026-08-29T12:25:49Z' },
+  ]);
+  const w = ocenObowiazek(o, TERAZ);
+  assert.equal(w.zwloka, true, 'Bot to nie etat.');
+  assert.equal(w.akt, null);
+});
+
+test('recenzja od nas przed scaleniem - brak zwloki, brak spoznienia', () => {
+  const o = pr(500, 'msgwing', '2026-09-01T12:00:00Z', [
+    { login: OWNER, typ: 'User', at: '2026-09-01T11:00:00Z' },
+  ]);
+  const w = ocenObowiazek(o, TERAZ);
+  assert.equal(w.zwloka, false);
+  assert.equal(w.spozniony, false);
+  assert.equal(w.akt.login, OWNER);
+});
+
+// "Spojrzal po scaleniu" to nie to samo co "nie spojrzal" i nie to samo co
+// "spojrzal". Trzeci stan istnieje, bo bez niego wpis w kolejce nigdy nie
+// znika i kolejka przestaje byc kolejka pracy.
+test('recenzja po scaleniu - spozniona, ale kolejka sie oczyszcza', () => {
+  const o = pr(501, 'msgwing', '2026-09-01T12:00:00Z', [
+    { login: OWNER, typ: 'User', at: '2026-09-01T14:00:00Z' },
+  ]);
+  const w = ocenObowiazek(o, TERAZ);
+  assert.equal(w.zwloka, false);
+  assert.equal(w.spozniony, true);
+  const r = raport([o], TERAZ);
+  assert.equal(r.zwloki.length, 0);
+  assert.equal(r.spoznione.length, 1);
+});
+
+// Karencja: obowiazek z terminem w przyszlosci nie jest jeszcze zwloka.
+// Bez tego kazde zgloszenie `do-akceptacji` bylo by breachem w sekundzie,
+// w ktorej dostaje etykiete.
+test('termin jeszcze nie minal - to nie jest zwloka', () => {
+  const o = {
+    seat: 'change-board', przedmiot: 'zgloszenie #999', trigger: 'do-akceptacji',
+    wyzwolonyAt: '2026-09-01T18:00:00Z',
+    terminAt: '2026-09-02T18:00:00Z',
+    akty: [], owner: OWNER,
+  };
+  assert.equal(ocenObowiazek(o, TERAZ).zwloka, false);
+  assert.equal(ocenObowiazek(o, Date.parse('2026-09-03T00:00:00Z')).zwloka, true);
+});
+
+test('najwczesniejszy akt wygrywa - pytanie brzmi kiedy KTOS PIERWSZY spojrzal', () => {
+  const o = pr(502, 'msgwing', '2026-09-01T12:00:00Z', [
+    { login: OWNER, typ: 'User', at: '2026-09-01T15:00:00Z' },
+    { login: OWNER, typ: 'User', at: '2026-09-01T10:00:00Z' },
+  ]);
+  assert.equal(ocenObowiazek(o, TERAZ).akt.at, '2026-09-01T10:00:00Z');
+  assert.equal(ocenObowiazek(o, TERAZ).spozniony, false);
+});
+
+test('slad: obcy login nie jest naszym aktem', () => {
+  assert.equal(slad({ login: OWNER, typ: 'User', at: 'x' }, OWNER), true);
+  assert.equal(slad({ login: 'k4its1t', typ: 'User', at: 'x' }, OWNER), false);
+  assert.equal(slad({ login: 'dependabot[bot]', typ: 'User', at: 'x' }, OWNER), false);
+  assert.equal(slad({ login: 'github-actions[bot]', typ: 'Bot', at: 'x' }, OWNER), false);
+  // Przypadku `{login: OWNER, typ: 'Bot'}` tu nie ma celowo: nie istnieje.
+  // `msgwing` jest kontem czlowieka, a kazdy nasz bot ma wlasny login. Test
+  // na stan, ktory nie moze zajsc, wymusza martwy kod w module.
+  assert.equal(slad(null, OWNER), false);
+  assert.equal(slad({ login: OWNER, typ: 'User' }, OWNER), false);
+});
+
+// Zasieg musi byc czescia wyniku, nie przypisem. Raport, ktory milczy
+// o etatach spoza zasiegu, klamie przez pominiecie - to jest DOCTRINE §5.
+test('lista etatow poza zasiegiem jest niepusta i kazda pozycja ma powod', () => {
+  assert.ok(NIEOBSERWOWALNE.length > 0);
+  for (const e of NIEOBSERWOWALNE) {
+    assert.ok(e.seat && e.powod, 'etat bez powodu jest ozdoba, nie zasiegiem');
+  }
+});
+
+test('pusta lista obowiazkow to pusty raport, nie wyjatek', () => {
+  const r = raport([], TERAZ);
+  assert.deepEqual(r.zwloki, []);
+  assert.deepEqual(r.spoznione, []);
+  assert.deepEqual(r.poEtacie, {});
+  assert.deepEqual(raport(undefined, TERAZ).zwloki, []);
+});
+
+// Szew dla `change-board`. Testowany jest MECHANIZM konsumpcji, nie tresc
+// polityki - tresc nalezy do tamtego etatu i moze sie zmieniac bez ruszania
+// tej bramki.
+test('bez polityki bramka melduje kazdy scalony PR - domysl w strone halasu', () => {
+  assert.equal(wymagaRecenzji({ autor: 'msgwing', etykiety: [] }, null, OWNER), true);
+  assert.equal(wymagaRecenzji({ autor: 'k4its1t', etykiety: [] }, undefined, OWNER), true);
+});
+
+test('z polityka: etykieta kwalifikuje, jej brak nie', () => {
+  const pol = { etykiety: ['ci', 'security'] };
+  assert.equal(wymagaRecenzji({ autor: OWNER, etykiety: ['ci'] }, pol, OWNER), true);
+  assert.equal(wymagaRecenzji({ autor: OWNER, etykiety: ['docs'] }, pol, OWNER), false);
+});
+
+test('z polityka: PR z zewnatrz kwalifikuje sie zawsze, chyba ze wprost wylaczone', () => {
+  const pol = { etykiety: [] };
+  assert.equal(wymagaRecenzji({ autor: 'k4its1t', etykiety: [] }, pol, OWNER), true,
+    '#390 przyszedl z cudzego forka i uruchamial sie na naszych runnerach.');
+  assert.equal(
+    wymagaRecenzji({ autor: 'k4its1t', etykiety: [] },
+      { etykiety: [], zewnetrzniZawsze: false }, OWNER), false);
+});


### PR DESCRIPTION
## What the owner said, and why it is a gate rather than a rule

2026-09-01: *"nie chce w firmie nigdy takich sytuacji, że ktoś na coś nie spojrzał"* — nobody may ever fail to look at something.

The trigger: every pull request merged that day — #390, #394, #396, #397, #399, #405 — returned `0` from `gh api repos/msgwing/ZeroSMTP/pulls/<n>/reviews`. Among them a pull request from an outside contributor running on our runners, a new CI job, and two new gates. `change-board`, whose file says it "approves or rejects changes on the owner's behalf", looked at none of them.

## The measurement that reframes it

Across the **last 60 pull requests, exactly one carries any review object** — #331, from `github-advanced-security[bot]`. Not one human review, ever.

So this was not a regression on a working practice. **The gate never existed.** A rule in a role file said the seat reviews changes, and nothing on earth checked whether it did.

## What it detects

`ocenObowiazek()` answers one question per obligation: the trigger fired — did anyone on our side leave a trace, and how late?

Deliberately narrow, with the limits written into the source rather than discovered later:

- **A bot does not count as looking.** The only review in this repository's history is a bot's; counting it would make this gate green for exactly the situation it exists to catch.
- **Earliest act wins, not latest** — the question is when somebody *first* looked, not when the thread went quiet.
- **It cannot attribute an act to a seat.** Every agent shares the owner's login, so the API cannot distinguish `change-board` from `ci-engineer`. What it can distinguish is whether anybody at all acted. That limit is documented in the module under `NIEOBSERWOWALNE`, not glossed.

## What it does not do

**It does not block merges.** `ci-engineer.md` records that `enforce_admins` is on and zero reviews are required, so `--auto` is deliberately how work lands; requiring a review on every pull request would stall the project. This detects and reports.

## Verified by breaking it

Per the standing rule that a gate which only runs when something is wrong must be proven by making something wrong — after one gate in this repository crashed with `UnboundLocalError` the first time it was actually needed:

```
$ node --test tools/seat-obligations.test.js          →  pass 13   fail 0
# invert slad(): every act counts as ours, bots included
$ node --test tools/seat-obligations.test.js          →  pass 11   fail 2
# restored
$ node --test tools/seat-obligations.test.js          →  pass 13   fail 0
```

The two that fail under inversion are the bot case and the outside-login case — the exact pair the gate exists for.

`python .github/check-workflows.py` → clean. Logic lives in `tools/*.js` with its own test file rather than glued inside YAML, which is the pattern `unanswered-external.js` was extracted for and the reason that one could be tested at all.

## Provenance

Started by `hr-lead`, which terminated on an API error mid-run leaving the work uncommitted. Tests, the deliberate-break pass, the 60-pull-request measurement and this pull request were completed and re-verified rather than taken on trust.


---

BOARD: MERGE - it earns a detectable answer to "did anybody look", which this repository has never had; it reports and does not block, so the deliberate "checks and nothing else" merge path is unchanged.

EVIDENCE: `node --test tools/seat-obligations.test.js` -> pass 13, fail 0; the same command with `slad()` inverted to `return true` -> pass 11, **fail 2** (the bot case and the foreign-login case, the exact pair the gate exists for), restored -> pass 13, fail 0. `python .github/check-workflows.py` -> `Workflow files: clean.` The premise was re-measured rather than taken from the report that raised it: iterating `gh api repos/msgwing/ZeroSMTP/pulls/<n>/reviews` over the last 60 pull requests returns a non-zero count for exactly one, #331, whose single review is from `github-advanced-security[bot]`.

Noted for the record, since this gate cannot attribute an act to a seat (all agents share one login, documented in the module under NIEOBSERWOWALNE): the verdict above was written by the coordinator, who performed the verification listed, not by `change-board`. `hr-lead` began this work and terminated on an API error mid-run, leaving it uncommitted; the tests, the break pass and the 60-pull-request measurement were re-run here rather than trusted.
