### PR TITLE
fix(mcp): registry publish was reachable only on the one run that published npm

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -159,7 +159,17 @@ jobs:
   # po npm, bo rejestr waliduje, ze wersja z server.json istnieje w npm.
   mcp-registry:
     needs: publish
-    if: ${{ inputs.package == 'zerosmtp-mcp' && inputs.dry_run == false }}
+    # `always()` z jawnym warunkiem, a nie `success()`. Powod zmierzony
+    # 2026-09-01, dziesiec minut po wdrozeniu pierwszej wersji tego zadania:
+    # `publish` slusznie odmawia, gdy wersja JUZ jest na npm - a to jest
+    # dokladnie stan, w ktorym publikacja do rejestru jest mozliwa i potrzebna.
+    # Sprzegniecie jej z `success()` sprawilo, ze rejestr byl nieosiagalny
+    # zawsze poza jednym przebiegiem w calym zyciu wersji.
+    #
+    # Bezpieczne, bo to zadanie NIE ufa `publish`: samo sprawdza, czy wersja
+    # z server.json jest na npm, i przerywa z wlasnym komunikatem, jesli nie.
+    # `cancelled()` nadal zatrzymuje wszystko.
+    if: ${{ !cancelled() && inputs.package == 'zerosmtp-mcp' && inputs.dry_run == false }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## The bug, found by running the thing rather than reading it

PR #414 shipped a `mcp-registry` job with `needs: publish` and a plain `if:`, which GitHub evaluates as `success() && ...`. The first real dispatch, ten minutes later, did this:

```
publish       failure   ->  ##[error]zerosmtp-mcp@1.0.2 is already on npm. Bump the version.
mcp-registry  skipped
```

Both behaviours are correct in isolation and wrong together. `publish` refuses to republish an existing version — that guard exists because an npm version is permanent. But **"the version is already on npm" is exactly the state in which publishing to the MCP registry is possible**, since the registry validates that `server.json`'s version exists there.

So as shipped, the registry step was reachable only during the single run that first published a given npm version, and unreachable forever afterwards. For 1.0.2, already published earlier today, that window had closed before the job existed.

## The fix

`if: ${{ !cancelled() && ... }}` instead of the implicit `success()`.

This is safe precisely because the job does not trust `publish`: its second step reads `server.json`, resolves the npm package and version, and exits 1 with its own message if npm does not have it. The precondition is checked where it matters rather than inferred from another job's colour. `cancelled()` still stops everything.

## Why this is reported as a result and not an apology

The design error was mine and it was ten minutes old. It was caught by dispatching the workflow instead of declaring it done — the same rule that governs everything else here: a run that is not exercised is a run that is not verified. Had it not been dispatched today, this would have surfaced at the next version bump, weeks from now, as a mystery skip.

BOARD: MERGE - it restores the only path to the canonical MCP registry, which the previous commit made unreachable for every existing version; the npm precondition is still enforced, just by the job that depends on it rather than by another job's outcome.

EVIDENCE: run 33546405224 on the merged #414 - `publish` failed with `zerosmtp-mcp@1.0.2 is already on npm`, `mcp-registry` `skipped`, confirming the coupling. `python .github/check-workflows.py` -> `Workflow files: clean.` The next dispatch is the test, and its final step fails the run if `?search=zerosmtp` still returns 0.
