### PR TITLE
docs(faq): an appeal from another address is not processed

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -127,6 +127,35 @@ deliverability for everyone else. If your use case needs more than what's
 documented here, ask at abuse@msgwing.com rather than assuming it isn't
 supported.
 
+## My account was suspended. How do I appeal?
+
+Write to **abuse@msgwing.com** **from the email address the account is
+registered to**. Requests sent from any other address are not processed.
+
+This is not a formality. "Please restore this account" is exactly what somebody
+who had taken over an account would write, and an appeal arriving from an
+unrelated address cannot be tied to the account holder. We also will not name
+the registered address in a reply, because that would disclose the account
+holder's email to whoever wrote in.
+
+If you no longer have access to the registered address, that is an account
+recovery question rather than an appeal, and it is handled separately.
+
+Two things worth knowing before writing:
+
+- Suspensions for third-party blocklist entries are not ours to reverse. Where
+  a domain is listed by an independent reputation service, delisting is
+  requested from that service, not from us.
+- On shared or low-cost web hosting, such a listing is often caused by another
+  customer on the same platform rather than by your own site. That case is
+  recoverable, but it has to be resolved with the service that published the
+  listing.
+
+If the site you are sending for is unrelated to the suspended account, you are
+free to register a new account. The [sending limits](#what-are-the-sending-limits)
+and the generated `@msgwing.com` sender address apply as usual, as do the same
+abuse rules.
+
 ## Can you share details about your infrastructure or how deliverability is maintained?
 
 No — see the [Security Policy](https://github.com/msgwing/ZeroSMTP/blob/main/SECURITY.md#infrastructure-and-third-party-integration-inquiries)

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1769,6 +1769,35 @@ deliverability for everyone else. If your use case needs more than what's
 documented here, ask at abuse@msgwing.com rather than assuming it isn't
 supported.
 
+## My account was suspended. How do I appeal?
+
+Write to **abuse@msgwing.com** **from the email address the account is
+registered to**. Requests sent from any other address are not processed.
+
+This is not a formality. "Please restore this account" is exactly what somebody
+who had taken over an account would write, and an appeal arriving from an
+unrelated address cannot be tied to the account holder. We also will not name
+the registered address in a reply, because that would disclose the account
+holder's email to whoever wrote in.
+
+If you no longer have access to the registered address, that is an account
+recovery question rather than an appeal, and it is handled separately.
+
+Two things worth knowing before writing:
+
+- Suspensions for third-party blocklist entries are not ours to reverse. Where
+  a domain is listed by an independent reputation service, delisting is
+  requested from that service, not from us.
+- On shared or low-cost web hosting, such a listing is often caused by another
+  customer on the same platform rather than by your own site. That case is
+  recoverable, but it has to be resolved with the service that published the
+  listing.
+
+If the site you are sending for is unrelated to the suspended account, you are
+free to register a new account. The [sending limits](#what-are-the-sending-limits)
+and the generated `@msgwing.com` sender address apply as usual, as do the same
+abuse rules.
+
 ## Can you share details about your infrastructure or how deliverability is maintained?
 
 No — see the [Security Policy](https://github.com/msgwing/ZeroSMTP/blob/main/SECURITY.md#infrastructure-and-third-party-integration-inquiries)


### PR DESCRIPTION
Adds one FAQ entry: **"My account was suspended. How do I appeal?"**

## Why

A real case on 2026-09-02. An account was suspended on a third-party blocklist entry, and the appeal arrived from an address unrelated to the one the account is registered to. The rule — appeals are only processed from the registered address — was applied, but it was written down nowhere, so the person had no way to know it before writing. A rule enforced but unpublished reads as arbitrary from outside.

## What it says, and what it deliberately does not

It gives the requirement, and the reason, in the reader's terms: *"Please restore this account" is exactly what somebody who had taken over an account would write.* Stated that way it is a protection the reader can recognise rather than a formality to argue with.

It also records something the same case taught: **the registered address is never quoted back in a reply.** Naming it would disclose the account holder's email to whoever wrote in — which is precisely the failure the rule exists to prevent. That was almost shipped in a draft reply and caught before sending.

What the page does **not** contain, on purpose:

- **No blocklist provider is named.** It says "an independent reputation service" and directs delisting there.
- **No threshold, counter or window.** This page is read by the person about to appeal. A rule that explains what triggers it is a rule that explains how to stay under it.
- **No account details from the case.** Verified with `grep -icE "spamhaus|dbl|185\.|<address>|<username>|threshold"` over the added section → `0`.

Two things are included because they help an honest reader and cost nothing: that a listing on shared or low-cost hosting is often caused by another customer on the same platform, and that registering a new account is legitimate if the site is unrelated — with the limits and the same abuse rules restated so it is not read as a way around a suspension.

## Verified

- `tools/build-llms-full.py --check` failed after the edit (drift), regenerated, now `llms-full.txt matches the site (12 pages, 99 KB)`.
- `build-llms-txt`, `check-facts`, `build-app-pages`, `build-error-pages`, `build-client-error-pages` — all `--check` clean.
- The in-page anchor `#what-are-the-sending-limits` resolves to the existing `## What are the sending limits?` heading at `docs/FAQ.md:56`.
- `git show --numstat --format= HEAD` → `29 0` on each file; no line-ending rewrite.

BOARD: MERGE - it publishes a rule the company already enforces, so a suspended user can satisfy it before writing rather than after being refused; it names no provider, threshold or account detail, so it cannot be read as a guide to avoiding enforcement.

EVIDENCE: `grep -icE "spamhaus|dbl|185\.|caumartincochet|firmvale|threshold"` over the added section returns `0`; all six generator `--check` gates pass after regenerating `llms-full.txt`, which failed before; the anchor target exists at `docs/FAQ.md:56`.
