### PR TITLE
docs: the sender rejection nobody documented, and the Postfix line that causes it

### DIFF
--- a/docs/SYSTEM-MTA.md
+++ b/docs/SYSTEM-MTA.md
@@ -76,6 +76,61 @@ echo "Test from Postfix satellite" | mail -s "ZeroSMTP test" you@example.com
 tail -f /var/log/mail.log
 ```
 
+## Making mail leave as your account (sender rewriting)
+
+**Do this before you test.** Without it, Postfix satellite mode sends system
+mail as the local user — `root@yourhost`, `pi@raspberrypi` — and the relay
+refuses it:
+
+```
+553 5.7.1 <root@yourhost>: Sender address rejected: not owned by user
+```
+
+That is not an authentication problem; the login succeeded. Mail has to leave
+as the account it was sent with, and `cron`, `logwatch`, `unattended-upgrades`,
+`systemd` failure mail and `mdadm` all use the local system sender instead.
+
+Two maps are needed, because the envelope sender and the visible `From:` header
+are separate things and the relay checks the first one:
+
+```bash
+sudo tee /etc/postfix/sender_canonical > /dev/null <<'EOF'
+/.+/    your-username@msgwing.com
+EOF
+sudo tee /etc/postfix/header_from > /dev/null <<'EOF'
+/^From:.*/  REPLACE From: your-username@msgwing.com
+EOF
+sudo postmap /etc/postfix/sender_canonical
+```
+
+`header_from` is deliberately **not** run through `postmap` — `regexp:` and
+`pcre:` tables are read as plain text and have no `.db` to build.
+
+Add to `/etc/postfix/main.cf`:
+
+```ini
+sender_canonical_classes = envelope_sender, header_sender
+sender_canonical_maps = regexp:/etc/postfix/sender_canonical
+smtp_header_checks = regexp:/etc/postfix/header_from
+```
+
+Then `sudo systemctl restart postfix`.
+
+Where do replies go? Not to the relay account — set `Reply-To` in whatever
+generates the mail, or simply read the mailbox of the address you configured.
+The `Reply-To` header is not restricted; only the sender is.
+
+Verify the rewrite actually happened, rather than that the command ran:
+
+```bash
+echo test | mail -s "sender test" you@example.com
+grep "from=<" /var/log/mail.log | tail -1
+```
+
+The `from=<...>` on that line has to be your `@msgwing.com` address. If it
+still shows `root@`, the maps are not being applied — check
+`postconf sender_canonical_maps` reads back what you wrote.
+
 ## Alternative: msmtp (simplest option, no mail queue)
 
 Good if you don't want a full MTA — just a way for `cron`/scripts to send

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -110,6 +110,41 @@ none of the server's text at all.
 Three of the four causes are still reversible before the deadline, so somebody
 telling you to migrate today may be wrong. Check which case you are in first.
 
+## `553 5.7.1 ... Sender address rejected: not owned by user`
+
+The full refusal looks like this:
+
+```
+553 5.7.1 <root@yourhost>: Sender address rejected: not owned by user
+you@msgwing.com
+```
+
+**Authentication succeeded.** The password is right and the account is fine.
+What was refused is the *From* address: you logged in as one account and then
+asked to send as somebody else. A shared relay cannot allow that — if it did,
+anyone with an account could send as anyone.
+
+Mail must leave as the account it was sent with. Nothing else is accepted, and
+this cannot be configured per account.
+
+### Where it usually comes from
+
+Almost never from an application you wrote. Two situations produce nearly all
+of these:
+
+**A Linux host sending its own system mail.** `cron`, `logwatch`,
+`unattended-upgrades`, `systemd` failure notifications and `mdadm` all send as
+the local system user — `root@yourhost`, `pi@raspberrypi`, `backup@nas`. Postfix
+in satellite mode passes that straight through unless it is told to rewrite it.
+See [rewriting the sender in the system MTA guide](SYSTEM-MTA.md#making-mail-leave-as-your-account-sender-rewriting),
+which is the fix.
+
+**A device or client set to "use my real email as the From address."** Printers,
+scanners, NAS boxes and DVRs often have a *From* or *Sender* field separate from
+the login. Put the `@msgwing.com` account address in it, not a personal Gmail,
+Outlook or company address. That personal address is what receives the replies —
+which is what the `Reply-To` field is for, and that one is unrestricted.
+
 ## Certificate / TLS verification failed
 
 > On a printer or scanner this is usually the frozen root store rather than

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1230,6 +1230,41 @@ none of the server's text at all.
 Three of the four causes are still reversible before the deadline, so somebody
 telling you to migrate today may be wrong. Check which case you are in first.
 
+## `553 5.7.1 ... Sender address rejected: not owned by user`
+
+The full refusal looks like this:
+
+```
+553 5.7.1 <root@yourhost>: Sender address rejected: not owned by user
+you@msgwing.com
+```
+
+**Authentication succeeded.** The password is right and the account is fine.
+What was refused is the *From* address: you logged in as one account and then
+asked to send as somebody else. A shared relay cannot allow that — if it did,
+anyone with an account could send as anyone.
+
+Mail must leave as the account it was sent with. Nothing else is accepted, and
+this cannot be configured per account.
+
+### Where it usually comes from
+
+Almost never from an application you wrote. Two situations produce nearly all
+of these:
+
+**A Linux host sending its own system mail.** `cron`, `logwatch`,
+`unattended-upgrades`, `systemd` failure notifications and `mdadm` all send as
+the local system user — `root@yourhost`, `pi@raspberrypi`, `backup@nas`. Postfix
+in satellite mode passes that straight through unless it is told to rewrite it.
+See [rewriting the sender in the system MTA guide](SYSTEM-MTA.md#making-mail-leave-as-your-account-sender-rewriting),
+which is the fix.
+
+**A device or client set to "use my real email as the From address."** Printers,
+scanners, NAS boxes and DVRs often have a *From* or *Sender* field separate from
+the login. Put the `@msgwing.com` account address in it, not a personal Gmail,
+Outlook or company address. That personal address is what receives the replies —
+which is what the `Reply-To` field is for, and that one is unrestricted.
+
 ## Certificate / TLS verification failed
 
 > On a printer or scanner this is usually the frozen root store rather than


### PR DESCRIPTION
## Found in a production log, not by guessing

A mail log from the live relay, read today. One account, `sharpwave`, produced:

- **8 rejections** — `553 5.7.1 <pi@sherif-pi> / <root@sherif-pi> / <sherifs@openssh-debian-sherifs>: Sender address rejected: not owned by user`
- **3 successful sends** in the same window

A **73% failure rate** for a user who authenticated correctly every single time. A second account, `slimnook`, hit the same refusal the same day — then tried to log in *as their personal ProtonMail address*, which failed too. Two of roughly seven active accounts, on one day, stuck on the same thing.

The HELO tells you what it is: `sherif-pi.tail7fef02.ts.net`. A Raspberry Pi whose `cron`, `unattended-upgrades` and systemd mail leave as `pi@` and `root@`.

## The cause is in our own recipe

`docs/SYSTEM-MTA.md` calls Postfix satellite mode the "top pick" and gives a complete, working configuration — `relayhost`, SASL, TLS, the `default_database_type` trap, port 465 wrappermode. It is a good page.

**It never mentions rewriting the sender.** So every reader who follows it and then lets cron send anything gets refused, and the refusal says nothing about what to change.

And the error string itself — `Sender address rejected: not owned by user` — appeared **nowhere** in this repository. Not in `docs/`, not in `data/errors.json`, not in the CLI corpus. Verified by grep before writing anything.

## What this adds

**`docs/SYSTEM-MTA.md` → "Making mail leave as your account (sender rewriting)"**, placed before the test step, because doing it afterwards means the test fails first. Both maps, because the envelope sender and the `From:` header are separate and the relay checks the envelope. It also states the thing that trips people up: `regexp:` tables must **not** be run through `postmap` — there is no `.db` to build.

Verification is on the effect, not the command: `grep "from=<" /var/log/mail.log | tail -1` must show the `@msgwing.com` address. Running `systemctl restart` proves nothing.

**`docs/TROUBLESHOOTING.md` → the error, by its exact text.** It opens by saying authentication *succeeded*, because that is the wrong conclusion everybody reaches. It names the two real sources — Linux system mail, and a device with a separate "From" field set to a personal address — and points at `Reply-To`, which is unrestricted, for where replies should go.

## A false claim caught before it shipped

The first draft ended with "check it in one line: `zerosmtp-check --explain "553 5.7.1 Sender address rejected"`". I ran it rather than assuming:

```
530 5.7.1 - Delivery not authorized
... the authenticated account is not allowed to send as the address in the From field
... Microsoft does document it for this one
```

It matches on `5.7.1` and returns **Microsoft's 530**, which sends the reader to look at their Exchange Online tenant for a refusal our own relay issued. The promise was removed. That the CLI answers this string with a confidently wrong page is a real defect and is filed separately — it is a corpus-scope decision, not something to patch inside a docs change.

## Verified

All six generator gates `--check` clean; `build-llms-full.py` failed on drift after the edit, was regenerated, passes. The cross-page anchor was computed rather than eyeballed — `#making-mail-leave-as-your-account-sender-rewriting` matches the new heading exactly. `git show --numstat --format= HEAD` → `55 0`, `35 0`, `35 0`, no line-ending rewrite.

BOARD: MERGE - it closes a gap measured at a 73% failure rate for one real account and hit by two accounts in one day, and the fix lands in the recipe that causes it rather than only in the error page.

EVIDENCE: production mail log shows 8 `553 ... not owned by user` rejections against 3 sends for `sharpwave`, plus one for `slimnook`; `grep -rli "sender address rejected|not owned by user" docs/ data/ README.md` returned nothing before this change; `node packages/zerosmtp-check/index.js --explain "553 5.7.1 Sender address rejected"` returns Microsoft's 530 page, which is why the CLI promise was cut; six `--check` gates pass after regenerating `llms-full.txt`.
