### PR TITLE
fix(check): refuse --explain match when reply code contradicts the corpus (#423)

### DIFF
--- a/packages/zerosmtp-check/index.js
+++ b/packages/zerosmtp-check/index.js
@@ -312,6 +312,21 @@ function enhancedCode(text) {
   return m ? m[1] : null;
 }
 
+/** The reply code (530, 553, ...) right before the enhanced code. Every entry
+ *  in the corpus is Microsoft's, so a reply code the corpus does not record
+ *  for this enhanced code means the pasted line came from somewhere else -
+ *  our own relay's 553 shares 5.7.1 with Microsoft's 530, and looks like a
+ *  match right up until this is checked. Refusing beats guessing: see #423. */
+function replyCode(text) {
+  const m = text.match(/\b([2-5]\d{2})\s+\d\.\d\.\d{1,3}\b/);
+  return m ? m[1] : null;
+}
+
+function contradictsCorpus(matches, text) {
+  const reply = replyCode(text);
+  return reply !== null && !matches.some(e => e.code.startsWith(reply + ' '));
+}
+
 /** Several entries share 5.7.139 and differ only in whether the block sits on
  *  the tenant or the mailbox. If the pasted text says which, use it. */
 function narrowByScope(matches, lower) {
@@ -389,7 +404,8 @@ export function explain(text) {
 
   const code = enhancedCode(text);
   if (code) {
-    const matches = narrowByScope(ERRORS.filter(e => e.enhanced === code), lower);
+    const byCode = ERRORS.filter(e => e.enhanced === code);
+    const matches = contradictsCorpus(byCode, text) ? [] : narrowByScope(byCode, lower);
     if (matches.length === 1) return explainMatch(matches[0]);
     if (matches.length > 1) {
       out.push(`${code} covers more than one case and the text you pasted does `
@@ -439,8 +455,9 @@ export function explain(text) {
 
 export function explainJson(text) {
   const code = enhancedCode(text);
-  const matches = code
-    ? narrowByScope(ERRORS.filter(e => e.enhanced === code), text.toLowerCase())
+  const byCode = code ? ERRORS.filter(e => e.enhanced === code) : [];
+  const matches = code && !contradictsCorpus(byCode, text)
+    ? narrowByScope(byCode, text.toLowerCase())
     : [];
   return {
     input: text,

--- a/packages/zerosmtp-check/test/zerosmtp-check.test.js
+++ b/packages/zerosmtp-check/test/zerosmtp-check.test.js
@@ -109,6 +109,25 @@ describe('zerosmtp-check', () => {
       assert.equal(result.matched, false);
       assert.equal(result.matches.length, 0);
     });
+
+    test('#423: a foreign reply code sharing an enhanced code with the corpus is not matched', () => {
+      // 5.7.1 is Microsoft's 530 in the corpus. Our own relay's 553 shares the
+      // same enhanced code but is a different server's refusal - matching by
+      // 5.7.1 alone answered with Microsoft's 530 explanation, confidently and
+      // wrongly, for an error the corpus does not contain.
+      const result = explain('553 5.7.1 Sender address rejected');
+      assert.ok(result.startsWith('No match for that one.'));
+      assert.ok(!result.includes('530'));
+
+      const json = explainJson('553 5.7.1 Sender address rejected');
+      assert.equal(json.matched, false);
+      assert.equal(json.matches.length, 0);
+    });
+
+    test('#423: the real Microsoft 530 5.7.1 still matches', () => {
+      const result = explain('530 5.7.1 Delivery not authorized');
+      assert.ok(result.startsWith('530 5.7.1'));
+    });
   });
 
   describe('CLI integration', () => {


### PR DESCRIPTION
Closes #423.

`--explain` dopasowywal wylacznie po kodzie rozszerzonym (`5.7.1`), wiec nasz
wlasny odrzut przekaznika `553 5.7.1 Sender address rejected` dostawal
odpowiedz o Microsoftowym `530 5.7.1 Delivery not authorized` - pewna, ale zla.

Wariant 3 z opisu zgloszenia: gdy wklejony tekst niesie kod odpowiedzi (`553`),
ktorego korpus nie zna dla tego kodu rozszerzonego (korpus ma tylko `530` dla
`5.7.1`), odmowa dopasowania zamiast zgadywania. Zastosowane w `explain()` i
`explainJson()`.

BOARD: zerosmtp-check
EVIDENCE: `node --test` w `packages/zerosmtp-check` - 30/30, w tym dwa nowe
przypadki dla #423 (obcy kod odpowiedzi odrzucony, prawdziwy Microsoft 530
nadal dziala). Zywe polecenie z warunku odbioru zgloszenia sprawdzone recznie:
`node index.js --explain "553 5.7.1 Sender address rejected"` zwraca teraz
"No match for that one." zamiast strony o Microsoft 365.
