### PR TITLE
chore(mcp): add basic-authentication keyword to npm metadata

### DIFF
--- a/packages/zerosmtp-mcp/package.json
+++ b/packages/zerosmtp-mcp/package.json
@@ -10,7 +10,8 @@
     "office365",
     "exchange-online",
     "smtp-auth",
-    "5.7.139"
+    "5.7.139",
+    "basic-authentication"
   ],
   "bin": {
     "zerosmtp-mcp": "index.js"


### PR DESCRIPTION
Adds the `basic-authentication` keyword to `packages/zerosmtp-mcp/package.json`.
`zerosmtp-check` already carries it; `zerosmtp-mcp` targets the same buyer -
someone replacing Basic Auth SMTP in a script or AI agent - and was missing
the one term that names what they're replacing.

Metadata only. This does not change anything on registry.npmjs.org by
itself - the registry package document is generated at publish time, so the
new keyword only takes effect after the next `npm publish` of `zerosmtp-mcp`
(currently 1.0.2). Filed as its own commit rather than bundled with a version
bump.

BOARD: MERGE - a one-keyword metadata fix with no behavioural change, verified locally before publish
EVIDENCE: `python tools/check-mcp-server.py` -> "server.json is publishable - description 97/100 characters, version 1.0.2, and both descriptions name the relay" (unaffected, checks description not keywords); `node --test test/*.test.js` in packages/zerosmtp-mcp -> 10 pass, 0 fail; `python -c "import json; print(json.load(open('packages/zerosmtp-mcp/package.json'))['keywords'])"` -> confirms valid JSON with the new entry appended
