### PR TITLE
feat(ci): scalony wklad bez odpowiedzi jest teraz wykrywalny

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -455,6 +455,24 @@ jobs:
       - name: "Etat nie spojrzal: bramka i test na szesciu PR-ach z 2026-09-01"
         run: node --test tools/seat-obligations.test.js
 
+  # Dlug wobec kontrybutorow, ktorych prace SCALILISMY - logika z
+  # `tools/contributor-care.js`. Osobno od `unanswered-external` powyzej, bo
+  # tamten modul patrzy na watki otwarte, a scalony wniosek jest zamkniety;
+  # test niesie prawdziwe dane wszystkich 14 wnioskow od ludzi z zewnatrz
+  # i przewraca sie, gdy ktos odwroci ktorekolwiek z dwoch porownan
+  # decydujacych o tym, czy cokolwiek jest dlugiem.
+  contributor-care:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+      - name: "Scalony wklad bez odpowiedzi: bramka i testy na 14 prawdziwych wnioskach"
+        run: node --test tools/contributor-care.test.js
+
   zerosmtp-mcp:
     needs: changes
     if: needs.changes.outputs.code == 'true'

--- a/.github/workflows/ready-for-approval.yml
+++ b/.github/workflows/ready-for-approval.yml
@@ -409,6 +409,212 @@ jobs:
               core.notice('Utworzono ' + issue.data.html_url);
             }
 
+  # Kontrybutor, ktoremu SCALILISMY prace i nie powiedzielismy ani slowa.
+  #
+  # DLACZEGO OSOBNE ZADANIE, SKORO JEST `czeka-czlowiek` POWYZEJ: tamto pyta
+  # GitHuba o `state: 'open'`. Scalony pull request jest ZAMKNIETY, wiec
+  # przyjeta i nieodnotowana praca byla dla niego niewidzialna z definicji -
+  # nie przez blad w nim. Ta sama slepota dotyczy `zalegle-zewnetrzne`, bo
+  # startuje z tej samej listy.
+  #
+  # Zmierzone 2026-09-01 na wszystkich 14 scalonych wnioskach od ludzi z
+  # zewnatrz: PIEC nie ma ani jednego naszego slowa. #238 i #245 czekaly
+  # dziewiec dni. Zaden przeglad ich nie znalazl, bo zaden nie patrzyl na
+  # rzeczy zamkniete - a to jest jedyne miejsce, gdzie konczy sie przyjeta
+  # praca.
+  #
+  # CZEGO TO ZADANIE CELOWO NIE ROBI:
+  #
+  #   - nie pisze podziekowan. Automatyczne "dziekujemy" jest gorsze niz
+  #     cisza, bo mowi czlowiekowi wprost, ze po drugiej stronie nie bylo
+  #     nikogo. Bramka pokazuje, komu jestesmy winni slowo; slowo pisze
+  #     czlowiek albo agent, imiennie i o tym, co ta osoba faktycznie zrobila.
+  #   - nie zaczepia nikogo, kto ucichl. Uspienie jest w tabeli kontekstu i
+  #     nigdy nie zaklada tego zgloszenia samo. Prog jest nieskalibrowany
+  #     (n=2 odstepy od jednej osoby), a analiza forkujacych z 2026-08-27 juz
+  #     raz pokazala, ze przy takiej probie profilowanie ludzi nie ma pokrycia.
+  #   - nie przypisuje wlasciciela. To jest praca firmy, nie jego.
+  #
+  # Logika siedzi w `tools/contributor-care.js`, testowana na prawdziwych
+  # danych tych 14 wnioskow w `tools/contributor-care.test.js`, i importuje
+  # regule "kto napisal ostatni" z `tools/unanswered-external.js` zamiast
+  # trzymac jej druga kopie.
+  opieka-nad-kontrybutorami:
+    if: github.event_name != 'issues'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const { ocenWklad, ocenOpieke, PROGI } = await import(
+              `${process.env.GITHUB_WORKSPACE}/tools/contributor-care.js`);
+
+            const owner = context.repo.owner, repo = context.repo.repo;
+            const ACK = 'Ten komentarz zostal dodany automatycznie';
+            const TYTUL = 'Kontrybutorzy bez odpowiedzi';
+            const ZALEGLE = 'stan:zalegle';
+            const NL = String.fromCharCode(10);
+            const TICK = String.fromCharCode(96);
+            const teraz = Date.now();
+
+            // Wnioski scalone, nie nasze, nie bota. Zapytanie sprawdzone
+            // 2026-09-01 wobec niezaleznego `gh pr list --state merged`:
+            // oba daja te same 14 numerow.
+            const znalezione = (await github.rest.search.issuesAndPullRequests({
+              q: `repo:${owner}/${repo} is:pr is:merged -author:${owner} -author:app/dependabot`,
+              per_page: 100,
+            })).data.items;
+
+            if (!znalezione.length) {
+              // DOCTRINE §9: cisza i awaria wygladaja tak samo. Zero
+              // scalonych wkladow od ludzi z zewnatrz jest mozliwe tylko w
+              // repozytorium, ktore nigdy zadnego nie mialo - a to nie jest
+              // to repozytorium. Glosno, zamiast "nic nie znaleziono".
+              core.setFailed(
+                'Zapytanie nie zwrocilo ANI JEDNEGO scalonego wniosku z zewnatrz. ' +
+                'To repozytorium ma ich 14, wiec to jest awaria zapytania, ' +
+                'nie pusta kolejka.');
+              return;
+            }
+
+            const wklady = [];
+            for (const it of znalezione) {
+              const kom = (await github.rest.issues.listComments({
+                owner, repo, issue_number: it.number, per_page: 100,
+              })).data;
+              const rec = (await github.rest.pulls.listReviews({
+                owner, repo, pull_number: it.number, per_page: 100,
+              })).data;
+
+              wklady.push(ocenWklad(
+                {
+                  number: it.number,
+                  title: it.title,
+                  user: it.user,
+                  created_at: it.created_at,
+                  merged_at: it.pull_request.merged_at,
+                  pull_request: it.pull_request,
+                },
+                kom, rec, owner, ACK, teraz));
+            }
+
+            const o = ocenOpieke(wklady, teraz, PROGI);
+            core.info(`wkladow: ${wklady.length}, dlug: ${o.dlug}, ` +
+              `bez slowa: ${o.bezPotwierdzenia.length}, ` +
+              `ostatnie slowo ich: ${o.ostatnieSlowoIch.length}, ` +
+              `retencja: ${o.retencja.powracajacych}/${o.retencja.kontrybutorow}`);
+
+            const istniejace = (await github.rest.issues.listForRepo({
+              owner, repo, state: 'open', labels: ZALEGLE, per_page: 100,
+            })).data.filter((i) => !i.pull_request && i.title === TYTUL);
+
+            // Zamyka sie samo. To jest jedyny sposob, w jaki mozna zobaczyc,
+            // ze kolejka jest pusta - tak samo jak w `zalegle-zewnetrzne`.
+            if (!o.dlug) {
+              for (const i of istniejace) {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: i.number,
+                  body: 'Kazdy scalony wklad z zewnatrz ma nasza odpowiedz. Zamykam.',
+                });
+                await github.rest.issues.update({
+                  owner, repo, issue_number: i.number, state: 'closed',
+                });
+              }
+              core.info('Zero dlugu wobec kontrybutorow.');
+              return;
+            }
+
+            const esc = (t) => (t || '').replace(/\|/g, '-').slice(0, 46);
+            const wiersz = (w) => '| ' + w.dniOdScalenia + ' dni | #' + w.numer +
+              ' | @' + w.autor + ' | ' + TICK + esc(w.tytul) + TICK + ' |';
+
+            const body = [];
+            body.push('**' + o.dlug + ' scalony(ch) wklad(ow) od ludzi z zewnatrz czeka na slowo od nas.**');
+            body.push('');
+            body.push('Ta lista patrzy na wnioski **scalone**, czyli zamkniete. `czeka-czlowiek`');
+            body.push('i `zalegle-zewnetrzne` pytaja o `state: open`, wiec przyjeta i nieodnotowana');
+            body.push('praca byla dla nich niewidzialna z definicji.');
+            body.push('');
+
+            if (o.bezPotwierdzenia.length) {
+              body.push('### Ani jednego naszego slowa');
+              body.push('');
+              body.push('Praca przyjeta, watek bez komentarza i bez recenzji z trescia od nas.');
+              body.push('');
+              body.push('| Od scalenia | Wniosek | Kto | Tytul |');
+              body.push('|---|---|---|---|');
+              for (const w of o.bezPotwierdzenia) body.push(wiersz(w));
+              body.push('');
+            }
+
+            if (o.ostatnieSlowoIch.length) {
+              body.push('### Rozmowa byla, ostatnie zdanie zostalo ich');
+              body.push('');
+              body.push('| Od scalenia | Wniosek | Kto | Tytul |');
+              body.push('|---|---|---|---|');
+              for (const w of o.ostatnieSlowoIch) body.push(wiersz(w));
+              body.push('');
+            }
+
+            body.push('### Co z tym zrobic');
+            body.push('');
+            body.push('Napisz w kazdym z tych watkow **imiennie i konkretnie** - co ta zmiana');
+            body.push('dodala i co to zmienia. "Dzieki" jest szumem; "to pierwszy potwierdzony');
+            body.push('raport dla tej galezi firmware, jest juz na liscie zgodnosci" mowi');
+            body.push('czlowiekowi, co kupilo jego piec minut.');
+            body.push('');
+            body.push('**Ta bramka celowo nie pisze tych slow sama.** Automatyczne podziekowanie');
+            body.push('jest gorsze niz cisza - mowi wprost, ze po drugiej stronie nie bylo nikogo.');
+            body.push('');
+            body.push('---');
+            body.push('');
+            body.push('### Kontekst - te liczby NIE zakladaja tego zgloszenia');
+            body.push('');
+            body.push('**Retencja: ' + o.retencja.powracajacych + ' z ' +
+              o.retencja.kontrybutorow + ' kontrybutorow zlozylo wiecej niz jeden wklad.**');
+            body.push('To jest liczba zliczona, nie prognoza - nie mowi, dlaczego ktos nie wrocil.');
+            body.push('');
+
+            if (o.usypiajacy.length) {
+              body.push('**Ucichli (>= ' + PROGI.uspienieDni + ' dni od ICH ostatniej czynnosci, nie od naszego scalenia):**');
+              body.push('');
+              for (const p of o.usypiajacy) {
+                body.push('- @' + p.login + ' - ' + p.dni + ' dni, wkladow: ' + p.wkladow);
+              }
+              body.push('');
+              body.push('**Prog ' + PROGI.uspienieDni + ' dni jest nieskalibrowany i nie udajemy inaczej.**');
+              body.push('Jedyne dane, na ktorych da sie go oprzec, to dwa odstepy miedzy wkladami');
+              body.push('jednej osoby (3 i 4 dni). Czy zaczepienie kogos, kto ucichl, pomaga czy');
+              body.push('szkodzi - **tego nie da sie tutaj zmierzyc** i nikt tego nie zmierzyl.');
+              body.push('Ta lista jest informacja dla czlowieka, nie poleceniem kontaktu.');
+              body.push('');
+            }
+
+            body.push('_To zgloszenie zamknie sie samo, gdy kazdy scalony wklad dostanie odpowiedz._');
+
+            const tresc = body.join(NL);
+
+            if (istniejace.length) {
+              await github.rest.issues.update({
+                owner, repo, issue_number: istniejace[0].number, body: tresc,
+              });
+              core.notice('Zaktualizowano #' + istniejace[0].number + ' - dlug: ' + o.dlug);
+            } else {
+              const zgl = await github.rest.issues.create({
+                owner, repo, title: TYTUL, body: tresc,
+                // Jedna etykieta stanu, zgodnie z regula "kazde otwarte
+                // zgloszenie nosi dokladnie jedna". Zalegle jest wlasciwe:
+                // nikt tego nie robi i nikt nie czeka na wlasciciela.
+                labels: [ZALEGLE],
+              });
+              core.notice('Utworzono ' + zgl.data.html_url);
+            }
+
   waiting:
     if: github.event_name != 'issues'
     runs-on: ubuntu-latest

--- a/tools/contributor-care.js
+++ b/tools/contributor-care.js
@@ -1,0 +1,195 @@
+// Dlug wobec kontrybutorow: czyja praca zostala SCALONA, a nikt z nas nie
+// powiedzial mu ani slowa.
+//
+// DLACZEGO OSOBNY MODUL, SKORO ISTNIEJE unanswered-external.js
+//
+// `tools/unanswered-external.js` odpowiada na pytanie "czy ostatnie slowo w
+// tym watku jest nasze" i jest poprawny. Zadania, ktore go wolaja
+// (`czeka-czlowiek`, `zalegle-zewnetrzne`), pytaja jednak GitHuba o
+// `state: 'open'` - a scalony pull request jest ZAMKNIETY. Wklad, ktory
+// zostal przyjety i nieodnotowany, byl dla tamtej bramki niewidzialny
+// z definicji, nie przez blad w niej.
+//
+// Zmierzone 2026-09-01, po przejrzeniu wszystkich 14 scalonych wnioskow od
+// ludzi z zewnatrz: PIEC z nich nie ma ani jednego slowa od nas, a nie
+// jedno, jak sadzono. #238 i #245 czekaly dziewiec dni i nie znalazl ich
+// zaden przeglad, bo zaden nie patrzyl na rzeczy zamkniete.
+//
+// Modul jest czysty - zadnych wywolan sieciowych. Regule "kto napisal
+// ostatni" importujemy z unanswered-external.js zamiast pisac ja drugi raz:
+// dwie kopie tej samej logiki rozjezdzaja sie przy pierwszej poprawce.
+
+import { ocenWatek, jestZewnetrzny } from './unanswered-external.js';
+
+export const PROGI = {
+  // Ile godzin po scaleniu wklad zaczyna sie liczyc jako dlug. Nie jest
+  // wymyslony: CLAUDE.md niesie stojace polecenie "Odpowiadac tym ludziom
+  // tego samego dnia", wiec doba jest zapisana norma tej firmy, a nie
+  // wygodnie dobrana liczba. Sprawdzone na przypadku: #390 dostal
+  // podziekowanie po okolo 25 godzinach i ta bramka MA sie o niego upomniec.
+  potwierdzenieH: 24,
+
+  // Po ilu dniach ciszy kontrybutor jest uznany za usypiajacego.
+  //
+  // TEN PROG JEST NIESKALIBROWANY I TAK MA BYC RAPORTOWANY. Jedyne dane, na
+  // ktorych da sie go oprzec, to odstepy miedzy kolejnymi wkladami jedynego
+  // powracajacego kontrybutora (Mohitingale13): 3 i 4 dni. Dwie obserwacje
+  // od jednej osoby to nie jest rozklad. 21 dni to okolo pieciokrotnosc
+  // tego, co widzielismy - liczba wybrana, nie wyliczona.
+  //
+  // Dlatego uspienie NIGDY nie zaklada zgloszenia samo i nie generuje
+  // zadnego kontaktu. Jest wylacznie wierszem kontekstu. To ta sama
+  // konkluzja, ktora dala analiza forkujacych z 2026-08-27: przy n=5
+  // profilowanie ludzi po metadanych nie ma pokrycia, a niezamowiony
+  // kontakt kosztuje wiecej, niz moze przyniesc.
+  uspienieDni: 21,
+};
+
+/** Czy to jest prawdziwe slowo od nas, a nie pusta formalnosc. */
+export function jestNaszymSlowem(login, body, owner, ackMarker) {
+  if (login !== owner) return false;
+  const t = (body || '').trim();
+  if (!t) return false;
+  // Wlasne automatyczne potwierdzenie nie jest podziekowaniem. Ta sama
+  // zasada co w ocenWatek: bot nie zalatwia dlugu za czlowieka.
+  if (ackMarker && t.includes(ackMarker)) return false;
+  return true;
+}
+
+export function dniOd(iso, teraz) {
+  return Math.floor((teraz - new Date(iso).getTime()) / 86400000);
+}
+
+export function godzinOd(iso, teraz) {
+  return Math.floor((teraz - new Date(iso).getTime()) / 3600000);
+}
+
+/**
+ * Najpozniejszy slad autora wniosku w jego wlasnym watku.
+ *
+ * SWIADOMIE bez `merged_at`: scalenie jest NASZA czynnoscia, nie jego.
+ * Liczac je jako jego aktywnosc, zrobilibysmy z wlasnego klikniecia dowod,
+ * ze kontrybutor wciaz jest z nami - a to jest dokladnie ten rodzaj miary,
+ * ktora sama sobie przytakuje. Na zywym przypadku roznica wynosi piec dni:
+ * @slegarraga wyslal ostatni wniosek 2026-08-06, a my scalilismy go
+ * 2026-08-11.
+ */
+function ostatniaAktywnoscAutora(pr, komentarze, owner) {
+  let max = pr.created_at;
+  for (const k of komentarze || []) {
+    const login = k.user && k.user.login;
+    if (!jestZewnetrzny(login, k.user && k.user.type, owner)) continue;
+    if (login !== pr.user.login) continue;
+    if (k.created_at > max) max = k.created_at;
+  }
+  return max;
+}
+
+/**
+ * Ocenia JEDEN scalony wniosek od kogos z zewnatrz.
+ *
+ * @param {{number:number, title:string, user:{login:string,type:string}, created_at:string, merged_at:string}} pr
+ * @param {Array<{user:{login:string,type:string}, created_at:string, body:string}>} komentarze
+ * @param {Array<{user:{login:string,type:string}, submitted_at:string, body:string, state:string}>} recenzje
+ * @param {string} owner
+ * @param {string} ackMarker
+ * @param {number} teraz - Date.now()
+ */
+export function ocenWklad(pr, komentarze, recenzje, owner, ackMarker, teraz) {
+  let potwierdzone = false;
+  for (const k of komentarze || []) {
+    if (jestNaszymSlowem(k.user && k.user.login, k.body, owner, ackMarker)) {
+      potwierdzone = true;
+      break;
+    }
+  }
+  if (!potwierdzone) {
+    // Recenzja z trescia jest podziekowaniem tak samo jak komentarz - i to
+    // nie jest szczegol. Trzy wklady @slegarraga (#83, #84, #85) nie maja
+    // ani jednego zwyklego komentarza od nas, tylko recenzje z trescia.
+    // Bramka liczaca wylacznie komentarze zglosilaby je jako dlug i tym
+    // samym nauczyla czytelnika, ze ta lista klamie.
+    //
+    // Pusta akceptacja to co innego: APPROVED bez tresci jest mechanika
+    // scalania, nie slowem powiedzianym czlowiekowi.
+    for (const r of recenzje || []) {
+      if (jestNaszymSlowem(r.user && r.user.login, r.body, owner, ackMarker)) {
+        potwierdzone = true;
+        break;
+      }
+    }
+  }
+
+  // ocenWatek chce watku i list komentarzy - dla PR-a dziala tak samo, bo
+  // pull request jest u GitHuba zgloszeniem.
+  const { czeka, ostatniZewnetrzny } =
+    ocenWatek(pr, komentarze, recenzje, owner, ackMarker);
+
+  return {
+    numer: pr.number,
+    autor: pr.user.login,
+    tytul: pr.title || '',
+    mergedAt: pr.merged_at,
+    dniOdScalenia: dniOd(pr.merged_at, teraz),
+    // Dojrzaly = minela doba od scalenia. Przed nia nie ma dlugu, jest
+    // swiezy merge i ktos wlasnie pisze odpowiedz.
+    dojrzaly: godzinOd(pr.merged_at, teraz) >= PROGI.potwierdzenieH,
+    potwierdzone,
+    ostatnieSlowoIch: czeka,
+    ostatniZewnetrzny,
+    ostatniaAktywnosc: ostatniaAktywnoscAutora(pr, komentarze, owner),
+  };
+}
+
+/**
+ * Sklada oceny pojedynczych wkladow w jeden obraz opieki nad kontrybutorami.
+ *
+ * @param {Array<ReturnType<typeof ocenWklad>>} wklady
+ * @param {number} teraz
+ * @param {typeof PROGI} progi
+ */
+export function ocenOpieke(wklady, teraz, progi = PROGI) {
+  const wgDaty = (a, b) => (a.mergedAt < b.mergedAt ? -1 : 1);
+
+  const bezPotwierdzenia = wklady
+    .filter((w) => w.dojrzaly && !w.potwierdzone)
+    .sort(wgDaty);
+
+  // Wklad bez ani jednego naszego slowa jest juz na liscie wyzej - ten sam
+  // czlowiek nie ma sie pojawiac dwa razy pod dwoma naglowkami, bo wtedy
+  // dlug wyglada na wiekszy, niz jest, i lista traci wiarygodnosc.
+  const ostatnieSlowoIch = wklady
+    .filter((w) => w.dojrzaly && w.potwierdzone && w.ostatnieSlowoIch)
+    .sort(wgDaty);
+
+  const perOsoba = new Map();
+  for (const w of wklady) {
+    const p = perOsoba.get(w.autor) || { wkladow: 0, ostatnia: '' };
+    p.wkladow++;
+    if (w.ostatniaAktywnosc > p.ostatnia) p.ostatnia = w.ostatniaAktywnosc;
+    perOsoba.set(w.autor, p);
+  }
+
+  const usypiajacy = [...perOsoba.entries()]
+    .map(([login, p]) => ({ login, wkladow: p.wkladow, ostatnia: p.ostatnia, dni: dniOd(p.ostatnia, teraz) }))
+    .filter((p) => p.dni >= progi.uspienieDni)
+    .sort((a, b) => b.dni - a.dni);
+
+  // Retencja liczona z tego, co widac: ilu ludzi wrocilo po drugi wklad.
+  // To jest liczba, nie prognoza. Nie mowi nic o tym, DLACZEGO ktos nie
+  // wrocil, i nie wolno jej tak uzywac.
+  const kontrybutorow = perOsoba.size;
+  const powracajacych = [...perOsoba.values()].filter((p) => p.wkladow > 1).length;
+
+  return {
+    bezPotwierdzenia,
+    ostatnieSlowoIch,
+    usypiajacy,
+    retencja: { kontrybutorow, powracajacych },
+    // JEDYNA liczba, ktora zaklada albo zamyka zgloszenie. Uspienie i
+    // retencja sa kontekstem i celowo NIE licza sie do dlugu: kolejka do
+    // polowy wypelniona rzeczami, ktorych nie da sie zalatwic, przestaje
+    // byc czytana - a to juz kosztowalo ten projekt kolejke `outreach`.
+    dlug: bezPotwierdzenia.length + ostatnieSlowoIch.length,
+  };
+}

--- a/tools/contributor-care.test.js
+++ b/tools/contributor-care.test.js
@@ -1,0 +1,252 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ocenWklad, ocenOpieke, jestNaszymSlowem, PROGI } from './contributor-care.js';
+
+const OWNER = 'msgwing';
+const ACK = 'Ten komentarz zostal dodany automatycznie';
+
+// TERAZ ustawione na chwile pomiaru, zeby wieki liczyly sie tak jak wtedy.
+const TERAZ = new Date('2026-09-01T19:00:00Z').getTime();
+
+// Dane ponizej sa PRAWDZIWE - odczytane 2026-09-01 przez
+//   gh api repos/msgwing/ZeroSMTP/issues/<n>/comments
+//   gh api repos/msgwing/ZeroSMTP/pulls/<n>/reviews
+// dla wszystkich 14 scalonych wnioskow od ludzi z zewnatrz. Tresci sa
+// skrocone do dlugosci, bo liczy sie tylko kto i kiedy, oraz czy tresc byla
+// niepusta.
+const k = (login, at, body) => ({ user: { login, type: 'User' }, created_at: at, body });
+const r = (login, at, state, body) => ({ user: { login, type: 'User' }, submitted_at: at, state, body });
+const pr = (numer, autor, utworzony, scalony, tytul) => ({
+  number: numer,
+  title: tytul || 'x',
+  user: { login: autor, type: 'User' },
+  created_at: utworzony,
+  merged_at: scalony,
+  pull_request: {},
+});
+
+test('#238: scalony 9 dni temu, ZERO komentarzy i ZERO recenzji - dlug', () => {
+  const w = ocenWklad(
+    pr(238, 'Mohitingale13', '2026-08-23T10:08:28Z', '2026-08-23T12:22:19Z'),
+    [], [], OWNER, ACK, TERAZ);
+
+  assert.equal(w.potwierdzone, false,
+    'Praca zostala przyjeta i nikt nie powiedzial ani slowa. Ten wklad byl ' +
+    'niewidoczny dla kazdego dotychczasowego przegladu, bo scalony PR jest ' +
+    'zamkniety, a `czeka-czlowiek` pyta wylacznie o state:open.');
+  assert.equal(w.dojrzaly, true);
+  assert.equal(w.dniOdScalenia, 9);
+});
+
+test('#245: drugi taki sam przypadek tego samego dnia', () => {
+  const w = ocenWklad(
+    pr(245, 'Mohitingale13', '2026-08-23T10:21:58Z', '2026-08-23T12:24:47Z'),
+    [], [], OWNER, ACK, TERAZ);
+  assert.equal(w.potwierdzone, false);
+});
+
+test('#83 @slegarraga: sama recenzja z trescia, zero komentarzy - NIE dlug', () => {
+  const w = ocenWklad(
+    pr(83, 'slegarraga', '2026-08-06T05:49:29Z', '2026-08-11T18:28:53Z'),
+    [],
+    [
+      r('msgwing', '2026-08-09T11:56:06Z', 'CHANGES_REQUESTED', 'x'.repeat(3156)),
+      r('msgwing', '2026-08-11T18:17:06Z', 'APPROVED', 'x'.repeat(139)),
+      r('msgwing', '2026-08-11T18:28:50Z', 'APPROVED', 'x'.repeat(100)),
+    ],
+    OWNER, ACK, TERAZ);
+
+  assert.equal(w.potwierdzone, true,
+    'Bramka liczaca wylacznie komentarze zglosilaby trzy wklady tego ' +
+    'czlowieka jako niepotwierdzone. Recenzja z trescia jest rozmowa.');
+  assert.equal(w.ostatnieSlowoIch, false);
+});
+
+test('pusta akceptacja NIE jest slowem do czlowieka', () => {
+  const w = ocenWklad(
+    pr(999, 'ktos', '2026-08-01T00:00:00Z', '2026-08-01T01:00:00Z'),
+    [], [r('msgwing', '2026-08-01T02:00:00Z', 'APPROVED', '')],
+    OWNER, ACK, TERAZ);
+  assert.equal(w.potwierdzone, false,
+    'APPROVED bez tresci to mechanika scalania, nie podziekowanie.');
+});
+
+test('#362 @lesbass: jedyny komentarz jest od INNEGO kontrybutora, nie od nas', () => {
+  const w = ocenWklad(
+    pr(362, 'lesbass', '2026-08-30T10:42:24Z', '2026-08-30T12:07:20Z'),
+    [k('Mohitingale13', '2026-08-30T11:54:08Z', 'x'.repeat(747))],
+    [], OWNER, ACK, TERAZ);
+
+  assert.equal(w.potwierdzone, false,
+    'Watek ma komentarz, wiec z listy "0 komentarzy" wypadal. Ale ten ' +
+    'komentarz napisal inny czlowiek z zewnatrz - @lesbass nie uslyszal od ' +
+    'nas niczego.');
+  assert.equal(w.ostatnieSlowoIch, true);
+  assert.equal(w.ostatniZewnetrzny.autor, 'Mohitingale13');
+});
+
+test('#369: ostatnie slowo autora, zero slow od nas', () => {
+  const w = ocenWklad(
+    pr(369, 'Mohitingale13', '2026-08-30T12:27:39Z', '2026-08-30T14:54:06Z'),
+    [k('Mohitingale13', '2026-08-30T12:29:49Z', 'x'.repeat(370))],
+    [], OWNER, ACK, TERAZ);
+  assert.equal(w.potwierdzone, false);
+  assert.equal(w.ostatnieSlowoIch, true);
+});
+
+test('#300: rozmawialismy, ale ostatnie slowo zostalo jego', () => {
+  const w = ocenWklad(
+    pr(300, 'Mohitingale13', '2026-08-26T05:33:00Z', '2026-08-26T21:15:29Z'),
+    [
+      k('msgwing', '2026-08-26T21:15:26Z', 'x'.repeat(1810)),
+      k('Mohitingale13', '2026-08-27T18:12:17Z', 'x'.repeat(865)),
+      k('msgwing', '2026-08-30T10:02:59Z', 'x'.repeat(1734)),
+      k('Mohitingale13', '2026-08-30T11:27:08Z', 'x'.repeat(281)),
+      k('msgwing', '2026-08-30T11:51:01Z', 'x'.repeat(337)),
+      k('Mohitingale13', '2026-08-30T12:34:02Z', 'x'.repeat(448)),
+    ],
+    [], OWNER, ACK, TERAZ);
+
+  assert.equal(w.potwierdzone, true, 'Podziekowanie bylo.');
+  assert.equal(w.ostatnieSlowoIch, true, 'A mimo to ostatnie slowo jest jego.');
+});
+
+test('#390 @k4its1t: retrospektywnie - przed podziekowaniem dlug, po nim nie', () => {
+  const wniosek = pr(390, 'k4its1t', '2026-08-31T11:51:11Z', '2026-08-31T17:11:42Z');
+
+  // Stan przez pierwsze 25 godzin po scaleniu: zero komentarzy.
+  const przed = ocenWklad(wniosek, [], [], OWNER, ACK,
+    new Date('2026-09-01T18:00:00Z').getTime());
+  assert.equal(przed.dojrzaly, true,
+    'Doba minela, wiec ta bramka upomnialaby sie o #390 zanim ktokolwiek ' +
+    'zauwazyl go recznie.');
+  assert.equal(przed.potwierdzone, false);
+
+  const po = ocenWklad(wniosek,
+    [
+      k('msgwing', '2026-09-01T18:23:49Z', 'x'.repeat(1484)),
+      k('msgwing', '2026-09-01T18:25:38Z', 'x'.repeat(1235)),
+    ],
+    [], OWNER, ACK, TERAZ);
+  assert.equal(po.potwierdzone, true);
+  assert.equal(po.ostatnieSlowoIch, false);
+});
+
+test('swiezo scalony wklad nie jest jeszcze dlugiem', () => {
+  const w = ocenWklad(
+    pr(500, 'ktos', '2026-09-01T16:00:00Z', '2026-09-01T17:00:00Z'),
+    [], [], OWNER, ACK, TERAZ);
+  assert.equal(w.dojrzaly, false,
+    'Dwie godziny po scaleniu ktos wlasnie pisze odpowiedz. Bramka, ktora ' +
+    'krzyczy natychmiast, uczy zeby jej nie czytac.');
+});
+
+test('wlasne automatyczne potwierdzenie nie zamyka dlugu', () => {
+  assert.equal(jestNaszymSlowem(OWNER, ACK + ' po 4 godzinach', OWNER, ACK), false);
+  assert.equal(jestNaszymSlowem(OWNER, 'Dziekujemy, to pierwszy raport dla tej wersji.', OWNER, ACK), true);
+  assert.equal(jestNaszymSlowem('Mohitingale13', 'dzieki!', OWNER, ACK), false);
+});
+
+// --- Caly stan repozytorium, zmierzony 2026-09-01 ---------------------------
+// Wszystkie 14 scalonych wnioskow od ludzi z zewnatrz. Zapytanie, ktore je
+// wylonilo (i ktorego wynik zgadza sie co do numeru z niezaleznym
+// `gh pr list --state merged`):
+//   gh api -X GET search/issues -f q='repo:msgwing/ZeroSMTP is:pr is:merged
+//     -author:msgwing -author:app/dependabot'
+
+const WSZYSTKIE = [
+  [pr(83, 'slegarraga', '2026-08-06T05:49:29Z', '2026-08-11T18:28:53Z'), [],
+    [r('msgwing', '2026-08-09T11:56:06Z', 'CHANGES_REQUESTED', 'x'.repeat(3156)),
+     r('msgwing', '2026-08-11T18:28:50Z', 'APPROVED', 'x'.repeat(100))]],
+  [pr(84, 'slegarraga', '2026-08-06T15:52:48Z', '2026-08-11T19:07:06Z'),
+    [k('msgwing', '2026-08-11T18:20:02Z', 'x'.repeat(979))],
+    [r('msgwing', '2026-08-11T19:07:03Z', 'APPROVED', 'x'.repeat(430))]],
+  [pr(85, 'slegarraga', '2026-08-06T16:18:41Z', '2026-08-11T18:17:04Z'),
+    [k('msgwing', '2026-08-29T12:00:06Z', 'x'.repeat(1210))],
+    [r('msgwing', '2026-08-11T18:17:00Z', 'APPROVED', 'x'.repeat(139))]],
+  [pr(223, 'Mohitingale13', '2026-08-22T18:01:22Z', '2026-08-23T09:39:21Z'),
+    [k('msgwing', '2026-08-23T09:28:28Z', 'x'.repeat(1683))], []],
+  [pr(230, 'Mohitingale13', '2026-08-22T18:50:28Z', '2026-08-23T09:41:49Z'),
+    [k('msgwing', '2026-08-23T09:43:18Z', 'x'.repeat(1269))], []],
+  [pr(238, 'Mohitingale13', '2026-08-23T10:08:28Z', '2026-08-23T12:22:19Z'), [], []],
+  [pr(245, 'Mohitingale13', '2026-08-23T10:21:58Z', '2026-08-23T12:24:47Z'), [], []],
+  [pr(252, 'Mohitingale13', '2026-08-23T10:54:01Z', '2026-08-23T12:26:36Z'),
+    [k('msgwing', '2026-08-23T12:27:05Z', 'x'.repeat(1426)),
+     k('Mohitingale13', '2026-08-23T13:32:53Z', 'x'.repeat(536)),
+     k('msgwing', '2026-08-25T19:43:19Z', 'x'.repeat(1786))], []],
+  [pr(300, 'Mohitingale13', '2026-08-26T05:33:00Z', '2026-08-26T21:15:29Z'),
+    [k('msgwing', '2026-08-26T21:15:26Z', 'x'.repeat(1810)),
+     k('Mohitingale13', '2026-08-30T12:34:02Z', 'x'.repeat(448))], []],
+  [pr(310, 'TrueFurina', '2026-08-27T16:45:35Z', '2026-08-27T19:32:41Z'),
+    [k('msgwing', '2026-08-27T19:07:15Z', 'x'.repeat(1690))], []],
+  [pr(362, 'lesbass', '2026-08-30T10:42:24Z', '2026-08-30T12:07:20Z'),
+    [k('Mohitingale13', '2026-08-30T11:54:08Z', 'x'.repeat(747))], []],
+  [pr(368, 'Mohitingale13', '2026-08-30T12:16:19Z', '2026-08-30T14:52:12Z'), [], []],
+  [pr(369, 'Mohitingale13', '2026-08-30T12:27:39Z', '2026-08-30T14:54:06Z'),
+    [k('Mohitingale13', '2026-08-30T12:29:49Z', 'x'.repeat(370))], []],
+  [pr(390, 'k4its1t', '2026-08-31T11:51:11Z', '2026-08-31T17:11:42Z'),
+    [k('msgwing', '2026-09-01T18:23:49Z', 'x'.repeat(1484))], []],
+];
+
+const oceny = () => WSZYSTKIE.map(
+  ([w, kom, rec]) => ocenWklad(w, kom, rec, OWNER, ACK, TERAZ));
+
+test('stan zastany: PIEC wkladow bez ani jednego slowa od nas', () => {
+  const o = ocenOpieke(oceny(), TERAZ);
+
+  assert.deepEqual(o.bezPotwierdzenia.map((w) => w.numer), [238, 245, 362, 368, 369],
+    'Brief opisujacy to zadanie wymienial jeden zalegly wklad (#368). ' +
+    'Recznie znaleziono drugi (#390). Bramka znajduje piec, najstarsze ' +
+    'czekaja dziewiec dni - i wszystkie piec byly widoczne przez caly czas ' +
+    'dla kazdego, kto zapytalby o rzeczy ZAMKNIETE.');
+
+  assert.deepEqual(o.ostatnieSlowoIch.map((w) => w.numer), [300],
+    'Watki, gdzie rozmowa byla, ale ostatnie zdanie zostalo ich. ' +
+    '#362 i #369 nie dubluja sie tutaj - sa juz wyzej.');
+
+  assert.equal(o.dlug, 6);
+});
+
+test('retencja: 2 z 5 kontrybutorow wrocilo po drugi wklad', () => {
+  const o = ocenOpieke(oceny(), TERAZ);
+  assert.deepEqual(o.retencja, { kontrybutorow: 5, powracajacych: 2 });
+});
+
+test('uspienie: @slegarraga cichnie od 26 dni i jest jedyny', () => {
+  const o = ocenOpieke(oceny(), TERAZ);
+  assert.deepEqual(o.usypiajacy.map((p) => [p.login, p.dni]), [['slegarraga', 26]],
+    'Liczone od jego OSTATNIEJ wlasnej czynnosci (2026-08-06), nie od ' +
+    'naszego scalenia (2026-08-11). Roznica to piec dni.');
+});
+
+test('uspienie i retencja NIE podnosza dlugu', () => {
+  // Tylko czyste wklady: wszystko potwierdzone, ostatnie slowo nasze,
+  // ale autor milczy od pol roku.
+  const stary = ocenWklad(
+    pr(1, 'ktos-dawny', '2026-01-01T00:00:00Z', '2026-01-02T00:00:00Z'),
+    [k('msgwing', '2026-01-02T01:00:00Z', 'dziekujemy')], [], OWNER, ACK, TERAZ);
+
+  const o = ocenOpieke([stary], TERAZ);
+  assert.equal(o.usypiajacy.length, 1, 'Uspienie widac...');
+  assert.equal(o.dlug, 0,
+    '...ale dlug jest zerowy, wiec zgloszenie sie NIE zaklada. Prog ' +
+    'uspienia jest nieskalibrowany (n=2 odstepy od jednej osoby), a kolejka ' +
+    'z pozycjami, ktorych nie da sie zalatwic, przestaje byc czytana.');
+});
+
+test('czysty stan: zero dlugu, kolejka do zamkniecia', () => {
+  const czysty = ocenWklad(
+    pr(2, 'ktos', '2026-08-30T00:00:00Z', '2026-08-30T01:00:00Z'),
+    [k('msgwing', '2026-08-30T02:00:00Z', 'dziekujemy, to pierwszy taki raport')],
+    [], OWNER, ACK, TERAZ);
+  const o = ocenOpieke([czysty], TERAZ);
+  assert.equal(o.dlug, 0);
+  assert.equal(o.bezPotwierdzenia.length, 0);
+  assert.equal(o.ostatnieSlowoIch.length, 0);
+});
+
+test('progi sa jawne i nie zmienily sie po cichu', () => {
+  assert.equal(PROGI.potwierdzenieH, 24);
+  assert.equal(PROGI.uspienieDni, 21);
+});


### PR DESCRIPTION
## Co bylo zalozone, co zmierzono, co z tego wynika

**Zalozone:** nadzor nad odpowiadaniem ludziom z zewnatrz jest kompletny -
`czeka-czlowiek` i `zalegle-zewnetrzne` pilnuja, zeby ostatnie slowo bylo nasze.

**Zmierzone:** oba zadania pytaja GitHuba o `state: 'open'`. **Scalony pull
request jest zamkniety.** Praca przyjeta i nieodnotowana byla dla nich
niewidzialna z definicji, a nie przez blad - i to jest jedyne miejsce, w
ktorym konczy zycie wklad kontrybutora.

Przeskanowane wszystkie **14** scalonych wnioskow od ludzi z zewnatrz:

| stan | ile |
|---|---|
| **bez ani jednego naszego slowa** | **5** - #238, #245 (po 9 dni), #362, #368, #369 |
| rozmowa byla, ostatnie zdanie ich | 1 - #300 |
| retencja | **2 z 5** kontrybutorow zlozylo drugi wklad |
| ucichli | @slegarraga, **26 dni** |

Zlecenie tego zadania wymienialo **jeden** zalegly wklad. Recznie znaleziono
drugi. Bramka znajduje **piec**.

## Dwie rzeczy, ktore wychodza tylko dlatego, ze bramka sprawdza AUTORA

Nie liczbe komentarzy:

- **#362 (@lesbass)** ma komentarz, wiec z listy "zero komentarzy" wypadal.
  Ten komentarz napisal **inny kontrybutor**. @lesbass nie uslyszal od nas nic.
- **#83-#85 (@slegarraga)** nie maja ani jednego zwyklego komentarza od nas,
  tylko recenzje z trescia - i **nie sa dlugiem**. Bramka liczaca komentarze
  dalaby trzy falszywe trafienia i nauczylaby czytelnika, ze ta lista klamie.
  Pusta akceptacja (`APPROVED` bez tresci) dlugu nie zamyka.

## Progi, i ktory z nich jest wybrany zamiast wyliczony

- **24 godziny** do dojrzalosci wkladu - to nie jest wygodna liczba, tylko
  zapisana norma tej firmy ("odpowiadac tym ludziom tego samego dnia").
  Sprawdzone retrospektywnie: #390 dostal podziekowanie po ~25 godzinach,
  wiec ta bramka upomnialaby sie o niego przed czlowiekiem.
- **21 dni** ciszy kontrybutora - **wybrany, nie wyliczony**, okolo
  pieciokrotnosc jedynych zaobserwowanych odstepow miedzy wkladami (3 i 4 dni,
  od jednej osoby). Dlatego uspienie **nigdy nie zaklada zgloszenia samo**
  i nie generuje kontaktu - jest wierszem kontekstu.

Cisza liczona od **jego** ostatniej czynnosci, nie od naszego scalenia.
Inaczej wlasne klikniecie byloby dowodem, ze kontrybutor wciaz z nami jest;
na @slegarraga roznica wynosi piec dni.

## Czego to zadanie celowo nie robi

- **Nie pisze podziekowan.** Automatyczne "dziekujemy" jest gorsze niz cisza -
  mowi czlowiekowi wprost, ze po drugiej stronie nie bylo nikogo, i cofa
  dokladnie to, po co bramka powstala. Bramka mowi, komu jestesmy winni slowo;
  slowo pisze czlowiek, imiennie i o tym, co ta osoba zrobila.
- **Nie zaczepia nikogo, kto ucichl.** Przy piatce kontrybutorow nie da sie
  wyliczyc, czy to pomaga czy szkodzi - ta sama konkluzja co analiza
  forkujacych z 2026-08-27.
- **Nie przypisuje wlasciciela.** To praca firmy.
- **Nie zaklada drugiej kolejki na `good first issue`.** Jesli ktos zapytal
  i nie odpowiedzielismy, `czeka-czlowiek` juz to lapie.

## Sprawdzone przez zepsucie, nie przez przeczytanie

Bramka, ktora uruchamia sie tylko gdy cos jest zle, musi zostac sprawdzona
przez zepsucie czegos - `/CLAUDE.md` mechanika 10.

| co odwrocone | wynik |
|---|---|
| prog dojrzalosci `>=` na `<` | **4 z 16 testow pada**, w tym "PIEC wkladow bez slowa" i "#390 retrospektywnie" |
| test autorstwa `!==` na `===` | **8 z 16 testow pada** |
| przywrocone | **16 z 16 przechodzi** |

Dodatkowo uruchomione na **zywych danych** przez `gh api` przed wyslaniem:
wynik zgadza sie co do numeru z danymi w tescie - 14 wkladow, dlug 6,
retencja 2/5, @slegarraga 26 dni.

Zapytanie wylaniajace wnioski sprawdzone wobec niezaleznego
`gh pr list --state merged`: oba daja te same 14 numerow. Puste zapytanie
konczy zadanie przez `core.setFailed`, a nie cicho - cisza i awaria wygladaja
tak samo (DOCTRINE §9).

## Ksztalt zmiany

Bez nowego pliku workflow. Jedno zadanie w `ready-for-approval.yml`, ktore
juz hostuje cztery zadania tego rodzaju i juz importuje `unanswered-external.js`.
Logika w `tools/contributor-care.js` z testami w `node --test`, wpieta w
`lint.yml` - nie sklejona w YAML. Regula "kto napisal ostatni" jest
**importowana** z `unanswered-external.js`, nie skopiowana: dwie kopie
rozjezdzaja sie przy pierwszej poprawce.

Jedno samozamykajace sie zgloszenie "Kontrybutorzy bez odpowiedzi",
etykieta `stan:zalegle` - dokladnie jedna etykieta stanu.

**Uwaga o rownoleglej pracy:** `hr-lead` dopisuje w tym samym cyklu wlasne
zadanie do `ready-for-approval.yml`. Moje jest wstawione w srodku pliku
(przed `waiting:`), zeby nie kolidowac z zadaniem dopisywanym na koncu.
