### PR TITLE
feat(mcp): publish to the canonical MCP registry from CI, not by hand

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -135,3 +135,81 @@ jobs:
             echo "Published ${{ inputs.package }}@$v" >> "$GITHUB_STEP_SUMMARY"
             echo "https://www.npmjs.com/package/${{ inputs.package }}" >> "$GITHUB_STEP_SUMMARY"
           fi
+
+  # Publikacja do kanonicznego rejestru serwerow MCP.
+  #
+  # Dlaczego to nie jest kolejny katalog: `modelcontextprotocol/servers`
+  # (89 990 gwiazdek) WYCOFAL wlasna liste serwerow i w CONTRIBUTING.md
+  # odsyla tutaj, odmawiajac przyjmowania nowych. To jest polka, na ktora
+  # tamte gwiazdki kieruja ruch.
+  #
+  # Zmierzone 2026-09-01: `?search=smtp` w tym rejestrze zwraca `count: 0`.
+  # Ani jednego serwera SMTP. Brak progu gwiazdek, brak wymogu FLOSS.
+  #
+  # Dlaczego BEZ udzialu wlasciciela, wbrew temu, co przez pol dnia stalo
+  # w zgloszeniach #398 i #409: rejestr NIE wymaga device flow. Jego wlasne
+  # zrodlo, `cmd/publisher/auth/github-oidc.go`, mowi wprost
+  # "Login is not needed for OIDC since tokens are provided by GitHub
+  # Actions" i czyta ACTIONS_ID_TOKEN_REQUEST_TOKEN. Potrzebne jest tylko
+  # `id-token: write`, ktore ten workflow ma juz dla provenance npm.
+  # Instrukcja kazaca wlascicielowi sciagnac binarke i wpisac kod byla
+  # nieprzeczytana dokumentacja po naszej stronie, nie ograniczenie platformy.
+  #
+  # Osobne zadanie, nie krok w `publish`: publikacja do rejestru MUSI nastapic
+  # po npm, bo rejestr waliduje, ze wersja z server.json istnieje w npm.
+  mcp-registry:
+    needs: publish
+    if: ${{ inputs.package == 'zerosmtp-mcp' && inputs.dry_run == false }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: packages/zerosmtp-mcp
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Pobierz mcp-publisher
+        run: |
+          set -euo pipefail
+          curl -fsSL -o publisher.tar.gz             "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz"
+          tar xf publisher.tar.gz mcp-publisher
+          chmod +x mcp-publisher
+          ./mcp-publisher --version || true
+
+      # Wersja w server.json musi juz byc na npm, inaczej rejestr odmowi.
+      # Sprawdzamy to sami, zeby komunikat mowil o przyczynie, a nie o skutku.
+      - name: Wersja z server.json jest na npm
+        run: |
+          set -euo pipefail
+          v=$(node -p "require('./server.json').version")
+          n=$(node -p "require('./server.json').packages[0].identifier")
+          if ! npm view "$n@$v" version >/dev/null 2>&1; then
+            echo "::error::server.json wskazuje $n@$v, a tej wersji nie ma na npm."
+            exit 1
+          fi
+          echo "$n@$v jest na npm."
+
+      - name: Zaloguj przez OIDC
+        run: ./mcp-publisher login github-oidc
+
+      - name: Opublikuj
+        run: ./mcp-publisher publish
+
+      # Mechanika 8: komunikat "Successfully published" nie jest dowodem.
+      # Dowodem jest odczyt z rejestru.
+      - name: Rejestr nas widzi
+        run: |
+          set -euo pipefail
+          for i in 1 2 3 4 5; do
+            n=$(curl -fsS "https://registry.modelcontextprotocol.io/v0/servers?search=zerosmtp" | node -p "JSON.parse(require('fs').readFileSync(0)).metadata.count")
+            echo "proba $i: count=$n"
+            if [ "$n" -ge 1 ]; then
+              echo "Rejestr zwraca $n wpis(ow) dla zerosmtp." >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::Publikacja zakonczyla sie bez bledu, ale rejestr nadal zwraca 0."
+          exit 1


### PR DESCRIPTION
## The correction this is built on

Issues #398 and #409 both told the owner that publishing to the official MCP registry needs `mcp-publisher login github` — a device flow, a code typed at `github.com/login/device`. **That was wrong, and it was our own unread documentation rather than a platform limit.**

The registry's own source, `cmd/publisher/auth/github-oidc.go`, read today:

```
// Login is not needed for OIDC since tokens are provided by GitHub Actions
...
requestToken := os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
... "are you running in GitHub Actions with id-token: write permissions?"
```

And `cmd/publisher/main.go` lists `github-oidc   GitHub Actions OIDC authentication` as a real login method. `publish-npm.yml` already carries `id-token: write` for npm provenance, so nothing new is granted.

**The company can do this itself. It was never the owner's turn.**

## Why this shelf and not another

`modelcontextprotocol/servers` — **89,990 stars** — retired its own list of third-party servers and its `CONTRIBUTING.md` now refuses new ones, redirecting to this registry. It is not one more awesome-list; it is where those stars send people.

Measured 2026-09-01, directly against their API:

```
?search=smtp     ->  {"servers":[],"metadata":{"count":0}}
?search=zerosmtp ->  {"servers":[],"metadata":{"count":0}}
```

**Not one SMTP server of any kind on the canonical shelf.** No star threshold (ours is 4, and a 100-star rule disqualified us elsewhere this week), no self-hostable-FLOSS requirement, and `server.json`'s `io.github.msgwing/zerosmtp` is already the namespace GitHub grants `repo:msgwing/ZeroSMTP` automatically.

## Shape

A separate `mcp-registry` job rather than a step inside `publish`, with `needs: publish` — the registry validates that the version named in `server.json` exists on npm, so ordering is a correctness requirement, not tidiness. It runs only for `zerosmtp-mcp` and only when `dry_run` is false.

Three things it does that matter:

- **Checks the npm precondition itself**, so a failure names the cause ("server.json points at X@Y and npm does not have it") rather than surfacing the registry's downstream complaint.
- **Proves the outcome by reading the registry**, not by trusting `Successfully published`. Mechanic 8: a 200 and a success message are not evidence; the changed value on the target object is. It polls `?search=zerosmtp` and **fails the run if the count is still 0** after five attempts.
- Fails loudly rather than quietly recording a zero.

## What is not verified here, stated plainly

The OIDC handshake cannot be exercised locally — `ACTIONS_ID_TOKEN_REQUEST_TOKEN` exists only inside a GitHub Actions run. What was verified before shipping: the `github-oidc` login method exists in the publisher's own `main.go`; a `mcp-publisher_linux_amd64.tar.gz` asset exists on the current release (`v1.8.1`); `server.json` version `1.0.2` matches what npm now serves; and `python .github/check-workflows.py` is clean.

The first real dispatch is the test, and it is designed so that a silent failure is impossible — if the registry does not show us afterwards, the run goes red.

BOARD: MERGE - it removes a false owner-gate from the critical path and takes an uncontested position on the canonical MCP shelf; the outcome check makes a silent failure impossible.

EVIDENCE: `curl .../cmd/publisher/auth/github-oidc.go | grep -in "login is not needed|ACTIONS_ID_TOKEN"` returns the comment at line 48 and the env read at line 112; `main.go` line 111 lists `github-oidc`; `curl ".../v0/servers?search=smtp"` returns `count: 0`; `curl registry.npmjs.org/zerosmtp-mcp/latest` returns `1.0.2`, matching `server.json`; `python .github/check-workflows.py` -> `Workflow files: clean.`
