### PR TITLE
docs: monthly vendor advisory review, 2026-09

### DIFF
--- a/data/devices.json
+++ b/data/devices.json
@@ -16,7 +16,7 @@
     "  check-advisory  vendor publishes a per-model list we do not reproduce",
     "  unsupported     the product has no OAuth capability for this purpose"
   ],
-  "updated": "2026-08-27",
+  "updated": "2026-09-07",
   "entries": [
     {
       "vendor": "Konica Minolta / DEVELOP",
@@ -37,18 +37,25 @@
         "ineo+ 3100P",
         "ineo+ 754e",
         "ineo+ 654e",
+        "ineo 654e",
+        "ineo 226",
         "ineo 246",
         "ineo 236",
-        "ineo 226",
         "ineo 216",
+        "ineo 7223",
+        "ineo 206",
         "ineo 4700P",
         "ineo 3301P",
         "ineo 4000P",
-        "ineo 165 variants",
-        "ineo 185 variants"
+        "ineo 4020",
+        "ineo 3320",
+        "ineo 165",
+        "ineo 165e",
+        "ineo 185",
+        "ineo 185e"
       ],
       "evidence": "https://www.develop.eu/en/support/discontinuation-of-basic-authentication-for-smtp.html",
-      "notes": "Marked \"N/A\" in the vendor's own OAuth column. The advisory points these owners at a different mail service rather than at an update. Other ineo product groups in the same advisory do have OAuth firmware - check the exact model. A third category exists that is neither: several Product Group 10 models are listed as \"Under planning\" with no release date, so their owners have no answer yet in either direction."
+      "notes": "Marked \"N/A\" in the vendor's own OAuth column, and the advisory states that \"for devices marked as N/A under Release Schedule and devices not listed, no firmware update is planned\". It points these owners at a different mail service rather than at an update. One suffix decides: ineo 165en and ineo 185en are listed as Released (V3.00) while ineo 165/165e and 185/185e are N/A. Other ineo product groups in the same advisory do have OAuth firmware - check the exact model. A third category exists that is neither: several Product Group 10 models are listed as \"Under planning\" with no release date, so their owners have no answer yet in either direction."
     },
     {
       "vendor": "Xerox",
@@ -61,11 +68,10 @@
         "VersaLink C620",
         "VersaLink B625",
         "VersaLink C625",
-        "AltaLink",
-        "PrimeLink"
+        "AltaLink"
       ],
       "evidence": "https://www.xerox.com/en-us/office/insights/exchange-online-authentication",
-      "notes": "Device Code Flow is supported broadly; Client Credentials Flow only on the ConnectKey models listed. Devices not on Xerox's supported-firmware list are the problem cases and are not promised an update. Affects Scan to Email, Internet Fax (Send), Fax Forward to Email and Auto Email Notifications."
+      "notes": "Device Code Flow is available now across the whole published range; Client Credentials Flow only on the ConnectKey models listed here. PrimeLink is not one of them - Xerox's table marks PrimeLink C9065/C9070, B9100/B9110/B9125/B9136 and C9265/C9275/C9281 as \"Not Available\" in the Client Credential Flow column. Devices not on Xerox's supported-firmware list are the problem cases and are not promised an update. Affects Scan to Email, Internet Fax (Send), Fax Forward to Email and Auto Email Notifications."
     },
     {
       "vendor": "Ricoh",
@@ -73,7 +79,7 @@
       "status": "check-advisory",
       "models": [],
       "evidence": "https://www.ricoh.com/info/2025/0526_1",
-      "notes": "Ricoh publishes affected products with per-product firmware status, revised on 2026-01-30 into two tables - products with released OAuth firmware, and products newly added - plus a third group the Ricoh Firmware Update Tool cannot update, where the local representative has to do it. Not reproduced here because the list is long and still moving; check the model against the advisory. Ricoh does not say any product is permanently excluded, but for devices still waiting its own recommendation is to stop relying on email from the device or to use a mail service other than Exchange Online."
+      "notes": "Ricoh publishes affected products with per-product firmware status, last updated 2026-02-06, in two tables - products with released OAuth firmware, and products added as of 2026-01-30 - plus a third group the Ricoh Firmware Update Tool cannot update, where the local representative has to do it. Not reproduced here because the list is long and still moving; check the model against the advisory. Firmware is not the end of it: because \"the TLS cipher suites supported by Microsoft 365 will be updated\", Ricoh warns that \"some Ricoh products - including models that already support OAuth 2.0 authentication - will no longer be able to send or receive emails via Exchange Online\". Ricoh does not say any product is permanently excluded, but for devices still waiting its own recommendation is to stop relying on email from the device or to use a mail service other than Exchange Online."
     },
     {
       "vendor": "Brother",
@@ -144,10 +150,10 @@
     {
       "vendor": "Laserfiche",
       "product": "Workflow email",
-      "status": "check-advisory",
+      "status": "partial",
       "models": [],
       "evidence": "https://answers.laserfiche.com/questions/200557/Disabling-basic-authentication-causing-Workflow-emails-to-fail",
-      "notes": "Workflow emails failing on Basic auth removal, reported in the vendor's own community."
+      "notes": "Laserfiche now answers this thread directly. The selected answer: \"Customers must upgrade to the Laserfiche Workflow 12 2025H1 release or later to use OAuth 2.0 for SMTP through Exchange Online. There are no current plans to backport OAuth support for Exchange Online SMTP to earlier versions of Workflow.\" The approved answer, updated April 2026, adds that \"version 12 Laserfiche products support Microsoft OAuth 2.0\", and that for v10.4, v11 and v12 installs which cannot upgrade, Laserfiche has confirmed Microsoft's own alternatives instead - High Volume Email, Azure Communication Services Email, or on-premises Exchange in a hybrid configuration."
     },
     {
       "vendor": "ManageEngine",
@@ -160,18 +166,18 @@
     {
       "vendor": "Cerberus",
       "product": "FTP Server",
-      "status": "check-advisory",
+      "status": "partial",
       "models": [],
       "evidence": "https://support.cerberusftp.com/hc/en-us/articles/24103821642643-Troubleshooting-SMTP-Setup-Error-on-Office365-com-Resolving-EHLO-Message-Failure-535-5-7-139-Authentication-Unsuccessful-Basic-Authentication-Disabled",
-      "notes": "Vendor support article covers the exact 535 5.7.139 failure."
+      "notes": "The vendor article on the exact 535 5.7.139 failure now answers it: \"Microsoft deprecated Basic Authentication as the default setting for O365 in October of 2023 and Cerberus now supports Microsoft OAuth2 for O365 SMTP Authentication.\" The current SMTP setup article documents an Authentication selector on the SMTP target with a Microsoft OAuth2 option taking tenant ID, application (client) ID and client secret from Entra ID, and describes Basic as the same functionality as the previous Use Authentication checkbox \"(prior to Cerberus 2025.3.0)\" - so the build decides. Older builds offer username and password only."
     },
     {
       "vendor": "Faxination",
       "product": "fax server",
-      "status": "check-advisory",
+      "status": "partial",
       "models": [],
       "evidence": "https://faxination.com/microsoft-timeline-for-basic-authentication-deprecation-in-exchange-online-smtp-auth/",
-      "notes": "Vendor published a timeline notice. Apply their update if one exists for the version in use; otherwise the outbound SMTP account has to be repointed."
+      "notes": "Fenestrae states that \"Faxination 2024 supports Modern Authentication (OAuth 2.0) for Microsoft 365 and Exchange Online\", so for this product the answer is a version number rather than a firmware wait; older installs still have to repoint the outbound SMTP account. Read the timeline on the same page with care - it still describes the superseded March-April 2026 schedule rather than the current one."
     },
     {
       "vendor": "Lexmark",
@@ -200,8 +206,8 @@
       "product": "printers and MFPs",
       "status": "partial",
       "models": [],
-      "evidence": "https://global.sharp/restricted/products/copier/downloads/manuals/bp70m65/us/contents_09-07_003.html",
-      "notes": "Sharp documents OAuth 2.0 authentication for Microsoft 365 and Exchange Online SMTP on multiple newer printer and MFP models, including BP-series devices. Sharp does not appear to publish a centralized compatibility list or universal firmware floor for the full printer/MFP range. Verify the exact model's SMTP settings or current manual before assuming OAuth 2.0 support.",
+      "evidence": "https://global.sharp/restricted/print/manuals/5/bp70m65/us/contents_09-07_018.html",
+      "notes": "Sharp documents OAuth 2.0 for SMTP in the machine manual rather than in a compatibility advisory: under Network Settings the SMTP \"Authentication Method\" reads \"Select OAuth 2.0 when using Microsoft365, Exchange Online, etc.\", with Provider defaulting to Microsoft and a Get Token key on the device. The same option appears on the POP3 side for Internet Fax reception. Sharp does not appear to publish a centralized compatibility list or a universal firmware floor for the full printer/MFP range, so verify the exact model's current manual before assuming OAuth 2.0 support.",
       "contributor": "Mohitingale13",
       "contributor_pr": 238
     },

--- a/docs/DEVICE-COMPATIBILITY.md
+++ b/docs/DEVICE-COMPATIBILITY.md
@@ -31,22 +31,22 @@ answer.
 
 | System | OAuth status | Named models | Evidence |
 | --- | --- | --- | --- |
-| **[Konica Minolta / DEVELOP](devices/konica-minolta-develop-ineo-and-ineo-mfps.md)** ineo and ineo+ MFPs | **No OAuth firmware planned** | `ineo 306`, `ineo 7228`, `ineo 266`, `ineo+ 266`, `ineo+ 256`, `ineo+ 226`, `ineo 4752`, `ineo 4052`, `ineo 4750`, `ineo 4050`, `ineo+ 3110`, `ineo+ 3100P`, `ineo+ 754e`, `ineo+ 654e`, `ineo 246`, `ineo 236`, `ineo 226`, `ineo 216`, `ineo 4700P`, `ineo 3301P`, `ineo 4000P`, `ineo 165 variants`, `ineo 185 variants` | [advisory](https://www.develop.eu/en/support/discontinuation-of-basic-authentication-for-smtp.html) |
+| **[Konica Minolta / DEVELOP](devices/konica-minolta-develop-ineo-and-ineo-mfps.md)** ineo and ineo+ MFPs | **No OAuth firmware planned** | `ineo 306`, `ineo 7228`, `ineo 266`, `ineo+ 266`, `ineo+ 256`, `ineo+ 226`, `ineo 4752`, `ineo 4052`, `ineo 4750`, `ineo 4050`, `ineo+ 3110`, `ineo+ 3100P`, `ineo+ 754e`, `ineo+ 654e`, `ineo 654e`, `ineo 226`, `ineo 246`, `ineo 236`, `ineo 216`, `ineo 7223`, `ineo 206`, `ineo 4700P`, `ineo 3301P`, `ineo 4000P`, `ineo 4020`, `ineo 3320`, `ineo 165`, `ineo 165e`, `ineo 185`, `ineo 185e` | [advisory](https://www.develop.eu/en/support/discontinuation-of-basic-authentication-for-smtp.html) |
 | **[Canon](devices/canon-maxify-mb2755.md)** Maxify MB2755 | No OAuth for this purpose | `Maxify MB2755` | [advisory](https://github.com/msgwing/ZeroSMTP/blob/main/docs/DEVICE-CASE-STUDIES.md) |
 | **[QNAP](devices/qnap-nas-notification-settings.md)** NAS notification settings | No OAuth for this purpose | — | [advisory](https://gist.github.com/msgwing/39958d909e085ae9cc0e6b3584d930bf) |
+| **[Cerberus](devices/cerberus-ftp-server.md)** FTP Server | Some models or versions | — | [advisory](https://support.cerberusftp.com/hc/en-us/articles/24103821642643-Troubleshooting-SMTP-Setup-Error-on-Office365-com-Resolving-EHLO-Message-Failure-535-5-7-139-Authentication-Unsuccessful-Basic-Authentication-Disabled) |
+| **[Faxination](devices/faxination-fax-server.md)** fax server | Some models or versions | — | [advisory](https://faxination.com/microsoft-timeline-for-basic-authentication-deprecation-in-exchange-online-smtp-auth/) |
 | **[HP](devices/hp-printers-and-mfps.md)** printers and MFPs | Some models or versions | — | [advisory](https://support.hp.com/nz-en/document/ish_13623350-13600809-16) |
+| **[Laserfiche](devices/laserfiche-workflow-email.md)** Workflow email | Some models or versions | — | [advisory](https://answers.laserfiche.com/questions/200557/Disabling-basic-authentication-causing-Workflow-emails-to-fail) |
 | **[Microsoft](devices/microsoft-dynamics-nav-business-central.md)** Dynamics NAV / Business Central | Some models or versions | — | [advisory](https://www.innovia.com/blog/microsoft-to-retire-basic-auth-smtp-for-exchange-online-what-bc-nav-users-need-to-know) |
-| **[Sharp](devices/sharp-printers-and-mfps.md)** printers and MFPs | Some models or versions | — | [advisory](https://global.sharp/restricted/products/copier/downloads/manuals/bp70m65/us/contents_09-07_003.html) |
+| **[Sharp](devices/sharp-printers-and-mfps.md)** printers and MFPs | Some models or versions | — | [advisory](https://global.sharp/restricted/print/manuals/5/bp70m65/us/contents_09-07_018.html) |
 | **[TrueNAS](devices/truenas-truenas-email-alerts.md)** TrueNAS email alerts | Some models or versions | — | [advisory](https://www.truenas.com/docs/scale/systemsettings/general/settingupsystememail/) |
 | **[Veeam](devices/veeam-backup-for-microsoft-365-and-related-products.md)** Backup for Microsoft 365 and related products | Some models or versions | — | [advisory](https://helpcenter.veeam.com/docs/vbo365/guide/smtp_server.html) |
-| **[Xerox](devices/xerox-connectkey-printers-and-mfps.md)** ConnectKey printers and MFPs | Some models or versions | `VersaLink B415`, `VersaLink C415`, `VersaLink B620`, `VersaLink C620`, `VersaLink B625`, `VersaLink C625`, `AltaLink`, `PrimeLink` | [advisory](https://www.xerox.com/en-us/office/insights/exchange-online-authentication) |
+| **[Xerox](devices/xerox-connectkey-printers-and-mfps.md)** ConnectKey printers and MFPs | Some models or versions | `VersaLink B415`, `VersaLink C415`, `VersaLink B620`, `VersaLink C620`, `VersaLink B625`, `VersaLink C625`, `AltaLink` | [advisory](https://www.xerox.com/en-us/office/insights/exchange-online-authentication) |
 | **[Zabbix](devices/zabbix-email-notifications.md)** email notifications | Some models or versions | — | [advisory](https://www.zabbix.com/documentation/7.4/en/manual/introduction/whatsnew) |
 | **[Brother](devices/brother-printers-mfps-and-document-scanners.md)** printers, MFPs and document scanners | Check vendor advisory | — | [advisory](https://support.brother.com/g/b/oscontents.aspx?c=us&lang=en&ossid=42) |
-| **[Cerberus](devices/cerberus-ftp-server.md)** FTP Server | Check vendor advisory | — | [advisory](https://support.cerberusftp.com/hc/en-us/articles/24103821642643-Troubleshooting-SMTP-Setup-Error-on-Office365-com-Resolving-EHLO-Message-Failure-535-5-7-139-Authentication-Unsuccessful-Basic-Authentication-Disabled) |
 | **[Cisco](devices/cisco-unity-connection.md)** Unity Connection | Check vendor advisory | — | [advisory](https://learn.microsoft.com/en-us/exchange/clients-and-mobile-in-exchange-online/deprecation-of-basic-authentication-exchange-online) |
-| **[Faxination](devices/faxination-fax-server.md)** fax server | Check vendor advisory | — | [advisory](https://faxination.com/microsoft-timeline-for-basic-authentication-deprecation-in-exchange-online-smtp-auth/) |
 | **[Kyocera](devices/kyocera-mfps-reporting-send-error-1102.md)** MFPs reporting send error 1102 | Check vendor advisory | — | [advisory](https://github.com/msgwing/ZeroSMTP/blob/main/docs/ERROR-MESSAGES.md) |
-| **[Laserfiche](devices/laserfiche-workflow-email.md)** Workflow email | Check vendor advisory | — | [advisory](https://answers.laserfiche.com/questions/200557/Disabling-basic-authentication-causing-Workflow-emails-to-fail) |
 | **[Lexmark](devices/lexmark-printers-and-mfps.md)** printers and MFPs | Check vendor advisory | — | [advisory](https://support.lexmark.com/content/support/guides/en/kb20211110020010549/setup-installation-and-configuration-issues/how-to-set-up-oauth-2-authentication.html) |
 | **[ManageEngine](devices/manageengine-opmanager.md)** OpManager | Check vendor advisory | — | [advisory](https://www.manageengine.com/network-monitoring/how-to/fix-smtpclientauth-disabled-error.html) |
 | **[Ricoh](devices/ricoh-multifunction-printers.md)** multifunction printers | Check vendor advisory | — | [advisory](https://www.ricoh.com/info/2025/0526_1) |
@@ -59,7 +59,7 @@ answer.
 ### Notes per entry
 
 **Konica Minolta / DEVELOP — ineo and ineo+ MFPs**  
-Marked "N/A" in the vendor's own OAuth column. The advisory points these owners at a different mail service rather than at an update. Other ineo product groups in the same advisory do have OAuth firmware - check the exact model. A third category exists that is neither: several Product Group 10 models are listed as "Under planning" with no release date, so their owners have no answer yet in either direction.
+Marked "N/A" in the vendor's own OAuth column, and the advisory states that "for devices marked as N/A under Release Schedule and devices not listed, no firmware update is planned". It points these owners at a different mail service rather than at an update. One suffix decides: ineo 165en and ineo 185en are listed as Released (V3.00) while ineo 165/165e and 185/185e are N/A. Other ineo product groups in the same advisory do have OAuth firmware - check the exact model. A third category exists that is neither: several Product Group 10 models are listed as "Under planning" with no release date, so their owners have no answer yet in either direction.
 
 **Canon — Maxify MB2755**  
 Separate failure mode from OAuth: the firmware ships a fixed root CA store predating current Let's Encrypt roots, so certificate validation fails regardless of authentication. Hardware-confirmed, unchanged after a firmware update. Verification has to be disabled on the device.
@@ -67,14 +67,23 @@ Separate failure mode from OAuth: the firmware ships a fixed root CA store preda
 **QNAP — NAS notification settings**  
 The notification settings accept username and password only; there is no OAuth option for Microsoft 365 SMTP.
 
+**Cerberus — FTP Server**  
+The vendor article on the exact 535 5.7.139 failure now answers it: "Microsoft deprecated Basic Authentication as the default setting for O365 in October of 2023 and Cerberus now supports Microsoft OAuth2 for O365 SMTP Authentication." The current SMTP setup article documents an Authentication selector on the SMTP target with a Microsoft OAuth2 option taking tenant ID, application (client) ID and client secret from Entra ID, and describes Basic as the same functionality as the previous Use Authentication checkbox "(prior to Cerberus 2025.3.0)" - so the build decides. Older builds offer username and password only.
+
+**Faxination — fax server**  
+Fenestrae states that "Faxination 2024 supports Modern Authentication (OAuth 2.0) for Microsoft 365 and Exchange Online", so for this product the answer is a version number rather than a firmware wait; older installs still have to repoint the outbound SMTP account. Read the timeline on the same page with care - it still describes the superseded March-April 2026 schedule rather than the current one.
+
 **HP — printers and MFPs**  
 HP documents OAuth 2.0 support for Microsoft 365 Scan to Email on HP Enterprise and HP Managed printers running FutureSmart firmware 5.7 and newer. However, HP also states that certain LaserJet Pro models, including the M478-M479 and M428-M429f, do not support OAuth 2.0. Verify the exact product family and firmware before assuming Microsoft 365 SMTP AUTH compatibility.
+
+**Laserfiche — Workflow email**  
+Laserfiche now answers this thread directly. The selected answer: "Customers must upgrade to the Laserfiche Workflow 12 2025H1 release or later to use OAuth 2.0 for SMTP through Exchange Online. There are no current plans to backport OAuth support for Exchange Online SMTP to earlier versions of Workflow." The approved answer, updated April 2026, adds that "version 12 Laserfiche products support Microsoft OAuth 2.0", and that for v10.4, v11 and v12 installs which cannot upgrade, Laserfiche has confirmed Microsoft's own alternatives instead - High Volume Email, Azure Communication Services Email, or on-premises Exchange in a hybrid configuration.
 
 **Microsoft — Dynamics NAV / Business Central**  
 Newer Business Central handles modern auth. Older on-prem NAV installs generally need the SMTP account repointed.
 
 **Sharp — printers and MFPs**  
-Sharp documents OAuth 2.0 authentication for Microsoft 365 and Exchange Online SMTP on multiple newer printer and MFP models, including BP-series devices. Sharp does not appear to publish a centralized compatibility list or universal firmware floor for the full printer/MFP range. Verify the exact model's SMTP settings or current manual before assuming OAuth 2.0 support.
+Sharp documents OAuth 2.0 for SMTP in the machine manual rather than in a compatibility advisory: under Network Settings the SMTP "Authentication Method" reads "Select OAuth 2.0 when using Microsoft365, Exchange Online, etc.", with Provider defaulting to Microsoft and a Get Token key on the device. The same option appears on the POP3 side for Internet Fax reception. Sharp does not appear to publish a centralized compatibility list or a universal firmware floor for the full printer/MFP range, so verify the exact model's current manual before assuming OAuth 2.0 support.
 
 **TrueNAS — TrueNAS email alerts**  
 TrueNAS SCALE supports OAuth for Outlook and Gmail, but standard SMTP requires basic authentication. Some forum users report issues with Microsoft 365 enforcing OAuth while configuring standard SMTP on CORE.
@@ -83,7 +92,7 @@ TrueNAS SCALE supports OAuth for Outlook and Gmail, but standard SMTP requires b
 Corrected 2026-08-16 - the previous note claimed newer versions added OAuth for SMTP, which the linked page does not support. The v8 documentation offers "SMTP server (basic authentication)" and does not describe an OAuth option for SMTP notifications; modern app-only authentication appears elsewhere in the product, for Entra applications, not here. So the fix is not "upgrade and SMTP gets OAuth" - check whether your build offers a notification method that is not SMTP at all, and treat the SMTP path as basic-auth only.
 
 **Xerox — ConnectKey printers and MFPs**  
-Device Code Flow is supported broadly; Client Credentials Flow only on the ConnectKey models listed. Devices not on Xerox's supported-firmware list are the problem cases and are not promised an update. Affects Scan to Email, Internet Fax (Send), Fax Forward to Email and Auto Email Notifications.
+Device Code Flow is available now across the whole published range; Client Credentials Flow only on the ConnectKey models listed here. PrimeLink is not one of them - Xerox's table marks PrimeLink C9065/C9070, B9100/B9110/B9125/B9136 and C9265/C9275/C9281 as "Not Available" in the Client Credential Flow column. Devices not on Xerox's supported-firmware list are the problem cases and are not promised an update. Affects Scan to Email, Internet Fax (Send), Fax Forward to Email and Auto Email Notifications.
 
 **Zabbix — email notifications**  
 Zabbix 7.4 introduced OAuth 2.0 authentication for SMTP, including automated OAuth configuration for Office365 and Gmail. Verify the Zabbix version and Office365 SmtpClientAuthentication configuration before assuming Microsoft 365 SMTP AUTH compatibility.
@@ -91,20 +100,11 @@ Zabbix 7.4 introduced OAuth 2.0 authentication for SMTP, including automated OAu
 **Brother — printers, MFPs and document scanners**  
 Brother publishes a per-model Product Support List and states plainly that a machine not on it does not support OAuth 2.0, with no firmware promised - the vendor's own guidance for those owners is to use a different mail service. Listed models split into two tiers: OAuth already present, or present after a firmware update that is already downloadable. Affects Scan to Email Server, Internet Fax, Email Reports and Email Notifications. Check the exact model: support is firmware-dependent as well as model-dependent.
 
-**Cerberus — FTP Server**  
-Vendor support article covers the exact 535 5.7.139 failure.
-
 **Cisco — Unity Connection**  
 Named in Microsoft's own deprecation documentation. OAuth support depends on the release; check yours before assuming either way.
 
-**Faxination — fax server**  
-Vendor published a timeline notice. Apply their update if one exists for the version in use; otherwise the outbound SMTP account has to be repointed.
-
 **Kyocera — MFPs reporting send error 1102**  
 1102 / 0x1102 is Kyocera's device-side code for an SMTP authentication failure, not a model list. No public per-model OAuth statement located; check with the vendor for a specific model.
-
-**Laserfiche — Workflow email**  
-Workflow emails failing on Basic auth removal, reported in the vendor's own community.
 
 **Lexmark — printers and MFPs**  
 Lexmark documents OAuth 2.0 authentication for printers starting with the FW24 firmware release, including Outlook Live and Microsoft 365. The Email Server flow is configured through the printer's Embedded Web Server and requires OAuth 2.0 registration. Verify the specific device and firmware before assuming support.
@@ -113,7 +113,7 @@ Lexmark documents OAuth 2.0 authentication for printers starting with the FW24 f
 OpManager supports OAuth 2.0 from build 126306, so for anyone on that build or later this is a settings change rather than a migration - the vendor's guide states it directly. The same page also documents re-enabling SMTP AUTH in the Exchange admin centre, which works until the end of December 2026 and not after; treat it as breathing room, not a fix.
 
 **Ricoh — multifunction printers**  
-Ricoh publishes affected products with per-product firmware status, revised on 2026-01-30 into two tables - products with released OAuth firmware, and products newly added - plus a third group the Ricoh Firmware Update Tool cannot update, where the local representative has to do it. Not reproduced here because the list is long and still moving; check the model against the advisory. Ricoh does not say any product is permanently excluded, but for devices still waiting its own recommendation is to stop relying on email from the device or to use a mail service other than Exchange Online.
+Ricoh publishes affected products with per-product firmware status, last updated 2026-02-06, in two tables - products with released OAuth firmware, and products added as of 2026-01-30 - plus a third group the Ricoh Firmware Update Tool cannot update, where the local representative has to do it. Not reproduced here because the list is long and still moving; check the model against the advisory. Firmware is not the end of it: because "the TLS cipher suites supported by Microsoft 365 will be updated", Ricoh warns that "some Ricoh products - including models that already support OAuth 2.0 authentication - will no longer be able to send or receive emails via Exchange Online". Ricoh does not say any product is permanently excluded, but for devices still waiting its own recommendation is to stop relying on email from the device or to use a mail service other than Exchange Online.
 
 **Synology — NAS notification email**  
 Synology DSM 7 supports Outlook as an email notification service with an interactive Sign In flow rather than manual SMTP credentials. Synology documents OAuth-based authentication for this Outlook integration, but availability and behavior depend on the DSM version. Verify the exact DSM version and current Outlook notification configuration before assuming Microsoft 365 SMTP AUTH OAuth compatibility.
@@ -130,7 +130,7 @@ Microsoft's own product. Enable modern auth on the resource account - no relay n
 **Sophos — Sophos Firewall (email alerts and reports)**  
 Sophos publishes an official guide 'Configure OAuth 2.0 on Microsoft 365' for Sophos Firewall 22.0: register the firewall as an app in Microsoft Entra, add delegated SMTP.Send + offline_access permissions, turn on Authenticated SMTP for the sending user, and configure notifications with client ID / secret / refresh token. Confirms Modern (OAuth 2.0) SMTP AUTH support; availability depends on the firewall version.
 
-*24 entries, last reviewed 2026-08-27.*
+*24 entries, last reviewed 2026-09-07.*
 
 <!-- END GENERATED TABLE -->
 

--- a/docs/NO-OAUTH-FIRMWARE.md
+++ b/docs/NO-OAUTH-FIRMWARE.md
@@ -21,13 +21,21 @@ service rather than at an update:
 
 - ineo 306, ineo 7228, ineo 266
 - ineo+ 266, ineo+ 256, ineo+ 226
+- ineo 4752, ineo 4052
 - ineo 4750, ineo 4050
+- ineo+ 3110, ineo+ 3100P
+- ineo+ 754e, ineo+ 654e, ineo 654e
+- ineo 226, ineo 246, ineo 236, ineo 216, ineo 7223, ineo 206
 - ineo 4700P, ineo 3301P, ineo 4000P
-- ineo 165 and ineo 185 variants
+- ineo 4020, ineo 3320
+- ineo 165, ineo 165e
+- ineo 185, ineo 185e
 
 Check your exact model against the advisory before concluding anything — the
 lists are long, similar model numbers land in different groups, and a digit
-decides whether an update exists for you.
+decides whether an update exists for you. A suffix decides too: **ineo 165en
+and ineo 185en are not on this list** — the vendor marks both as Released on
+firmware V3.00, while ineo 165/165e and ineo 185/185e stay "N/A".
 
 **What "N/A" means in practice.** The device will keep speaking SMTP with a
 username and password for as long as it runs. What stops working is the
@@ -43,9 +51,10 @@ Notifications as affected.
 
 OAuth firmware exists for the supported list — Device Code Flow broadly, and
 Client Credentials Flow only on ConnectKey models such as VersaLink
-B415/C415, B620/C620, B625/C625, AltaLink and PrimeLink. **Devices that are
-not on that list are the problem cases**, and Xerox does not promise them an
-update.
+B415/C415, B620/C620, B625/C625 and AltaLink. PrimeLink is on the Device Code
+Flow side only; Xerox's table reads "Not Available" in the Client Credential
+Flow column for every PrimeLink row. **Devices that are not on that list are
+the problem cases**, and Xerox does not promise them an update.
 
 ## Ricoh
 

--- a/docs/data/devices.json
+++ b/docs/data/devices.json
@@ -16,7 +16,7 @@
     "  check-advisory  vendor publishes a per-model list we do not reproduce",
     "  unsupported     the product has no OAuth capability for this purpose"
   ],
-  "updated": "2026-08-27",
+  "updated": "2026-09-07",
   "entries": [
     {
       "vendor": "Konica Minolta / DEVELOP",
@@ -37,18 +37,25 @@
         "ineo+ 3100P",
         "ineo+ 754e",
         "ineo+ 654e",
+        "ineo 654e",
+        "ineo 226",
         "ineo 246",
         "ineo 236",
-        "ineo 226",
         "ineo 216",
+        "ineo 7223",
+        "ineo 206",
         "ineo 4700P",
         "ineo 3301P",
         "ineo 4000P",
-        "ineo 165 variants",
-        "ineo 185 variants"
+        "ineo 4020",
+        "ineo 3320",
+        "ineo 165",
+        "ineo 165e",
+        "ineo 185",
+        "ineo 185e"
       ],
       "evidence": "https://www.develop.eu/en/support/discontinuation-of-basic-authentication-for-smtp.html",
-      "notes": "Marked \"N/A\" in the vendor's own OAuth column. The advisory points these owners at a different mail service rather than at an update. Other ineo product groups in the same advisory do have OAuth firmware - check the exact model. A third category exists that is neither: several Product Group 10 models are listed as \"Under planning\" with no release date, so their owners have no answer yet in either direction."
+      "notes": "Marked \"N/A\" in the vendor's own OAuth column, and the advisory states that \"for devices marked as N/A under Release Schedule and devices not listed, no firmware update is planned\". It points these owners at a different mail service rather than at an update. One suffix decides: ineo 165en and ineo 185en are listed as Released (V3.00) while ineo 165/165e and 185/185e are N/A. Other ineo product groups in the same advisory do have OAuth firmware - check the exact model. A third category exists that is neither: several Product Group 10 models are listed as \"Under planning\" with no release date, so their owners have no answer yet in either direction."
     },
     {
       "vendor": "Xerox",
@@ -61,11 +68,10 @@
         "VersaLink C620",
         "VersaLink B625",
         "VersaLink C625",
-        "AltaLink",
-        "PrimeLink"
+        "AltaLink"
       ],
       "evidence": "https://www.xerox.com/en-us/office/insights/exchange-online-authentication",
-      "notes": "Device Code Flow is supported broadly; Client Credentials Flow only on the ConnectKey models listed. Devices not on Xerox's supported-firmware list are the problem cases and are not promised an update. Affects Scan to Email, Internet Fax (Send), Fax Forward to Email and Auto Email Notifications."
+      "notes": "Device Code Flow is available now across the whole published range; Client Credentials Flow only on the ConnectKey models listed here. PrimeLink is not one of them - Xerox's table marks PrimeLink C9065/C9070, B9100/B9110/B9125/B9136 and C9265/C9275/C9281 as \"Not Available\" in the Client Credential Flow column. Devices not on Xerox's supported-firmware list are the problem cases and are not promised an update. Affects Scan to Email, Internet Fax (Send), Fax Forward to Email and Auto Email Notifications."
     },
     {
       "vendor": "Ricoh",
@@ -73,7 +79,7 @@
       "status": "check-advisory",
       "models": [],
       "evidence": "https://www.ricoh.com/info/2025/0526_1",
-      "notes": "Ricoh publishes affected products with per-product firmware status, revised on 2026-01-30 into two tables - products with released OAuth firmware, and products newly added - plus a third group the Ricoh Firmware Update Tool cannot update, where the local representative has to do it. Not reproduced here because the list is long and still moving; check the model against the advisory. Ricoh does not say any product is permanently excluded, but for devices still waiting its own recommendation is to stop relying on email from the device or to use a mail service other than Exchange Online."
+      "notes": "Ricoh publishes affected products with per-product firmware status, last updated 2026-02-06, in two tables - products with released OAuth firmware, and products added as of 2026-01-30 - plus a third group the Ricoh Firmware Update Tool cannot update, where the local representative has to do it. Not reproduced here because the list is long and still moving; check the model against the advisory. Firmware is not the end of it: because \"the TLS cipher suites supported by Microsoft 365 will be updated\", Ricoh warns that \"some Ricoh products - including models that already support OAuth 2.0 authentication - will no longer be able to send or receive emails via Exchange Online\". Ricoh does not say any product is permanently excluded, but for devices still waiting its own recommendation is to stop relying on email from the device or to use a mail service other than Exchange Online."
     },
     {
       "vendor": "Brother",
@@ -144,10 +150,10 @@
     {
       "vendor": "Laserfiche",
       "product": "Workflow email",
-      "status": "check-advisory",
+      "status": "partial",
       "models": [],
       "evidence": "https://answers.laserfiche.com/questions/200557/Disabling-basic-authentication-causing-Workflow-emails-to-fail",
-      "notes": "Workflow emails failing on Basic auth removal, reported in the vendor's own community."
+      "notes": "Laserfiche now answers this thread directly. The selected answer: \"Customers must upgrade to the Laserfiche Workflow 12 2025H1 release or later to use OAuth 2.0 for SMTP through Exchange Online. There are no current plans to backport OAuth support for Exchange Online SMTP to earlier versions of Workflow.\" The approved answer, updated April 2026, adds that \"version 12 Laserfiche products support Microsoft OAuth 2.0\", and that for v10.4, v11 and v12 installs which cannot upgrade, Laserfiche has confirmed Microsoft's own alternatives instead - High Volume Email, Azure Communication Services Email, or on-premises Exchange in a hybrid configuration."
     },
     {
       "vendor": "ManageEngine",
@@ -160,18 +166,18 @@
     {
       "vendor": "Cerberus",
       "product": "FTP Server",
-      "status": "check-advisory",
+      "status": "partial",
       "models": [],
       "evidence": "https://support.cerberusftp.com/hc/en-us/articles/24103821642643-Troubleshooting-SMTP-Setup-Error-on-Office365-com-Resolving-EHLO-Message-Failure-535-5-7-139-Authentication-Unsuccessful-Basic-Authentication-Disabled",
-      "notes": "Vendor support article covers the exact 535 5.7.139 failure."
+      "notes": "The vendor article on the exact 535 5.7.139 failure now answers it: \"Microsoft deprecated Basic Authentication as the default setting for O365 in October of 2023 and Cerberus now supports Microsoft OAuth2 for O365 SMTP Authentication.\" The current SMTP setup article documents an Authentication selector on the SMTP target with a Microsoft OAuth2 option taking tenant ID, application (client) ID and client secret from Entra ID, and describes Basic as the same functionality as the previous Use Authentication checkbox \"(prior to Cerberus 2025.3.0)\" - so the build decides. Older builds offer username and password only."
     },
     {
       "vendor": "Faxination",
       "product": "fax server",
-      "status": "check-advisory",
+      "status": "partial",
       "models": [],
       "evidence": "https://faxination.com/microsoft-timeline-for-basic-authentication-deprecation-in-exchange-online-smtp-auth/",
-      "notes": "Vendor published a timeline notice. Apply their update if one exists for the version in use; otherwise the outbound SMTP account has to be repointed."
+      "notes": "Fenestrae states that \"Faxination 2024 supports Modern Authentication (OAuth 2.0) for Microsoft 365 and Exchange Online\", so for this product the answer is a version number rather than a firmware wait; older installs still have to repoint the outbound SMTP account. Read the timeline on the same page with care - it still describes the superseded March-April 2026 schedule rather than the current one."
     },
     {
       "vendor": "Lexmark",
@@ -200,8 +206,8 @@
       "product": "printers and MFPs",
       "status": "partial",
       "models": [],
-      "evidence": "https://global.sharp/restricted/products/copier/downloads/manuals/bp70m65/us/contents_09-07_003.html",
-      "notes": "Sharp documents OAuth 2.0 authentication for Microsoft 365 and Exchange Online SMTP on multiple newer printer and MFP models, including BP-series devices. Sharp does not appear to publish a centralized compatibility list or universal firmware floor for the full printer/MFP range. Verify the exact model's SMTP settings or current manual before assuming OAuth 2.0 support.",
+      "evidence": "https://global.sharp/restricted/print/manuals/5/bp70m65/us/contents_09-07_018.html",
+      "notes": "Sharp documents OAuth 2.0 for SMTP in the machine manual rather than in a compatibility advisory: under Network Settings the SMTP \"Authentication Method\" reads \"Select OAuth 2.0 when using Microsoft365, Exchange Online, etc.\", with Provider defaulting to Microsoft and a Get Token key on the device. The same option appears on the POP3 side for Internet Fax reception. Sharp does not appear to publish a centralized compatibility list or a universal firmware floor for the full printer/MFP range, so verify the exact model's current manual before assuming OAuth 2.0 support.",
       "contributor": "Mohitingale13",
       "contributor_pr": 238
     },

--- a/docs/devices/brother-printers-mfps-and-document-scanners.md
+++ b/docs/devices/brother-printers-mfps-and-document-scanners.md
@@ -40,4 +40,4 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 - [The full compatibility list](../DEVICE-COMPATIBILITY.md) — every vendor, in one table
 - [Setup by printer brand](../PRINTERS.md) — where the SMTP fields actually live in each vendor's interface
 
-*Last reviewed 2026-08-27. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*
+*Last reviewed 2026-09-07. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*

--- a/docs/devices/canon-maxify-mb2755.md
+++ b/docs/devices/canon-maxify-mb2755.md
@@ -46,4 +46,4 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 - [The full compatibility list](../DEVICE-COMPATIBILITY.md) — every vendor, in one table
 - [Setup by printer brand](../PRINTERS.md) — where the SMTP fields actually live in each vendor's interface
 
-*Last reviewed 2026-08-27. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*
+*Last reviewed 2026-09-07. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*

--- a/docs/devices/cerberus-ftp-server.md
+++ b/docs/devices/cerberus-ftp-server.md
@@ -1,6 +1,6 @@
 ---
 title: "Cerberus: FTP Server"
-description: "Cerberus FTP Server and the Microsoft 365 SMTP AUTH shutdown: check vendor advisory, with a link to the vendor's own statement and what to do if firmware is not an option."
+description: "Cerberus FTP Server and the Microsoft 365 SMTP AUTH shutdown: some models or versions, with a link to the vendor's own statement and what to do if firmware is not an option."
 ---
 
 <!-- BEGIN GENERATED PAGE -->
@@ -9,13 +9,13 @@ description: "Cerberus FTP Server and the Microsoft 365 SMTP AUTH shutdown: chec
 
 # Cerberus FTP Server: OAuth 2.0 and Microsoft 365 SMTP AUTH
 
-**Status: Check vendor advisory**
+**Status: Some models or versions**
 
-The vendor publishes a per-model list and revises it over time, so it is not copied here; a stale second copy of a moving list is exactly how somebody ends up acting on the wrong row. Check your exact model against the vendor's own page.
+OAuth exists for part of the range. The model or version number decides, which means the answer for your unit is not the answer for the product line — check yours against the vendor's statement before planning either way.
 
 ## What the vendor says
 
-Vendor support article covers the exact 535 5.7.139 failure.
+The vendor article on the exact 535 5.7.139 failure now answers it: "Microsoft deprecated Basic Authentication as the default setting for O365 in October of 2023 and Cerberus now supports Microsoft OAuth2 for O365 SMTP Authentication." The current SMTP setup article documents an Authentication selector on the SMTP target with a Microsoft OAuth2 option taking tenant ID, application (client) ID and client secret from Entra ID, and describes Basic as the same functionality as the previous Use Authentication checkbox "(prior to Cerberus 2025.3.0)" - so the build decides. Older builds offer username and password only.
 
 [Read the vendor's statement in full](https://support.cerberusftp.com/hc/en-us/articles/24103821642643-Troubleshooting-SMTP-Setup-Error-on-Office365-com-Resolving-EHLO-Message-Failure-535-5-7-139-Authentication-Unsuccessful-Basic-Authentication-Disabled)  
 Everything on this page comes from that document. If it and this page disagree, the vendor is right and this page is out of date — [say so](https://github.com/msgwing/ZeroSMTP/issues/new?template=device_report.yml).
@@ -40,4 +40,4 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 - [The full compatibility list](../DEVICE-COMPATIBILITY.md) — every vendor, in one table
 - [Setup by printer brand](../PRINTERS.md) — where the SMTP fields actually live in each vendor's interface
 
-*Last reviewed 2026-08-27. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*
+*Last reviewed 2026-09-07. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*

--- a/docs/devices/cisco-unity-connection.md
+++ b/docs/devices/cisco-unity-connection.md
@@ -40,4 +40,4 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 - [The full compatibility list](../DEVICE-COMPATIBILITY.md) — every vendor, in one table
 - [Setup by printer brand](../PRINTERS.md) — where the SMTP fields actually live in each vendor's interface
 
-*Last reviewed 2026-08-27. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*
+*Last reviewed 2026-09-07. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*

--- a/docs/devices/faxination-fax-server.md
+++ b/docs/devices/faxination-fax-server.md
@@ -1,6 +1,6 @@
 ---
 title: "Faxination: fax server"
-description: "Faxination fax server and the Microsoft 365 SMTP AUTH shutdown: check vendor advisory, with a link to the vendor's own statement and what to do if firmware is not an option."
+description: "Faxination fax server and the Microsoft 365 SMTP AUTH shutdown: some models or versions, with a link to the vendor's own statement and what to do if firmware is not an option."
 ---
 
 <!-- BEGIN GENERATED PAGE -->
@@ -9,13 +9,13 @@ description: "Faxination fax server and the Microsoft 365 SMTP AUTH shutdown: ch
 
 # Faxination fax server: OAuth 2.0 and Microsoft 365 SMTP AUTH
 
-**Status: Check vendor advisory**
+**Status: Some models or versions**
 
-The vendor publishes a per-model list and revises it over time, so it is not copied here; a stale second copy of a moving list is exactly how somebody ends up acting on the wrong row. Check your exact model against the vendor's own page.
+OAuth exists for part of the range. The model or version number decides, which means the answer for your unit is not the answer for the product line — check yours against the vendor's statement before planning either way.
 
 ## What the vendor says
 
-Vendor published a timeline notice. Apply their update if one exists for the version in use; otherwise the outbound SMTP account has to be repointed.
+Fenestrae states that "Faxination 2024 supports Modern Authentication (OAuth 2.0) for Microsoft 365 and Exchange Online", so for this product the answer is a version number rather than a firmware wait; older installs still have to repoint the outbound SMTP account. Read the timeline on the same page with care - it still describes the superseded March-April 2026 schedule rather than the current one.
 
 [Read the vendor's statement in full](https://faxination.com/microsoft-timeline-for-basic-authentication-deprecation-in-exchange-online-smtp-auth/)  
 Everything on this page comes from that document. If it and this page disagree, the vendor is right and this page is out of date — [say so](https://github.com/msgwing/ZeroSMTP/issues/new?template=device_report.yml).
@@ -40,4 +40,4 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 - [The full compatibility list](../DEVICE-COMPATIBILITY.md) — every vendor, in one table
 - [Setup by printer brand](../PRINTERS.md) — where the SMTP fields actually live in each vendor's interface
 
-*Last reviewed 2026-08-27. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*
+*Last reviewed 2026-09-07. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*

--- a/docs/devices/hp-printers-and-mfps.md
+++ b/docs/devices/hp-printers-and-mfps.md
@@ -44,4 +44,4 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 - [The full compatibility list](../DEVICE-COMPATIBILITY.md) — every vendor, in one table
 - [Setup by printer brand](../PRINTERS.md) — where the SMTP fields actually live in each vendor's interface
 
-*Last reviewed 2026-08-27. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*
+*Last reviewed 2026-09-07. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*

--- a/docs/devices/konica-minolta-develop-ineo-and-ineo-mfps.md
+++ b/docs/devices/konica-minolta-develop-ineo-and-ineo-mfps.md
@@ -15,7 +15,7 @@ The vendor has stated that no OAuth firmware is coming for these models. This is
 
 ## What the vendor says
 
-Marked "N/A" in the vendor's own OAuth column. The advisory points these owners at a different mail service rather than at an update. Other ineo product groups in the same advisory do have OAuth firmware - check the exact model. A third category exists that is neither: several Product Group 10 models are listed as "Under planning" with no release date, so their owners have no answer yet in either direction.
+Marked "N/A" in the vendor's own OAuth column, and the advisory states that "for devices marked as N/A under Release Schedule and devices not listed, no firmware update is planned". It points these owners at a different mail service rather than at an update. One suffix decides: ineo 165en and ineo 185en are listed as Released (V3.00) while ineo 165/165e and 185/185e are N/A. Other ineo product groups in the same advisory do have OAuth firmware - check the exact model. A third category exists that is neither: several Product Group 10 models are listed as "Under planning" with no release date, so their owners have no answer yet in either direction.
 
 [Read the vendor's statement in full](https://www.develop.eu/en/support/discontinuation-of-basic-authentication-for-smtp.html)  
 Everything on this page comes from that document. If it and this page disagree, the vendor is right and this page is out of date — [say so](https://github.com/msgwing/ZeroSMTP/issues/new?template=device_report.yml).
@@ -36,15 +36,22 @@ Everything on this page comes from that document. If it and this page disagree, 
 - `ineo+ 3100P`
 - `ineo+ 754e`
 - `ineo+ 654e`
+- `ineo 654e`
+- `ineo 226`
 - `ineo 246`
 - `ineo 236`
-- `ineo 226`
 - `ineo 216`
+- `ineo 7223`
+- `ineo 206`
 - `ineo 4700P`
 - `ineo 3301P`
 - `ineo 4000P`
-- `ineo 165 variants`
-- `ineo 185 variants`
+- `ineo 4020`
+- `ineo 3320`
+- `ineo 165`
+- `ineo 165e`
+- `ineo 185`
+- `ineo 185e`
 
 A model missing from this list is not automatically safe. Vendors publish headline lists; regional variants and OEM rebadges drift away from them.
 
@@ -68,4 +75,4 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 - [The full compatibility list](../DEVICE-COMPATIBILITY.md) — every vendor, in one table
 - [Setup by printer brand](../PRINTERS.md) — where the SMTP fields actually live in each vendor's interface
 
-*Last reviewed 2026-08-27. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*
+*Last reviewed 2026-09-07. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*

--- a/docs/devices/kyocera-mfps-reporting-send-error-1102.md
+++ b/docs/devices/kyocera-mfps-reporting-send-error-1102.md
@@ -40,4 +40,4 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 - [The full compatibility list](../DEVICE-COMPATIBILITY.md) — every vendor, in one table
 - [Setup by printer brand](../PRINTERS.md) — where the SMTP fields actually live in each vendor's interface
 
-*Last reviewed 2026-08-27. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*
+*Last reviewed 2026-09-07. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*

--- a/docs/devices/laserfiche-workflow-email.md
+++ b/docs/devices/laserfiche-workflow-email.md
@@ -1,6 +1,6 @@
 ---
 title: "Laserfiche: Workflow email"
-description: "Laserfiche Workflow email and the Microsoft 365 SMTP AUTH shutdown: check vendor advisory, with a link to the vendor's own statement and what to do if firmware is not an option."
+description: "Laserfiche Workflow email and the Microsoft 365 SMTP AUTH shutdown: some models or versions, with a link to the vendor's own statement and what to do if firmware is not an option."
 ---
 
 <!-- BEGIN GENERATED PAGE -->
@@ -9,13 +9,13 @@ description: "Laserfiche Workflow email and the Microsoft 365 SMTP AUTH shutdown
 
 # Laserfiche Workflow email: OAuth 2.0 and Microsoft 365 SMTP AUTH
 
-**Status: Check vendor advisory**
+**Status: Some models or versions**
 
-The vendor publishes a per-model list and revises it over time, so it is not copied here; a stale second copy of a moving list is exactly how somebody ends up acting on the wrong row. Check your exact model against the vendor's own page.
+OAuth exists for part of the range. The model or version number decides, which means the answer for your unit is not the answer for the product line — check yours against the vendor's statement before planning either way.
 
 ## What the vendor says
 
-Workflow emails failing on Basic auth removal, reported in the vendor's own community.
+Laserfiche now answers this thread directly. The selected answer: "Customers must upgrade to the Laserfiche Workflow 12 2025H1 release or later to use OAuth 2.0 for SMTP through Exchange Online. There are no current plans to backport OAuth support for Exchange Online SMTP to earlier versions of Workflow." The approved answer, updated April 2026, adds that "version 12 Laserfiche products support Microsoft OAuth 2.0", and that for v10.4, v11 and v12 installs which cannot upgrade, Laserfiche has confirmed Microsoft's own alternatives instead - High Volume Email, Azure Communication Services Email, or on-premises Exchange in a hybrid configuration.
 
 [Read the vendor's statement in full](https://answers.laserfiche.com/questions/200557/Disabling-basic-authentication-causing-Workflow-emails-to-fail)  
 Everything on this page comes from that document. If it and this page disagree, the vendor is right and this page is out of date — [say so](https://github.com/msgwing/ZeroSMTP/issues/new?template=device_report.yml).
@@ -40,4 +40,4 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 - [The full compatibility list](../DEVICE-COMPATIBILITY.md) — every vendor, in one table
 - [Setup by printer brand](../PRINTERS.md) — where the SMTP fields actually live in each vendor's interface
 
-*Last reviewed 2026-08-27. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*
+*Last reviewed 2026-09-07. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*

--- a/docs/devices/lexmark-printers-and-mfps.md
+++ b/docs/devices/lexmark-printers-and-mfps.md
@@ -42,4 +42,4 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 - [The full compatibility list](../DEVICE-COMPATIBILITY.md) — every vendor, in one table
 - [Setup by printer brand](../PRINTERS.md) — where the SMTP fields actually live in each vendor's interface
 
-*Last reviewed 2026-08-27. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*
+*Last reviewed 2026-09-07. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*

--- a/docs/devices/manageengine-opmanager.md
+++ b/docs/devices/manageengine-opmanager.md
@@ -40,4 +40,4 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 - [The full compatibility list](../DEVICE-COMPATIBILITY.md) — every vendor, in one table
 - [Setup by printer brand](../PRINTERS.md) — where the SMTP fields actually live in each vendor's interface
 
-*Last reviewed 2026-08-27. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*
+*Last reviewed 2026-09-07. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*

--- a/docs/devices/microsoft-dynamics-nav-business-central.md
+++ b/docs/devices/microsoft-dynamics-nav-business-central.md
@@ -40,4 +40,4 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 - [The full compatibility list](../DEVICE-COMPATIBILITY.md) — every vendor, in one table
 - [Setup by printer brand](../PRINTERS.md) — where the SMTP fields actually live in each vendor's interface
 
-*Last reviewed 2026-08-27. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*
+*Last reviewed 2026-09-07. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*

--- a/docs/devices/microsoft-teams-rooms.md
+++ b/docs/devices/microsoft-teams-rooms.md
@@ -30,4 +30,4 @@ Follow the vendor's instructions above. Come back here only if the device turns 
 - [The full compatibility list](../DEVICE-COMPATIBILITY.md) — every vendor, in one table
 - [Setup by printer brand](../PRINTERS.md) — where the SMTP fields actually live in each vendor's interface
 
-*Last reviewed 2026-08-27. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*
+*Last reviewed 2026-09-07. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*

--- a/docs/devices/qnap-nas-notification-settings.md
+++ b/docs/devices/qnap-nas-notification-settings.md
@@ -40,4 +40,4 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 - [The full compatibility list](../DEVICE-COMPATIBILITY.md) — every vendor, in one table
 - [Setup by printer brand](../PRINTERS.md) — where the SMTP fields actually live in each vendor's interface
 
-*Last reviewed 2026-08-27. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*
+*Last reviewed 2026-09-07. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*

--- a/docs/devices/ricoh-multifunction-printers.md
+++ b/docs/devices/ricoh-multifunction-printers.md
@@ -15,7 +15,7 @@ The vendor publishes a per-model list and revises it over time, so it is not cop
 
 ## What the vendor says
 
-Ricoh publishes affected products with per-product firmware status, revised on 2026-01-30 into two tables - products with released OAuth firmware, and products newly added - plus a third group the Ricoh Firmware Update Tool cannot update, where the local representative has to do it. Not reproduced here because the list is long and still moving; check the model against the advisory. Ricoh does not say any product is permanently excluded, but for devices still waiting its own recommendation is to stop relying on email from the device or to use a mail service other than Exchange Online.
+Ricoh publishes affected products with per-product firmware status, last updated 2026-02-06, in two tables - products with released OAuth firmware, and products added as of 2026-01-30 - plus a third group the Ricoh Firmware Update Tool cannot update, where the local representative has to do it. Not reproduced here because the list is long and still moving; check the model against the advisory. Firmware is not the end of it: because "the TLS cipher suites supported by Microsoft 365 will be updated", Ricoh warns that "some Ricoh products - including models that already support OAuth 2.0 authentication - will no longer be able to send or receive emails via Exchange Online". Ricoh does not say any product is permanently excluded, but for devices still waiting its own recommendation is to stop relying on email from the device or to use a mail service other than Exchange Online.
 
 [Read the vendor's statement in full](https://www.ricoh.com/info/2025/0526_1)  
 Everything on this page comes from that document. If it and this page disagree, the vendor is right and this page is out of date — [say so](https://github.com/msgwing/ZeroSMTP/issues/new?template=device_report.yml).
@@ -40,4 +40,4 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 - [The full compatibility list](../DEVICE-COMPATIBILITY.md) — every vendor, in one table
 - [Setup by printer brand](../PRINTERS.md) — where the SMTP fields actually live in each vendor's interface
 
-*Last reviewed 2026-08-27. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*
+*Last reviewed 2026-09-07. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*

--- a/docs/devices/sharp-printers-and-mfps.md
+++ b/docs/devices/sharp-printers-and-mfps.md
@@ -15,9 +15,9 @@ OAuth exists for part of the range. The model or version number decides, which m
 
 ## What the vendor says
 
-Sharp documents OAuth 2.0 authentication for Microsoft 365 and Exchange Online SMTP on multiple newer printer and MFP models, including BP-series devices. Sharp does not appear to publish a centralized compatibility list or universal firmware floor for the full printer/MFP range. Verify the exact model's SMTP settings or current manual before assuming OAuth 2.0 support.
+Sharp documents OAuth 2.0 for SMTP in the machine manual rather than in a compatibility advisory: under Network Settings the SMTP "Authentication Method" reads "Select OAuth 2.0 when using Microsoft365, Exchange Online, etc.", with Provider defaulting to Microsoft and a Get Token key on the device. The same option appears on the POP3 side for Internet Fax reception. Sharp does not appear to publish a centralized compatibility list or a universal firmware floor for the full printer/MFP range, so verify the exact model's current manual before assuming OAuth 2.0 support.
 
-[Read the vendor's statement in full](https://global.sharp/restricted/products/copier/downloads/manuals/bp70m65/us/contents_09-07_003.html)  
+[Read the vendor's statement in full](https://global.sharp/restricted/print/manuals/5/bp70m65/us/contents_09-07_018.html)  
 Everything on this page comes from that document. If it and this page disagree, the vendor is right and this page is out of date — [say so](https://github.com/msgwing/ZeroSMTP/issues/new?template=device_report.yml).
 
 ## What to do instead
@@ -42,4 +42,4 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 - [The full compatibility list](../DEVICE-COMPATIBILITY.md) — every vendor, in one table
 - [Setup by printer brand](../PRINTERS.md) — where the SMTP fields actually live in each vendor's interface
 
-*Last reviewed 2026-08-27. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*
+*Last reviewed 2026-09-07. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*

--- a/docs/devices/sophos-sophos-firewall-email-alerts-and-reports.md
+++ b/docs/devices/sophos-sophos-firewall-email-alerts-and-reports.md
@@ -39,4 +39,4 @@ Follow the vendor's instructions above. Come back here only if the device turns 
 - [The full compatibility list](../DEVICE-COMPATIBILITY.md) — every vendor, in one table
 - [Setup by printer brand](../PRINTERS.md) — where the SMTP fields actually live in each vendor's interface
 
-*Last reviewed 2026-08-27. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*
+*Last reviewed 2026-09-07. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*

--- a/docs/devices/synology-nas-notification-email.md
+++ b/docs/devices/synology-nas-notification-email.md
@@ -42,4 +42,4 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 - [The full compatibility list](../DEVICE-COMPATIBILITY.md) — every vendor, in one table
 - [Setup by printer brand](../PRINTERS.md) — where the SMTP fields actually live in each vendor's interface
 
-*Last reviewed 2026-08-27. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*
+*Last reviewed 2026-09-07. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*

--- a/docs/devices/toshiba-printers-and-mfps.md
+++ b/docs/devices/toshiba-printers-and-mfps.md
@@ -42,4 +42,4 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 - [The full compatibility list](../DEVICE-COMPATIBILITY.md) — every vendor, in one table
 - [Setup by printer brand](../PRINTERS.md) — where the SMTP fields actually live in each vendor's interface
 
-*Last reviewed 2026-08-27. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*
+*Last reviewed 2026-09-07. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*

--- a/docs/devices/truenas-truenas-email-alerts.md
+++ b/docs/devices/truenas-truenas-email-alerts.md
@@ -40,4 +40,4 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 - [The full compatibility list](../DEVICE-COMPATIBILITY.md) — every vendor, in one table
 - [Setup by printer brand](../PRINTERS.md) — where the SMTP fields actually live in each vendor's interface
 
-*Last reviewed 2026-08-27. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*
+*Last reviewed 2026-09-07. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*

--- a/docs/devices/veeam-backup-for-microsoft-365-and-related-products.md
+++ b/docs/devices/veeam-backup-for-microsoft-365-and-related-products.md
@@ -40,4 +40,4 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 - [The full compatibility list](../DEVICE-COMPATIBILITY.md) — every vendor, in one table
 - [Setup by printer brand](../PRINTERS.md) — where the SMTP fields actually live in each vendor's interface
 
-*Last reviewed 2026-08-27. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*
+*Last reviewed 2026-09-07. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*

--- a/docs/devices/xerox-connectkey-printers-and-mfps.md
+++ b/docs/devices/xerox-connectkey-printers-and-mfps.md
@@ -15,7 +15,7 @@ OAuth exists for part of the range. The model or version number decides, which m
 
 ## What the vendor says
 
-Device Code Flow is supported broadly; Client Credentials Flow only on the ConnectKey models listed. Devices not on Xerox's supported-firmware list are the problem cases and are not promised an update. Affects Scan to Email, Internet Fax (Send), Fax Forward to Email and Auto Email Notifications.
+Device Code Flow is available now across the whole published range; Client Credentials Flow only on the ConnectKey models listed here. PrimeLink is not one of them - Xerox's table marks PrimeLink C9065/C9070, B9100/B9110/B9125/B9136 and C9265/C9275/C9281 as "Not Available" in the Client Credential Flow column. Devices not on Xerox's supported-firmware list are the problem cases and are not promised an update. Affects Scan to Email, Internet Fax (Send), Fax Forward to Email and Auto Email Notifications.
 
 [Read the vendor's statement in full](https://www.xerox.com/en-us/office/insights/exchange-online-authentication)  
 Everything on this page comes from that document. If it and this page disagree, the vendor is right and this page is out of date — [say so](https://github.com/msgwing/ZeroSMTP/issues/new?template=device_report.yml).
@@ -29,7 +29,6 @@ Everything on this page comes from that document. If it and this page disagree, 
 - `VersaLink B625`
 - `VersaLink C625`
 - `AltaLink`
-- `PrimeLink`
 
 A model missing from this list is not automatically safe. Vendors publish headline lists; regional variants and OEM rebadges drift away from them.
 
@@ -53,4 +52,4 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 - [The full compatibility list](../DEVICE-COMPATIBILITY.md) — every vendor, in one table
 - [Setup by printer brand](../PRINTERS.md) — where the SMTP fields actually live in each vendor's interface
 
-*Last reviewed 2026-08-27. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*
+*Last reviewed 2026-09-07. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*

--- a/docs/devices/xerox-mfps-reporting-send-error-027-779.md
+++ b/docs/devices/xerox-mfps-reporting-send-error-027-779.md
@@ -51,4 +51,4 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 - [The full compatibility list](../DEVICE-COMPATIBILITY.md) — every vendor, in one table
 - [Setup by printer brand](../PRINTERS.md) — where the SMTP fields actually live in each vendor's interface
 
-*Last reviewed 2026-08-27. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*
+*Last reviewed 2026-09-07. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*

--- a/docs/devices/zabbix-email-notifications.md
+++ b/docs/devices/zabbix-email-notifications.md
@@ -42,4 +42,4 @@ ZeroSMTP is the second option. It is free with no paid tier, accepts plain SMTP 
 - [The full compatibility list](../DEVICE-COMPATIBILITY.md) — every vendor, in one table
 - [Setup by printer brand](../PRINTERS.md) — where the SMTP fields actually live in each vendor's interface
 
-*Last reviewed 2026-08-27. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*
+*Last reviewed 2026-09-07. Source: [`data/devices.json`](https://github.com/msgwing/ZeroSMTP/blob/main/data/devices.json).*

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -656,22 +656,22 @@ answer.
 
 | System | OAuth status | Named models | Evidence |
 | --- | --- | --- | --- |
-| **[Konica Minolta / DEVELOP](devices/konica-minolta-develop-ineo-and-ineo-mfps.md)** ineo and ineo+ MFPs | **No OAuth firmware planned** | `ineo 306`, `ineo 7228`, `ineo 266`, `ineo+ 266`, `ineo+ 256`, `ineo+ 226`, `ineo 4752`, `ineo 4052`, `ineo 4750`, `ineo 4050`, `ineo+ 3110`, `ineo+ 3100P`, `ineo+ 754e`, `ineo+ 654e`, `ineo 246`, `ineo 236`, `ineo 226`, `ineo 216`, `ineo 4700P`, `ineo 3301P`, `ineo 4000P`, `ineo 165 variants`, `ineo 185 variants` | [advisory](https://www.develop.eu/en/support/discontinuation-of-basic-authentication-for-smtp.html) |
+| **[Konica Minolta / DEVELOP](devices/konica-minolta-develop-ineo-and-ineo-mfps.md)** ineo and ineo+ MFPs | **No OAuth firmware planned** | `ineo 306`, `ineo 7228`, `ineo 266`, `ineo+ 266`, `ineo+ 256`, `ineo+ 226`, `ineo 4752`, `ineo 4052`, `ineo 4750`, `ineo 4050`, `ineo+ 3110`, `ineo+ 3100P`, `ineo+ 754e`, `ineo+ 654e`, `ineo 654e`, `ineo 226`, `ineo 246`, `ineo 236`, `ineo 216`, `ineo 7223`, `ineo 206`, `ineo 4700P`, `ineo 3301P`, `ineo 4000P`, `ineo 4020`, `ineo 3320`, `ineo 165`, `ineo 165e`, `ineo 185`, `ineo 185e` | [advisory](https://www.develop.eu/en/support/discontinuation-of-basic-authentication-for-smtp.html) |
 | **[Canon](devices/canon-maxify-mb2755.md)** Maxify MB2755 | No OAuth for this purpose | `Maxify MB2755` | [advisory](https://github.com/msgwing/ZeroSMTP/blob/main/docs/DEVICE-CASE-STUDIES.md) |
 | **[QNAP](devices/qnap-nas-notification-settings.md)** NAS notification settings | No OAuth for this purpose | — | [advisory](https://gist.github.com/msgwing/39958d909e085ae9cc0e6b3584d930bf) |
+| **[Cerberus](devices/cerberus-ftp-server.md)** FTP Server | Some models or versions | — | [advisory](https://support.cerberusftp.com/hc/en-us/articles/24103821642643-Troubleshooting-SMTP-Setup-Error-on-Office365-com-Resolving-EHLO-Message-Failure-535-5-7-139-Authentication-Unsuccessful-Basic-Authentication-Disabled) |
+| **[Faxination](devices/faxination-fax-server.md)** fax server | Some models or versions | — | [advisory](https://faxination.com/microsoft-timeline-for-basic-authentication-deprecation-in-exchange-online-smtp-auth/) |
 | **[HP](devices/hp-printers-and-mfps.md)** printers and MFPs | Some models or versions | — | [advisory](https://support.hp.com/nz-en/document/ish_13623350-13600809-16) |
+| **[Laserfiche](devices/laserfiche-workflow-email.md)** Workflow email | Some models or versions | — | [advisory](https://answers.laserfiche.com/questions/200557/Disabling-basic-authentication-causing-Workflow-emails-to-fail) |
 | **[Microsoft](devices/microsoft-dynamics-nav-business-central.md)** Dynamics NAV / Business Central | Some models or versions | — | [advisory](https://www.innovia.com/blog/microsoft-to-retire-basic-auth-smtp-for-exchange-online-what-bc-nav-users-need-to-know) |
-| **[Sharp](devices/sharp-printers-and-mfps.md)** printers and MFPs | Some models or versions | — | [advisory](https://global.sharp/restricted/products/copier/downloads/manuals/bp70m65/us/contents_09-07_003.html) |
+| **[Sharp](devices/sharp-printers-and-mfps.md)** printers and MFPs | Some models or versions | — | [advisory](https://global.sharp/restricted/print/manuals/5/bp70m65/us/contents_09-07_018.html) |
 | **[TrueNAS](devices/truenas-truenas-email-alerts.md)** TrueNAS email alerts | Some models or versions | — | [advisory](https://www.truenas.com/docs/scale/systemsettings/general/settingupsystememail/) |
 | **[Veeam](devices/veeam-backup-for-microsoft-365-and-related-products.md)** Backup for Microsoft 365 and related products | Some models or versions | — | [advisory](https://helpcenter.veeam.com/docs/vbo365/guide/smtp_server.html) |
-| **[Xerox](devices/xerox-connectkey-printers-and-mfps.md)** ConnectKey printers and MFPs | Some models or versions | `VersaLink B415`, `VersaLink C415`, `VersaLink B620`, `VersaLink C620`, `VersaLink B625`, `VersaLink C625`, `AltaLink`, `PrimeLink` | [advisory](https://www.xerox.com/en-us/office/insights/exchange-online-authentication) |
+| **[Xerox](devices/xerox-connectkey-printers-and-mfps.md)** ConnectKey printers and MFPs | Some models or versions | `VersaLink B415`, `VersaLink C415`, `VersaLink B620`, `VersaLink C620`, `VersaLink B625`, `VersaLink C625`, `AltaLink` | [advisory](https://www.xerox.com/en-us/office/insights/exchange-online-authentication) |
 | **[Zabbix](devices/zabbix-email-notifications.md)** email notifications | Some models or versions | — | [advisory](https://www.zabbix.com/documentation/7.4/en/manual/introduction/whatsnew) |
 | **[Brother](devices/brother-printers-mfps-and-document-scanners.md)** printers, MFPs and document scanners | Check vendor advisory | — | [advisory](https://support.brother.com/g/b/oscontents.aspx?c=us&lang=en&ossid=42) |
-| **[Cerberus](devices/cerberus-ftp-server.md)** FTP Server | Check vendor advisory | — | [advisory](https://support.cerberusftp.com/hc/en-us/articles/24103821642643-Troubleshooting-SMTP-Setup-Error-on-Office365-com-Resolving-EHLO-Message-Failure-535-5-7-139-Authentication-Unsuccessful-Basic-Authentication-Disabled) |
 | **[Cisco](devices/cisco-unity-connection.md)** Unity Connection | Check vendor advisory | — | [advisory](https://learn.microsoft.com/en-us/exchange/clients-and-mobile-in-exchange-online/deprecation-of-basic-authentication-exchange-online) |
-| **[Faxination](devices/faxination-fax-server.md)** fax server | Check vendor advisory | — | [advisory](https://faxination.com/microsoft-timeline-for-basic-authentication-deprecation-in-exchange-online-smtp-auth/) |
 | **[Kyocera](devices/kyocera-mfps-reporting-send-error-1102.md)** MFPs reporting send error 1102 | Check vendor advisory | — | [advisory](https://github.com/msgwing/ZeroSMTP/blob/main/docs/ERROR-MESSAGES.md) |
-| **[Laserfiche](devices/laserfiche-workflow-email.md)** Workflow email | Check vendor advisory | — | [advisory](https://answers.laserfiche.com/questions/200557/Disabling-basic-authentication-causing-Workflow-emails-to-fail) |
 | **[Lexmark](devices/lexmark-printers-and-mfps.md)** printers and MFPs | Check vendor advisory | — | [advisory](https://support.lexmark.com/content/support/guides/en/kb20211110020010549/setup-installation-and-configuration-issues/how-to-set-up-oauth-2-authentication.html) |
 | **[ManageEngine](devices/manageengine-opmanager.md)** OpManager | Check vendor advisory | — | [advisory](https://www.manageengine.com/network-monitoring/how-to/fix-smtpclientauth-disabled-error.html) |
 | **[Ricoh](devices/ricoh-multifunction-printers.md)** multifunction printers | Check vendor advisory | — | [advisory](https://www.ricoh.com/info/2025/0526_1) |
@@ -684,7 +684,7 @@ answer.
 ### Notes per entry
 
 **Konica Minolta / DEVELOP — ineo and ineo+ MFPs**  
-Marked "N/A" in the vendor's own OAuth column. The advisory points these owners at a different mail service rather than at an update. Other ineo product groups in the same advisory do have OAuth firmware - check the exact model. A third category exists that is neither: several Product Group 10 models are listed as "Under planning" with no release date, so their owners have no answer yet in either direction.
+Marked "N/A" in the vendor's own OAuth column, and the advisory states that "for devices marked as N/A under Release Schedule and devices not listed, no firmware update is planned". It points these owners at a different mail service rather than at an update. One suffix decides: ineo 165en and ineo 185en are listed as Released (V3.00) while ineo 165/165e and 185/185e are N/A. Other ineo product groups in the same advisory do have OAuth firmware - check the exact model. A third category exists that is neither: several Product Group 10 models are listed as "Under planning" with no release date, so their owners have no answer yet in either direction.
 
 **Canon — Maxify MB2755**  
 Separate failure mode from OAuth: the firmware ships a fixed root CA store predating current Let's Encrypt roots, so certificate validation fails regardless of authentication. Hardware-confirmed, unchanged after a firmware update. Verification has to be disabled on the device.
@@ -692,14 +692,23 @@ Separate failure mode from OAuth: the firmware ships a fixed root CA store preda
 **QNAP — NAS notification settings**  
 The notification settings accept username and password only; there is no OAuth option for Microsoft 365 SMTP.
 
+**Cerberus — FTP Server**  
+The vendor article on the exact 535 5.7.139 failure now answers it: "Microsoft deprecated Basic Authentication as the default setting for O365 in October of 2023 and Cerberus now supports Microsoft OAuth2 for O365 SMTP Authentication." The current SMTP setup article documents an Authentication selector on the SMTP target with a Microsoft OAuth2 option taking tenant ID, application (client) ID and client secret from Entra ID, and describes Basic as the same functionality as the previous Use Authentication checkbox "(prior to Cerberus 2025.3.0)" - so the build decides. Older builds offer username and password only.
+
+**Faxination — fax server**  
+Fenestrae states that "Faxination 2024 supports Modern Authentication (OAuth 2.0) for Microsoft 365 and Exchange Online", so for this product the answer is a version number rather than a firmware wait; older installs still have to repoint the outbound SMTP account. Read the timeline on the same page with care - it still describes the superseded March-April 2026 schedule rather than the current one.
+
 **HP — printers and MFPs**  
 HP documents OAuth 2.0 support for Microsoft 365 Scan to Email on HP Enterprise and HP Managed printers running FutureSmart firmware 5.7 and newer. However, HP also states that certain LaserJet Pro models, including the M478-M479 and M428-M429f, do not support OAuth 2.0. Verify the exact product family and firmware before assuming Microsoft 365 SMTP AUTH compatibility.
+
+**Laserfiche — Workflow email**  
+Laserfiche now answers this thread directly. The selected answer: "Customers must upgrade to the Laserfiche Workflow 12 2025H1 release or later to use OAuth 2.0 for SMTP through Exchange Online. There are no current plans to backport OAuth support for Exchange Online SMTP to earlier versions of Workflow." The approved answer, updated April 2026, adds that "version 12 Laserfiche products support Microsoft OAuth 2.0", and that for v10.4, v11 and v12 installs which cannot upgrade, Laserfiche has confirmed Microsoft's own alternatives instead - High Volume Email, Azure Communication Services Email, or on-premises Exchange in a hybrid configuration.
 
 **Microsoft — Dynamics NAV / Business Central**  
 Newer Business Central handles modern auth. Older on-prem NAV installs generally need the SMTP account repointed.
 
 **Sharp — printers and MFPs**  
-Sharp documents OAuth 2.0 authentication for Microsoft 365 and Exchange Online SMTP on multiple newer printer and MFP models, including BP-series devices. Sharp does not appear to publish a centralized compatibility list or universal firmware floor for the full printer/MFP range. Verify the exact model's SMTP settings or current manual before assuming OAuth 2.0 support.
+Sharp documents OAuth 2.0 for SMTP in the machine manual rather than in a compatibility advisory: under Network Settings the SMTP "Authentication Method" reads "Select OAuth 2.0 when using Microsoft365, Exchange Online, etc.", with Provider defaulting to Microsoft and a Get Token key on the device. The same option appears on the POP3 side for Internet Fax reception. Sharp does not appear to publish a centralized compatibility list or a universal firmware floor for the full printer/MFP range, so verify the exact model's current manual before assuming OAuth 2.0 support.
 
 **TrueNAS — TrueNAS email alerts**  
 TrueNAS SCALE supports OAuth for Outlook and Gmail, but standard SMTP requires basic authentication. Some forum users report issues with Microsoft 365 enforcing OAuth while configuring standard SMTP on CORE.
@@ -708,7 +717,7 @@ TrueNAS SCALE supports OAuth for Outlook and Gmail, but standard SMTP requires b
 Corrected 2026-08-16 - the previous note claimed newer versions added OAuth for SMTP, which the linked page does not support. The v8 documentation offers "SMTP server (basic authentication)" and does not describe an OAuth option for SMTP notifications; modern app-only authentication appears elsewhere in the product, for Entra applications, not here. So the fix is not "upgrade and SMTP gets OAuth" - check whether your build offers a notification method that is not SMTP at all, and treat the SMTP path as basic-auth only.
 
 **Xerox — ConnectKey printers and MFPs**  
-Device Code Flow is supported broadly; Client Credentials Flow only on the ConnectKey models listed. Devices not on Xerox's supported-firmware list are the problem cases and are not promised an update. Affects Scan to Email, Internet Fax (Send), Fax Forward to Email and Auto Email Notifications.
+Device Code Flow is available now across the whole published range; Client Credentials Flow only on the ConnectKey models listed here. PrimeLink is not one of them - Xerox's table marks PrimeLink C9065/C9070, B9100/B9110/B9125/B9136 and C9265/C9275/C9281 as "Not Available" in the Client Credential Flow column. Devices not on Xerox's supported-firmware list are the problem cases and are not promised an update. Affects Scan to Email, Internet Fax (Send), Fax Forward to Email and Auto Email Notifications.
 
 **Zabbix — email notifications**  
 Zabbix 7.4 introduced OAuth 2.0 authentication for SMTP, including automated OAuth configuration for Office365 and Gmail. Verify the Zabbix version and Office365 SmtpClientAuthentication configuration before assuming Microsoft 365 SMTP AUTH compatibility.
@@ -716,20 +725,11 @@ Zabbix 7.4 introduced OAuth 2.0 authentication for SMTP, including automated OAu
 **Brother — printers, MFPs and document scanners**  
 Brother publishes a per-model Product Support List and states plainly that a machine not on it does not support OAuth 2.0, with no firmware promised - the vendor's own guidance for those owners is to use a different mail service. Listed models split into two tiers: OAuth already present, or present after a firmware update that is already downloadable. Affects Scan to Email Server, Internet Fax, Email Reports and Email Notifications. Check the exact model: support is firmware-dependent as well as model-dependent.
 
-**Cerberus — FTP Server**  
-Vendor support article covers the exact 535 5.7.139 failure.
-
 **Cisco — Unity Connection**  
 Named in Microsoft's own deprecation documentation. OAuth support depends on the release; check yours before assuming either way.
 
-**Faxination — fax server**  
-Vendor published a timeline notice. Apply their update if one exists for the version in use; otherwise the outbound SMTP account has to be repointed.
-
 **Kyocera — MFPs reporting send error 1102**  
 1102 / 0x1102 is Kyocera's device-side code for an SMTP authentication failure, not a model list. No public per-model OAuth statement located; check with the vendor for a specific model.
-
-**Laserfiche — Workflow email**  
-Workflow emails failing on Basic auth removal, reported in the vendor's own community.
 
 **Lexmark — printers and MFPs**  
 Lexmark documents OAuth 2.0 authentication for printers starting with the FW24 firmware release, including Outlook Live and Microsoft 365. The Email Server flow is configured through the printer's Embedded Web Server and requires OAuth 2.0 registration. Verify the specific device and firmware before assuming support.
@@ -738,7 +738,7 @@ Lexmark documents OAuth 2.0 authentication for printers starting with the FW24 f
 OpManager supports OAuth 2.0 from build 126306, so for anyone on that build or later this is a settings change rather than a migration - the vendor's guide states it directly. The same page also documents re-enabling SMTP AUTH in the Exchange admin centre, which works until the end of December 2026 and not after; treat it as breathing room, not a fix.
 
 **Ricoh — multifunction printers**  
-Ricoh publishes affected products with per-product firmware status, revised on 2026-01-30 into two tables - products with released OAuth firmware, and products newly added - plus a third group the Ricoh Firmware Update Tool cannot update, where the local representative has to do it. Not reproduced here because the list is long and still moving; check the model against the advisory. Ricoh does not say any product is permanently excluded, but for devices still waiting its own recommendation is to stop relying on email from the device or to use a mail service other than Exchange Online.
+Ricoh publishes affected products with per-product firmware status, last updated 2026-02-06, in two tables - products with released OAuth firmware, and products added as of 2026-01-30 - plus a third group the Ricoh Firmware Update Tool cannot update, where the local representative has to do it. Not reproduced here because the list is long and still moving; check the model against the advisory. Firmware is not the end of it: because "the TLS cipher suites supported by Microsoft 365 will be updated", Ricoh warns that "some Ricoh products - including models that already support OAuth 2.0 authentication - will no longer be able to send or receive emails via Exchange Online". Ricoh does not say any product is permanently excluded, but for devices still waiting its own recommendation is to stop relying on email from the device or to use a mail service other than Exchange Online.
 
 **Synology — NAS notification email**  
 Synology DSM 7 supports Outlook as an email notification service with an interactive Sign In flow rather than manual SMTP credentials. Synology documents OAuth-based authentication for this Outlook integration, but availability and behavior depend on the DSM version. Verify the exact DSM version and current Outlook notification configuration before assuming Microsoft 365 SMTP AUTH OAuth compatibility.
@@ -755,7 +755,7 @@ Microsoft's own product. Enable modern auth on the resource account - no relay n
 **Sophos — Sophos Firewall (email alerts and reports)**  
 Sophos publishes an official guide 'Configure OAuth 2.0 on Microsoft 365' for Sophos Firewall 22.0: register the firewall as an app in Microsoft Entra, add delegated SMTP.Send + offline_access permissions, turn on Authenticated SMTP for the sending user, and configure notifications with client ID / secret / refresh token. Confirms Modern (OAuth 2.0) SMTP AUTH support; availability depends on the firewall version.
 
-*24 entries, last reviewed 2026-08-27.*
+*24 entries, last reviewed 2026-09-07.*
 
 ## What this list is not
 

--- a/packages/zerosmtp-mcp/data/devices.json
+++ b/packages/zerosmtp-mcp/data/devices.json
@@ -16,7 +16,7 @@
     "  check-advisory  vendor publishes a per-model list we do not reproduce",
     "  unsupported     the product has no OAuth capability for this purpose"
   ],
-  "updated": "2026-08-27",
+  "updated": "2026-09-07",
   "entries": [
     {
       "vendor": "Konica Minolta / DEVELOP",
@@ -37,18 +37,25 @@
         "ineo+ 3100P",
         "ineo+ 754e",
         "ineo+ 654e",
+        "ineo 654e",
+        "ineo 226",
         "ineo 246",
         "ineo 236",
-        "ineo 226",
         "ineo 216",
+        "ineo 7223",
+        "ineo 206",
         "ineo 4700P",
         "ineo 3301P",
         "ineo 4000P",
-        "ineo 165 variants",
-        "ineo 185 variants"
+        "ineo 4020",
+        "ineo 3320",
+        "ineo 165",
+        "ineo 165e",
+        "ineo 185",
+        "ineo 185e"
       ],
       "evidence": "https://www.develop.eu/en/support/discontinuation-of-basic-authentication-for-smtp.html",
-      "notes": "Marked \"N/A\" in the vendor's own OAuth column. The advisory points these owners at a different mail service rather than at an update. Other ineo product groups in the same advisory do have OAuth firmware - check the exact model. A third category exists that is neither: several Product Group 10 models are listed as \"Under planning\" with no release date, so their owners have no answer yet in either direction."
+      "notes": "Marked \"N/A\" in the vendor's own OAuth column, and the advisory states that \"for devices marked as N/A under Release Schedule and devices not listed, no firmware update is planned\". It points these owners at a different mail service rather than at an update. One suffix decides: ineo 165en and ineo 185en are listed as Released (V3.00) while ineo 165/165e and 185/185e are N/A. Other ineo product groups in the same advisory do have OAuth firmware - check the exact model. A third category exists that is neither: several Product Group 10 models are listed as \"Under planning\" with no release date, so their owners have no answer yet in either direction."
     },
     {
       "vendor": "Xerox",
@@ -61,11 +68,10 @@
         "VersaLink C620",
         "VersaLink B625",
         "VersaLink C625",
-        "AltaLink",
-        "PrimeLink"
+        "AltaLink"
       ],
       "evidence": "https://www.xerox.com/en-us/office/insights/exchange-online-authentication",
-      "notes": "Device Code Flow is supported broadly; Client Credentials Flow only on the ConnectKey models listed. Devices not on Xerox's supported-firmware list are the problem cases and are not promised an update. Affects Scan to Email, Internet Fax (Send), Fax Forward to Email and Auto Email Notifications."
+      "notes": "Device Code Flow is available now across the whole published range; Client Credentials Flow only on the ConnectKey models listed here. PrimeLink is not one of them - Xerox's table marks PrimeLink C9065/C9070, B9100/B9110/B9125/B9136 and C9265/C9275/C9281 as \"Not Available\" in the Client Credential Flow column. Devices not on Xerox's supported-firmware list are the problem cases and are not promised an update. Affects Scan to Email, Internet Fax (Send), Fax Forward to Email and Auto Email Notifications."
     },
     {
       "vendor": "Ricoh",
@@ -73,7 +79,7 @@
       "status": "check-advisory",
       "models": [],
       "evidence": "https://www.ricoh.com/info/2025/0526_1",
-      "notes": "Ricoh publishes affected products with per-product firmware status, revised on 2026-01-30 into two tables - products with released OAuth firmware, and products newly added - plus a third group the Ricoh Firmware Update Tool cannot update, where the local representative has to do it. Not reproduced here because the list is long and still moving; check the model against the advisory. Ricoh does not say any product is permanently excluded, but for devices still waiting its own recommendation is to stop relying on email from the device or to use a mail service other than Exchange Online."
+      "notes": "Ricoh publishes affected products with per-product firmware status, last updated 2026-02-06, in two tables - products with released OAuth firmware, and products added as of 2026-01-30 - plus a third group the Ricoh Firmware Update Tool cannot update, where the local representative has to do it. Not reproduced here because the list is long and still moving; check the model against the advisory. Firmware is not the end of it: because \"the TLS cipher suites supported by Microsoft 365 will be updated\", Ricoh warns that \"some Ricoh products - including models that already support OAuth 2.0 authentication - will no longer be able to send or receive emails via Exchange Online\". Ricoh does not say any product is permanently excluded, but for devices still waiting its own recommendation is to stop relying on email from the device or to use a mail service other than Exchange Online."
     },
     {
       "vendor": "Brother",
@@ -144,10 +150,10 @@
     {
       "vendor": "Laserfiche",
       "product": "Workflow email",
-      "status": "check-advisory",
+      "status": "partial",
       "models": [],
       "evidence": "https://answers.laserfiche.com/questions/200557/Disabling-basic-authentication-causing-Workflow-emails-to-fail",
-      "notes": "Workflow emails failing on Basic auth removal, reported in the vendor's own community."
+      "notes": "Laserfiche now answers this thread directly. The selected answer: \"Customers must upgrade to the Laserfiche Workflow 12 2025H1 release or later to use OAuth 2.0 for SMTP through Exchange Online. There are no current plans to backport OAuth support for Exchange Online SMTP to earlier versions of Workflow.\" The approved answer, updated April 2026, adds that \"version 12 Laserfiche products support Microsoft OAuth 2.0\", and that for v10.4, v11 and v12 installs which cannot upgrade, Laserfiche has confirmed Microsoft's own alternatives instead - High Volume Email, Azure Communication Services Email, or on-premises Exchange in a hybrid configuration."
     },
     {
       "vendor": "ManageEngine",
@@ -160,18 +166,18 @@
     {
       "vendor": "Cerberus",
       "product": "FTP Server",
-      "status": "check-advisory",
+      "status": "partial",
       "models": [],
       "evidence": "https://support.cerberusftp.com/hc/en-us/articles/24103821642643-Troubleshooting-SMTP-Setup-Error-on-Office365-com-Resolving-EHLO-Message-Failure-535-5-7-139-Authentication-Unsuccessful-Basic-Authentication-Disabled",
-      "notes": "Vendor support article covers the exact 535 5.7.139 failure."
+      "notes": "The vendor article on the exact 535 5.7.139 failure now answers it: \"Microsoft deprecated Basic Authentication as the default setting for O365 in October of 2023 and Cerberus now supports Microsoft OAuth2 for O365 SMTP Authentication.\" The current SMTP setup article documents an Authentication selector on the SMTP target with a Microsoft OAuth2 option taking tenant ID, application (client) ID and client secret from Entra ID, and describes Basic as the same functionality as the previous Use Authentication checkbox \"(prior to Cerberus 2025.3.0)\" - so the build decides. Older builds offer username and password only."
     },
     {
       "vendor": "Faxination",
       "product": "fax server",
-      "status": "check-advisory",
+      "status": "partial",
       "models": [],
       "evidence": "https://faxination.com/microsoft-timeline-for-basic-authentication-deprecation-in-exchange-online-smtp-auth/",
-      "notes": "Vendor published a timeline notice. Apply their update if one exists for the version in use; otherwise the outbound SMTP account has to be repointed."
+      "notes": "Fenestrae states that \"Faxination 2024 supports Modern Authentication (OAuth 2.0) for Microsoft 365 and Exchange Online\", so for this product the answer is a version number rather than a firmware wait; older installs still have to repoint the outbound SMTP account. Read the timeline on the same page with care - it still describes the superseded March-April 2026 schedule rather than the current one."
     },
     {
       "vendor": "Lexmark",
@@ -200,8 +206,8 @@
       "product": "printers and MFPs",
       "status": "partial",
       "models": [],
-      "evidence": "https://global.sharp/restricted/products/copier/downloads/manuals/bp70m65/us/contents_09-07_003.html",
-      "notes": "Sharp documents OAuth 2.0 authentication for Microsoft 365 and Exchange Online SMTP on multiple newer printer and MFP models, including BP-series devices. Sharp does not appear to publish a centralized compatibility list or universal firmware floor for the full printer/MFP range. Verify the exact model's SMTP settings or current manual before assuming OAuth 2.0 support.",
+      "evidence": "https://global.sharp/restricted/print/manuals/5/bp70m65/us/contents_09-07_018.html",
+      "notes": "Sharp documents OAuth 2.0 for SMTP in the machine manual rather than in a compatibility advisory: under Network Settings the SMTP \"Authentication Method\" reads \"Select OAuth 2.0 when using Microsoft365, Exchange Online, etc.\", with Provider defaulting to Microsoft and a Get Token key on the device. The same option appears on the POP3 side for Internet Fax reception. Sharp does not appear to publish a centralized compatibility list or a universal firmware floor for the full printer/MFP range, so verify the exact model's current manual before assuming OAuth 2.0 support.",
       "contributor": "Mohitingale13",
       "contributor_pr": 238
     },


### PR DESCRIPTION
Monthly check that `data/devices.json` still matches what each vendor publishes today - #403. Every one of 22 vendors read against its own current page; 7 changed, 15 did not.

## What changed, each verified against the vendor's live page today (2026-09-07)

**Konica Minolta** — the model list was missing entries the advisory actually names: `ineo 654e`, `226`, `7223`, `206`, `4020`, `3320`, `165/165e`, `185/185e`. Added the fact that decides the 165/185 family: `ineo 165en` and `185en` are listed **Released on firmware V3.00**; the non-`en` variants stay `N/A`. Confirmed on the vendor page: `ineo 165en` sits in a table row reading `Released | V3.00`.

**Xerox** — `PrimeLink` was listed under Client Credentials Flow support. It is not. Xerox's own table marks every PrimeLink row (`C9065/C9070`, `B9100/B9110/B9125/B9136`, `C9265/C9275/C9281`) **"Not Available"** in that column — Device Code Flow only. Model numbers confirmed against the live page.

**Ricoh** — added the TLS cipher-suite deprecation Ricoh now warns about, which affects some already-OAuth-compatible products too. Quoted verbatim: *"the TLS cipher suites supported by Microsoft 365 will be updated... some Ricoh products - including models that already support OAuth 2.0 authentication - will no longer be able to send or receive emails via Exchange Online."*

**Laserfiche** `check-advisory` → `partial` — the community thread that was an open question now has the vendor's own accepted answer: upgrade to Workflow 12 2025H1+, no backport planned; Microsoft's own alternatives given for installs that can't upgrade.

**Cerberus** `check-advisory` → `partial` — the support article now documents OAuth2 support directly (build 2025.3.0+); older builds remain username/password only.

**Faxination** `check-advisory` → `partial` — Fenestrae's own line: *"Faxination 2024 supports Modern Authentication (OAuth 2.0)"*. Older installs still have to repoint the outbound account.

**Sharp** — evidence URL had moved (`.../restricted/products/copier/downloads/manuals/...` now 301s); replaced with the live current page (verified 200, content re-confirmed), not assumed from the redirect target.

## What did not change, and why that is worth stating

15 vendors were re-read and left as-is: Brother, Canon, Cisco, HP, Lexmark, ManageEngine, Microsoft, QNAP, Sophos, Synology, Toshiba, TrueNAS, Veeam, Zabbix, and the Konica Minolta / Xerox baseline claims that were already correct. Re-reading and confirming a claim is still true is the point of a monthly review, not a skipped step.

## Verified before shipping

- Every changed claim fetched live today and grepped for the exact quoted phrase — not paraphrased from a search snippet, not trusted from a prior read.
- Generated files were not hand-edited: `git diff` on every `docs/devices/*.md`, `docs/DEVICE-COMPATIBILITY.md`, `docs/NO-OAUTH-FIRMWARE.md`, `docs/data/devices.json`, `docs/llms-full.txt`, and `packages/zerosmtp-mcp/data/devices.json` traces to the single `data/devices.json` change that caused it.
- `packages/zerosmtp-mcp/data/devices.json` confirmed byte-identical to the source after regeneration.
- All four affected `--check` gates pass: `build-device-table`, `build-llms-txt`, `build-llms-full`, `check-facts`.
- `check-facts.py`'s device-panel-code invariant (merged this week in #416) re-verified by deliberately breaking it: injected an undocumented code (`888-888`, vendor `TestVendor2`) into the CLI generator — gate refused by name, `exit 1`; restored, `exit 0`.

BOARD: MERGE - every changed claim is a direct quote checked against the vendor's live page today, not a paraphrase; nothing here is guessed and the generated-file discipline was checked, not assumed.

EVIDENCE: `curl` against each of the seven vendor pages today returned the exact quoted phrase (verified individually: Konica Minolta `ineo 165en` + `Released|V3.00`, Xerox PrimeLink `Not Available` rows, Ricoh TLS cipher sentence, Laserfiche/Cerberus/Faxination OAuth support statements, Sharp new URL 200 vs old URL 301). `tools/build-device-table.py --check`, `build-llms-txt.py --check`, `build-llms-full.py --check`, `check-facts.py` all pass. Deliberate-break test on the device-panel-code gate: inject → refuses (exit 1) → restore → passes (exit 0).
